### PR TITLE
make tailrec checker work with recursive curried functions + some refactorings

### DIFF
--- a/test/org/jetbrains/plugins/scala/lang/psi/impl/ScFunctionDefinitionImplTest.scala
+++ b/test/org/jetbrains/plugins/scala/lang/psi/impl/ScFunctionDefinitionImplTest.scala
@@ -23,6 +23,10 @@ class ScFunctionDefinitionImplTest extends SimpleTestCase {
     assertRecursionTypeIs("def f(n: Int): Int = f(n + 1)", TailRecursion)
   }
 
+  def testTailRecursionWithCurring() {
+    assertRecursionTypeIs("def f(n: Int)(x:Int)(y:Int): Int = f(n + 1)(x)(y)", TailRecursion)
+  }
+
   def testReturn() {
     assertRecursionTypeIs("def f(n: Int): Int = return f(n + 1)", TailRecursion)
   }


### PR DESCRIPTION
Currently IDEA doesn't recognize curried tailrec recursive functions correctly. This patch fixes that.
I've also refactored some of the methods to be more Scala-ish and readable, please review them attentively. My performance tests have showed that there should no be performance impact, but you probably know better :)
