### PR TITLE
fix 'scala object not found' error when FCS is used (SCL-2440 and friends)

### DIFF
--- a/src/org/jetbrains/plugins/scala/compiler/ScalacBackendCompiler.java
+++ b/src/org/jetbrains/plugins/scala/compiler/ScalacBackendCompiler.java
@@ -385,6 +385,9 @@ public class ScalacBackendCompiler extends ExternalCompiler {
 //    PrintStream printer = System.out;
 
     ScalacSettings settings = ScalacSettings.getInstance(myProject);
+    CompilerLibraryData compilerLibraryData = Libraries.findBy(settings.COMPILER_LIBRARY_NAME,
+        settings.COMPILER_LIBRARY_LEVEL, myProject).get();
+
 
     if (myFsc) {
       if (settings.INTERNAL_SERVER) {
@@ -398,8 +401,7 @@ public class ScalacBackendCompiler extends ExternalCompiler {
         printer.println(String.format("%s:%s", settings.REMOTE_HOST, settings.REMOTE_PORT));
       }
 
-      String compilerVersion = Libraries.findBy(settings.COMPILER_LIBRARY_NAME,
-          settings.COMPILER_LIBRARY_LEVEL, myProject).get().version().get();
+      String compilerVersion = compilerLibraryData.version().get();
 
       if (!compilerVersion.startsWith("2.8")) {
         printer.println("-max-idle");
@@ -428,7 +430,9 @@ public class ScalacBackendCompiler extends ExternalCompiler {
 
     printer.print(chunk.getCompilationBootClasspath());
     printer.print(File.pathSeparator);
-    printer.println(chunk.getCompilationClasspath());
+    printer.print(chunk.getCompilationClasspath());
+    printer.print(File.pathSeparator);
+    printer.println(compilerLibraryData.classpath());
 
     List<VirtualFile> filesToCompile = new LinkedList<VirtualFile>();
     if (settings.SCALAC_BEFORE) {


### PR DESCRIPTION
Hey guys,
this patch is an attempt to fix http://youtrack.jetbrains.com/issue/SCL-2440 and duplicates
So when FSC is used and you don't have compiler library in the project classpath (which is usually the case) IDEA will abort compilation with 'scala object not found' error
As always I would be glad to hear your code review comments (and fix them, if any)
Thanks,
Eugene

review by @pavelfatin
