### PR TITLE
Fix for ScalaLanguageLevel crashing with External build compiler

### DIFF
--- a/src/org/jetbrains/plugins/scala/lang/languageLevel/ScalaLanguageLevel.scala
+++ b/src/org/jetbrains/plugins/scala/lang/languageLevel/ScalaLanguageLevel.scala
@@ -70,7 +70,7 @@ object ScalaLanguageLevel extends Enumeration {
 
   def getLanguageLevel(element: PsiElement): ScalaLanguageLevel = {
     val file: PsiFile = element.getContainingFile
-    if (file == null) return DEFAULT_LANGUAGE_LEVEL
+    if (file == null || file.getVirtualFile == null) return DEFAULT_LANGUAGE_LEVEL
     val module: Module = ProjectFileIndex.SERVICE.getInstance(element.getProject).getModuleForFile(file.getVirtualFile)
     if (module == null) return DEFAULT_LANGUAGE_LEVEL
     ScalaFacet.findIn(module).map(_.languageLevel).getOrElse(DEFAULT_LANGUAGE_LEVEL)


### PR DESCRIPTION
`ScalaLanguageLevel.getLanguageLevel(element)` would crash if `element.getContainingFile.getVirtualFile` was null. This would pretty much kill any Completion/Highlighting processes that touched it, as in this bug report against Completion:

http://youtrack.jetbrains.com/issue/SCL-5108

I think getVirtualFile() is supposed to return null iff the file exists only in memory, however this was occurring for me with Scala 0.7.62/IU-123.94 on concrete .scala source files.

I previously thought that this was occurring only when 'Use External build' was enabled, but in fact the problem with getVirtualFile() returning null seems independent of that.

http://blog.jetbrains.com/scala/2012/12/28/a-new-way-to-compile/
