### PR TITLE
make FSC settings more user friendly

### DIFF
--- a/src/org/jetbrains/plugins/scala/compiler/ScalacConfigurable.form
+++ b/src/org/jetbrains/plugins/scala/compiler/ScalacConfigurable.form
@@ -270,7 +270,7 @@
                   <toolTipText value="Can compile circular dependencies, rely on Scalac Java parser and typer"/>
                 </properties>
               </component>
-              <component id="af445" class="javax.swing.JRadioButton" default-binding="true">
+              <component id="af445" class="javax.swing.JRadioButton" binding="javacBeforeRadioButton">
                 <constraints>
                   <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                 </constraints>

--- a/src/org/jetbrains/plugins/scala/compiler/ScalacConfigurable.java
+++ b/src/org/jetbrains/plugins/scala/compiler/ScalacConfigurable.java
@@ -24,6 +24,7 @@ import java.awt.*;
 public class ScalacConfigurable implements Configurable {
   private JPanel myPanel;
   private JRadioButton scalacBeforeRadioButton;
+  private JRadioButton javacBeforeRadioButton;
   private RawCommandLineEditor myVmParameters;
   private JTextField myMaximumHeapSize;
   private RawCommandLineEditor myFscOptions;
@@ -208,6 +209,7 @@ public class ScalacConfigurable implements Configurable {
 
   public void reset() {
     scalacBeforeRadioButton.setSelected(mySettings.SCALAC_BEFORE);
+    javacBeforeRadioButton.setSelected(!mySettings.SCALAC_BEFORE);
     updateLibrariesList();
     setCompilerLibraryById(new LibraryId(mySettings.COMPILER_LIBRARY_NAME, mySettings.COMPILER_LIBRARY_LEVEL));
     myMaximumHeapSize.setText(mySettings.MAXIMUM_HEAP_SIZE);


### PR DESCRIPTION
Hey guys, this is a small patch to fix joint compilation radio group in FSC settings. It shows when Scalac is seleted, but does not when Javac is.

As always I would be glad to see your code review comments
Thanks,
Eugene
