### PR TITLE
Update META-INF/plugin.xml to relax upper bounds

### DIFF
--- a/META-INF/plugin.xml
+++ b/META-INF/plugin.xml
@@ -21,7 +21,7 @@
     <description>Plugin for Scala language support</description>
     <version>VERSION</version>
     <vendor url="http://www.jetbrains.com" logo="/org/jetbrains/plugins/scala/images/scala-small-logo.png">JetBrains Inc.</vendor>
-    <idea-version since-build="123.116" until-build="123.9999"/>
+    <idea-version since-build="123.116" until-build="126.9999"/>
     <depends optional="true" config-file="scala-maven-integration.xml">org.jetbrains.idea.maven</depends>
     <depends optional="true" config-file="intellilang-scala-support.xml">org.intellij.intelliLang</depends>
     <depends optional="true" config-file="copyright.xml">com.intellij.copyright</depends>


### PR DESCRIPTION
Currently IntelliJ Community builds from git have been renumbered to 126.x so there are no more plugin updates for Scala coming thru.

This means it can't be used/tested under nightly builds of what will be 12.1 or later.
