### PR TITLE
fix serializer for large linearizations

### DIFF
--- a/src/org/jetbrains/plugins/scala/decompiler/DecompilerUtil.scala
+++ b/src/org/jetbrains/plugins/scala/decompiler/DecompilerUtil.scala
@@ -22,7 +22,7 @@ import com.intellij.reference.SoftReference
  */
 object DecompilerUtil {
   protected val LOG: Logger = Logger.getInstance("#org.jetbrains.plugins.scala.decompiler.DecompilerUtil")
-  val DECOMPILER_VERSION = 224
+  val DECOMPILER_VERSION = 225
   private val SCALA_DECOMPILER_FILE_ATTRIBUTE = new FileAttribute("_is_scala_compiled_", DECOMPILER_VERSION, true)
   private val SCALA_DECOMPILER_KEY = new Key[SoftReference[DecompilationResult]]("Is Scala File Key")
   

--- a/src/org/jetbrains/plugins/scala/lang/psi/stubs/elements/ScFunctionElementType.scala
+++ b/src/org/jetbrains/plugins/scala/lang/psi/stubs/elements/ScFunctionElementType.scala
@@ -53,7 +53,7 @@ extends ScStubElementType[ScFunctionStub, ScFunction](debugName) {
     dataStream.writeName(stub.getName)
     dataStream.writeBoolean(stub.isDeclaration)
     val annotations = stub.getAnnotations
-    dataStream.writeByte(annotations.length)
+    dataStream.writeInt(annotations.length)
     for (annotation <- annotations) {
       dataStream.writeName(annotation)
     }
@@ -67,7 +67,7 @@ extends ScStubElementType[ScFunctionStub, ScFunction](debugName) {
   def deserializeImpl(dataStream: StubInputStream, parentStub: Any): ScFunctionStub = {
     val name = dataStream.readName
     val isDecl = dataStream.readBoolean
-    val length = dataStream.readByte
+    val length = dataStream.readInt
     val annotations = new Array[StringRef](length)
     for (i <- 0 until length) {
       annotations(i) = dataStream.readName

--- a/src/org/jetbrains/plugins/scala/lang/psi/stubs/elements/ScModifiersElementType.scala
+++ b/src/org/jetbrains/plugins/scala/lang/psi/stubs/elements/ScModifiersElementType.scala
@@ -23,7 +23,7 @@ class ScModifiersElementType[Func <: ScModifierList](debugName: String)
         extends ScStubElementType[ScModifiersStub, ScModifierList](debugName) {
   def serialize(stub: ScModifiersStub, dataStream: StubOutputStream) {
     dataStream.writeBoolean(stub.hasExplicitModifiers)
-    dataStream.writeByte(stub.getModifiers.length)
+    dataStream.writeInt(stub.getModifiers.length)
     for (modifier <- stub.getModifiers) dataStream.writeName(modifier)
   }
 
@@ -37,7 +37,7 @@ class ScModifiersElementType[Func <: ScModifierList](debugName: String)
 
   def deserializeImpl(dataStream: StubInputStream, parentStub: Any): ScModifiersStub = {
     val explicitModifiers = dataStream.readBoolean()
-    val num = dataStream.readByte
+    val num = dataStream.readInt
     val modifiers = new Array[String](num)
     for (i <- 0 until num) modifiers(i) = dataStream.readName.toString
     new ScModifiersStubImpl(parentStub.asInstanceOf[StubElement[PsiElement]], this, modifiers, explicitModifiers)

--- a/src/org/jetbrains/plugins/scala/lang/psi/stubs/elements/ScTemplateParentsElementType.scala
+++ b/src/org/jetbrains/plugins/scala/lang/psi/stubs/elements/ScTemplateParentsElementType.scala
@@ -21,7 +21,7 @@ abstract class ScTemplateParentsElementType[Func <: ScTemplateParents](debugName
         extends ScStubElementType[ScTemplateParentsStub, ScTemplateParents](debugName) {
   def serialize(stub: ScTemplateParentsStub, dataStream: StubOutputStream) {
     val array = stub.getTemplateParentsTypesTexts
-    dataStream.writeByte(array.length)
+    dataStream.writeInt(array.length)
     for (s <- array) {
       dataStream.writeName(s)
     }
@@ -43,7 +43,7 @@ abstract class ScTemplateParentsElementType[Func <: ScTemplateParents](debugName
   }
 
   def deserializeImpl(dataStream: StubInputStream, parentStub: Any): ScTemplateParentsStub = {
-    val length = dataStream.readByte
+    val length = dataStream.readInt
     if (length >= 0) {
       val res = new Array[StringRef](length)
       for (i <- 0 until length) {


### PR DESCRIPTION
Writing the array length as a byte breaks when the linearization of a class exceeds 127. Since byte is signed, the length will be seen by the deserializer as a negative number and will trigger the error path. Storage is cheap, let's use an int instead for the length.

Also fixes up two other locations in the serializer (ScFunctionElementType and ScModifiersElementType) where byte was used to serialize array length.

Fixes http://youtrack.jetbrains.com/issue/SCL-5026
