### PR TITLE
Custom string interpolators need not be ScFunctionDefinitions.

### DIFF
--- a/src/org/jetbrains/plugins/scala/annotator/ScalaAnnotator.scala
+++ b/src/org/jetbrains/plugins/scala/annotator/ScalaAnnotator.scala
@@ -720,7 +720,7 @@ with DumbAware {
     }
     
     ref.resolve() match {
-      case r: ScFunctionDefinition =>
+      case r: ScFunction =>
         val elementsMap = mutable.HashMap[Int, PsiElement]()
         val params = new mutable.StringBuilder("(")
 

--- a/src/org/jetbrains/plugins/scala/highlighter/AnnotatorHighlighter.scala
+++ b/src/org/jetbrains/plugins/scala/highlighter/AnnotatorHighlighter.scala
@@ -216,7 +216,7 @@ object AnnotatorHighlighter {
       case x: ScParameter => {
         annotation.setTextAttributes(DefaultHighlighter.PARAMETER)
       }
-      case x@(_: ScFunctionDefinition | _: ScFunctionDeclaration) => {
+      case x@(_: ScFunctionDefinition | _: ScFunctionDeclaration | _: ScMacroDefinition) => {
         if (SCALA_FACTORY_METHODS_NAMES.contains(x.asInstanceOf[PsiMethod].getName) || x.asInstanceOf[PsiMethod].isConstructor) {
           val clazz = PsiTreeUtil.getParentOfType(x, classOf[PsiClass])
           if (clazz != null) {

--- a/src/org/jetbrains/plugins/scala/lang/psi/impl/expr/ScInterpolatedStringPrefixReference.scala
+++ b/src/org/jetbrains/plugins/scala/lang/psi/impl/expr/ScInterpolatedStringPrefixReference.scala
@@ -5,7 +5,7 @@ import com.intellij.psi._
 import org.jetbrains.plugins.scala.lang.resolve.ScalaResolveResult
 import com.intellij.openapi.util.TextRange
 import org.jetbrains.plugins.scala.lang.psi.impl.ScalaPsiElementFactory
-import org.jetbrains.plugins.scala.lang.psi.api.statements.ScFunctionDefinition
+import org.jetbrains.plugins.scala.lang.psi.api.statements.ScFunction
 import org.jetbrains.plugins.scala.lang.psi.types.ScType
 import org.jetbrains.plugins.scala.lang.psi.api.base.types.ScTypeElement
 import org.jetbrains.plugins.scala.lang.psi.api.base.ScInterpolatedStringLiteral
@@ -45,7 +45,9 @@ class ScInterpolatedStringPrefixReference(node: ASTNode) extends ScReferenceExpr
     
     parent.getStringContextExpression match {
       case Some(expr) => expr.getFirstChild.getLastChild.findReferenceAt(0) match {
-        case ref: PsiPolyVariantReference => ref.multiResolve(incomplete).filter(_.getElement.isInstanceOf[ScFunctionDefinition])
+        case ref: PsiPolyVariantReference =>
+          val resolve1 = ref.multiResolve(incomplete)
+          resolve1.filter(_.getElement.isInstanceOf[ScFunction])
         case _ => Array[ResolveResult]()
       } 
       case _ => Array[ResolveResult]()
@@ -67,7 +69,7 @@ class ScInterpolatedStringPrefixReference(node: ASTNode) extends ScReferenceExpr
   override def isSoft: Boolean = false
 
   override def expectedType(fromUnderscore: Boolean): Option[ScType] = resolve() match {
-    case f: ScFunctionDefinition =>
+    case f: ScFunction =>
       f.returnType match {
         case Success(result, _) => Option(result)
         case _ => super.expectedType(fromUnderscore)

--- a/test/org/jetbrains/plugins/scala/lang/resolve2/Bug3Test.scala
+++ b/test/org/jetbrains/plugins/scala/lang/resolve2/Bug3Test.scala
@@ -64,6 +64,7 @@ class Bug3Test extends ResolveTestBase {
   def testSCL5360() {doTest()}
   def testSCL5377() {doTest()}
   def testSCL5418() {doTest()}
+  def testStringInterpolatorPrefix() {doTest()}
   def testShadowedImport() {doTest()}
   def testSOE() {doTest()}
   def testAccessiblePattern() {doTest()}

--- a/testdata/resolve2/bug3/StringInterpolatorPrefix.scala
+++ b/testdata/resolve2/bug3/StringInterpolatorPrefix.scala
@@ -1,0 +1,13 @@
+object Test {
+  implicit class Foo(val sc: StringContext) {
+    def foo(args: Any*) = macro xxx // comment out macro, it works
+  }
+  StringContext(str).foo()
+  /*resolved: true*/foo"" // good code red
+
+  implicit def RichStringContext(sc: StringContext): RSC = ???
+  trait RSC {
+    def rich(args: Any*)
+  }
+  /*resolved: true*/rich""
+}


### PR DESCRIPTION
They could just as well be function declarations, or macro
declarations.

 #SCL-5449 Fixed

Review by @alefas
