### PR TITLE
SCL-4935 More robust breakpoint positioning for macro-arguments.

### DIFF
--- a/src/org/jetbrains/plugins/scala/debugger/ScalaPositionManager.java
+++ b/src/org/jetbrains/plugins/scala/debugger/ScalaPositionManager.java
@@ -102,6 +102,9 @@ public class ScalaPositionManager implements PositionManager {
         if (ScalaPsiUtil.isByNameArgument((ScExpression) element)) {
           break;
         }
+        if (isInsideMacro(position)) {
+          break;
+        }
       }
       element = element.getParent();
     }
@@ -157,7 +160,7 @@ public class ScalaPositionManager implements PositionManager {
           }
         });
         Boolean insideMacro =
-            ScalaMacroDebuggingUtil.isEnabled() && ApplicationManager.getApplication().runReadAction(new Computable<Boolean>() {
+            ApplicationManager.getApplication().runReadAction(new Computable<Boolean>() {
               public Boolean compute() {
                 return isInsideMacro(position);
               }
@@ -171,7 +174,7 @@ public class ScalaPositionManager implements PositionManager {
             sourceImage instanceof ScForStatement ||
             sourceImage instanceof ScExtendsBlock ||
             sourceImage instanceof ScCaseClauses && sourceImage.getParent() instanceof ScBlockExpr ||
-            sourceImage instanceof ScExpression /*by name argument*/ ||
+            sourceImage instanceof ScExpression /*by name or macro argument*/ ||
             sourceImage instanceof ScTypeDefinition) {
           ScTypeDefinition typeDefinition = findEnclosingTypeDefinition(position);
           if (typeDefinition != null) {


### PR DESCRIPTION
A def macro might splice its arguments directly into the enclosing
callsite, or into a nested class / anon function. If it does the latter,
the position manager produces the wrong breakpoint specification.

This commit uses the "f.q.n.EnclosingClass*" in such cases, which
catches both cases.

I don't think we have test infrastructure for this. My manual test
was to check that all println-s below could be breakpointed.

``` scala
import scala.reflect.macros.Context
import language.experimental._
object M {
  def impl(c: Context)(a: c.Expr[Any]): c.Expr[Any] = c.universe.reify {
    if ("".isEmpty)
      (() => {
        c.Expr[Any](c.resetAllAttrs(a.tree)).splice
      })()
    else ???
  }
  def apply(a: Any) = macro impl
}

object N {
  def impl(c: Context)(a: c.Expr[Any]): c.Expr[Any] = c.universe.reify {
    if ("".isEmpty)
      c.Expr[Any](c.resetAllAttrs(a.tree)).splice
    else ???
  }
  def apply(a: Any) = macro impl
}

object Lazy {
  def apply(a: =>Any) {a}
}

object Main {
  def main(args: Array[String]) {
    println("here")
    M {
      println("1")
      println("2")
    }
    N {
      println("1")
      println("2")
    }
    Lazy{
      println("1")
      println("2")
    }
    (new T {}).apply
    new C().apply
  }
}

trait T {
  def apply {
    println("here")
    M {
      println("1")
      M apply {
        println("2")
        println("2")
      }
    }
    N {
      println("2")
      N {
        println("1")
        println("1")
      }
    }
    Lazy {
      println("2")
      println("2")
    }
  }
}

class C {
  def apply {
    println("here")
    M {
      println("1")
      M {
        println("2")
      }
    }
    N {
      println("1")
      N {
        println("2")
      }
    }
    Lazy {
      println("2")
      println("xxx")
    }
  }
}
```
