### PR TITLE
refactor intention tests to remove duplication

### DIFF
--- a/test/org/jetbrains/plugins/scala/codeInsight/intentions/argument/AddNameToArgumentIntentionTest.scala
+++ b/test/org/jetbrains/plugins/scala/codeInsight/intentions/argument/AddNameToArgumentIntentionTest.scala
@@ -13,58 +13,64 @@ class AddNameToArgumentIntentionTest extends ScalaIntentionTestBase {
   def familyName = AddNameToArgumentIntention.familyName
 
   def test() {
-    val text = """
-                 |class NameParameters {
-                 |  def doSomething(flag: Boolean) {}
-                 |
-                 |  doSomething(t<caret>rue)
-                 |}
-               """.stripMargin.replace("\r", "").trim
-    val resultText = """
-                       |class NameParameters {
-                       |  def doSomething(flag: Boolean) {}
-                       |
-                       |  doSomething(flag = t<caret>rue)
-                       |}
-                     """.stripMargin.replace("\r", "").trim
+    val text =
+      """
+        |class NameParameters {
+        |  def doSomething(flag: Boolean) {}
+        |
+        |  doSomething(t<caret>rue)
+        |}
+      """
+    val resultText =
+      """
+        |class NameParameters {
+        |  def doSomething(flag: Boolean) {}
+        |
+        |  doSomething(flag = t<caret>rue)
+        |}
+      """
 
     doTest(text, resultText)
   }
 
   def test2() {
-    val text = """
-                 |class NameParameters {
-                 |  def doSomething(flag: Boolean, a: Int) {}
-                 |
-                 |  doSomething(t<caret>rue, 8)
-                 |}
-               """.stripMargin.replace("\r", "").trim
-    val resultText = """
-                       |class NameParameters {
-                       |  def doSomething(flag: Boolean, a: Int) {}
-                       |
-                       |  doSomething(flag = t<caret>rue, a = 8)
-                       |}
-                     """.stripMargin.replace("\r", "").trim
+    val text =
+      """
+        |class NameParameters {
+        |  def doSomething(flag: Boolean, a: Int) {}
+        |
+        |  doSomething(t<caret>rue, 8)
+        |}
+      """
+    val resultText =
+      """
+        |class NameParameters {
+        |  def doSomething(flag: Boolean, a: Int) {}
+        |
+        |  doSomething(flag = t<caret>rue, a = 8)
+        |}
+      """
 
     doTest(text, resultText)
   }
 
   def test3() {
-    val text = """
-                 |class NameParameters {
-                 |  def doSomething(flag: Boolean, a: Int, b: Int) {}
-                 |
-                 |  doSomething(true, 8, <caret>9)
-                 |}
-               """.stripMargin.replace("\r", "").trim
-    val resultText = """
-                       |class NameParameters {
-                       |  def doSomething(flag: Boolean, a: Int, b: Int) {}
-                       |
-                       |  doSomething(true, 8, <caret>b = 9)
-                       |}
-                     """.stripMargin.replace("\r", "").trim
+    val text =
+      """
+        |class NameParameters {
+        |  def doSomething(flag: Boolean, a: Int, b: Int) {}
+        |
+        |  doSomething(true, 8, <caret>9)
+        |}
+      """
+    val resultText =
+      """
+        |class NameParameters {
+        |  def doSomething(flag: Boolean, a: Int, b: Int) {}
+        |
+        |  doSomething(true, 8, <caret>b = 9)
+        |}
+      """
 
     doTest(text, resultText)
   }

--- a/test/org/jetbrains/plugins/scala/codeInsight/intentions/booleans/DeMorganLawIntentionTest.scala
+++ b/test/org/jetbrains/plugins/scala/codeInsight/intentions/booleans/DeMorganLawIntentionTest.scala
@@ -87,12 +87,12 @@ class DeMorganLawIntentionTest extends ScalaIntentionTestBase {
       """
         |val % = true
         |!(!(%) &<caret>& !(%))
-      """.stripMargin.replace("\r", "").trim
+      """
     val resultText =
       """
         |val % = true
         |% |<caret>| %
-      """.stripMargin.replace("\r", "").trim
+      """
 
     doTest(text, resultText)
   }
@@ -102,12 +102,12 @@ class DeMorganLawIntentionTest extends ScalaIntentionTestBase {
       """
         |val % = true
         |% |<caret>| %
-      """.stripMargin.replace("\r", "").trim
+      """
     val resultText =
       """
         |val % = true
         |!(!(%) &<caret>& !(%))
-      """.stripMargin.replace("\r", "").trim
+      """
 
     doTest(text, resultText)
   }
@@ -117,12 +117,12 @@ class DeMorganLawIntentionTest extends ScalaIntentionTestBase {
       """
         |val b = true
         |(true equals b) |<caret>| true
-      """.stripMargin.replace("\r", "").trim
+      """
     val resultText =
       """
         |val b = true
         |!(!(true equals b) &<caret>& false)
-      """.stripMargin.replace("\r", "").trim
+      """
 
     doTest(text, resultText)
   }
@@ -132,12 +132,12 @@ class DeMorganLawIntentionTest extends ScalaIntentionTestBase {
       """
         |val b = true
         |!(!(true equals b) &<caret>& false)
-      """.stripMargin.replace("\r", "").trim
+      """
     val resultText =
       """
         |val b = true
         |(true equals b) |<caret>| true
-      """.stripMargin.replace("\r", "").trim
+      """
 
     doTest(text, resultText)
   }
@@ -147,16 +147,13 @@ class DeMorganLawIntentionTest extends ScalaIntentionTestBase {
       """
         |val % = true
         |(%) |<caret>| (%)
-      """.stripMargin.replace("\r", "").trim
+      """
     val resultText =
       """
         |val % = true
         |!(!(%) &<caret>& !(%))
-      """.stripMargin.replace("\r", "").trim
+      """
 
     doTest(text, resultText)
   }
-
-
-
 }

--- a/test/org/jetbrains/plugins/scala/codeInsight/intentions/booleans/ExpandBooleanIntentionTest.scala
+++ b/test/org/jetbrains/plugins/scala/codeInsight/intentions/booleans/ExpandBooleanIntentionTest.scala
@@ -8,105 +8,113 @@ import org.jetbrains.plugins.scala.codeInsight.intention.booleans.ExpandBooleanI
  * @since 6/29/12
  */
 
-class ExpandBooleanIntentionTest  extends ScalaIntentionTestBase {
+class ExpandBooleanIntentionTest extends ScalaIntentionTestBase {
   val familyName = ExpandBooleanIntention.familyName
 
   def testExpandBoolean() {
-    val text = """
-                 |class X {
-                 |  def f(a: Int): Boolean = {
-                 |    retur<caret>n a > 0
-                 |  }
-                 |}
-               """.stripMargin.replace("\r", "").trim
-    val resultText = """
-                       |class X {
-                       |  def f(a: Int): Boolean = {
-                       |    <caret>if (a > 0) {
-                       |      return true
-                       |    } else {
-                       |      return false
-                       |    }
-                       |  }
-                       |}
-                     """.stripMargin.replace("\r", "").trim
+    val text =
+      """
+        |class X {
+        |  def f(a: Int): Boolean = {
+        |    retur<caret>n a > 0
+        |  }
+        |}
+      """
+    val resultText =
+      """
+        |class X {
+        |  def f(a: Int): Boolean = {
+        |    <caret>if (a > 0) {
+        |      return true
+        |    } else {
+        |      return false
+        |    }
+        |  }
+        |}
+      """
 
     doTest(text, resultText)
   }
 
   def testExpandBoolean2() {
-    val text = """
-                 |class X {
-                 |  def f(a: Int): Boolean = {
-                 |    retur<caret>n (a > 0)
-                 |  }
-                 |}
-               """.stripMargin.replace("\r", "").trim
-    val resultText = """
-                       |class X {
-                       |  def f(a: Int): Boolean = {
-                       |    <caret>if (a > 0) {
-                       |      return true
-                       |    } else {
-                       |      return false
-                       |    }
-                       |  }
-                       |}
-                     """.stripMargin.replace("\r", "").trim
+    val text =
+      """
+        |class X {
+        |  def f(a: Int): Boolean = {
+        |    retur<caret>n (a > 0)
+        |  }
+        |}
+      """
+    val resultText =
+      """
+        |class X {
+        |  def f(a: Int): Boolean = {
+        |    <caret>if (a > 0) {
+        |      return true
+        |    } else {
+        |      return false
+        |    }
+        |  }
+        |}
+      """
 
     doTest(text, resultText)
   }
 
   def testExpandBoolean3() {
-    val text = """
-                 |class X {
-                 |  def f(a: Int, b: Int): Boolean = {
-                 |    retur<caret>n (a > 0 || b < 7)
-                 |  }
-                 |}
-               """.stripMargin.replace("\r", "").trim
-    val resultText = """
-                       |class X {
-                       |  def f(a: Int, b: Int): Boolean = {
-                       |    <caret>if (a > 0 || b < 7) {
-                       |      return true
-                       |    } else {
-                       |      return false
-                       |    }
-                       |  }
-                       |}
-                     """.stripMargin.replace("\r", "").trim
+    val text =
+      """
+        |class X {
+        |  def f(a: Int, b: Int): Boolean = {
+        |    retur<caret>n (a > 0 || b < 7)
+        |  }
+        |}
+      """
+    val resultText =
+      """
+        |class X {
+        |  def f(a: Int, b: Int): Boolean = {
+        |    <caret>if (a > 0 || b < 7) {
+        |      return true
+        |    } else {
+        |      return false
+        |    }
+        |  }
+        |}
+      """
 
     doTest(text, resultText)
   }
 
   def testExpandBoolean4() {
-    val text = """
-                 |class X {
-                 |  def f(a: Int, b: Int): Boolean = {
-                 |    if (a > 0 || b < 7) {
-                 |      ret<caret>urn true
-                 |    } else {
-                 |      return false
-                 |    }
-                 |  }
-                 |}
-               """.stripMargin.replace("\r", "").trim
-    val resultText = """
-                       |class X {
-                       |  def f(a: Int, b: Int): Boolean = {
-                       |    if (a > 0 || b < 7) {
-                       |      <caret>if (true) {
-                       |        return true
-                       |      } else {
-                       |        return false
-                       |      }
-                       |    } else {
-                       |      return false
-                       |    }
-                       |  }
-                       |}
-                     """.stripMargin.replace("\r", "").trim
+    val text =
+      """
+        |class X {
+        |  def f(a: Int, b: Int): Boolean = {
+        |    if (a > 0 || b < 7) {
+        |      ret<caret>urn true
+        |    } else {
+        |      return false
+        |    }
+        |  }
+        |}
+      """
+    val resultText =
+      """
+        |class X {
+        |  def f(a: Int, b: Int): Boolean = {
+        |    if (a > 0 || b < 7) {
+        |      <caret>if (true) {
+        |        return true
+        |      } else {
+        |        return false
+        |      }
+        |    } else {
+        |      return false
+        |    }
+        |  }
+        |}
+      """
 
     doTest(text, resultText)
   }

--- a/test/org/jetbrains/plugins/scala/codeInsight/intentions/booleans/SimplifyBooleanExprWithLiteralTest.scala
+++ b/test/org/jetbrains/plugins/scala/codeInsight/intentions/booleans/SimplifyBooleanExprWithLiteralTest.scala
@@ -3,13 +3,12 @@ package codeInsight.intentions.booleans
 
 import org.jetbrains.plugins.scala.codeInsight.intentions.ScalaIntentionTestBase
 import org.jetbrains.plugins.scala.codeInsight.intention.booleans.SimplifyBooleanExprWithLiteralIntention
-import org.jetbrains.plugins.scala.codeInspection.booleans.SimplifyBooleanInspection
 
 /**
  * Nikolay.Tropin
  * 4/29/13
  */
-class SimplifyBooleanExprWithLiteralTest extends ScalaIntentionTestBase{
+class SimplifyBooleanExprWithLiteralTest extends ScalaIntentionTestBase {
   def familyName: String = SimplifyBooleanExprWithLiteralIntention.familyName
 
   def test_NotTrue() {
@@ -19,18 +18,22 @@ class SimplifyBooleanExprWithLiteralTest extends ScalaIntentionTestBase{
   }
 
   def test_TrueEqualsA() {
-    val text = """val a = true
-                 |<caret>true == a""".stripMargin.replace("\r", "").trim
-    val result = """val a = true
-                   |a""".stripMargin.replace("\r", "").trim
+    val text =
+      """val a = true
+        |<caret>true == a"""
+    val result =
+      """val a = true
+        |a"""
     doTest(text, result)
   }
 
   def test_TrueAndA() {
-    val text = """val a = true
-                 |true <caret>&& a""".stripMargin.replace("\r", "").trim
-    val result = """val a = true
-                   |a""".stripMargin.replace("\r", "").trim
+    val text =
+      """val a = true
+        |true <caret>&& a"""
+    val result =
+      """val a = true
+        |a"""
     doTest(text, result)
   }
 
@@ -41,28 +44,34 @@ class SimplifyBooleanExprWithLiteralTest extends ScalaIntentionTestBase{
   }
 
   def test_TwoExpressions() {
-    val text = s"""
+    val text =
+      """
         |val a = true
         |<caret>true && (a || false)
-      """.stripMargin.replace("\r", "").trim
-    val result = """val a = true
-                   |a""".stripMargin.replace("\r", "").trim
+      """
+    val result =
+      """val a = true
+        |a"""
     doTest(text, result)
   }
 
   def test_TrueNotEqualsA() {
-    val text = """val a = true
-                  |val flag: Boolean = <caret>true != a""".stripMargin.replace("\r", "").trim
-    val result = """val a = true
-                   |val flag: Boolean = !a""".stripMargin.replace("\r", "").trim
+    val text =
+      """val a = true
+        |val flag: Boolean = <caret>true != a"""
+    val result =
+      """val a = true
+        |val flag: Boolean = !a"""
     doTest(text, result)
   }
 
   def test_SimplifyInParentheses() {
-    val text = """val a = true
-                 |!(<caret>true != a)""".stripMargin.replace("\r", "").trim
-    val result = """val a = true
-                    |!(!a)""".stripMargin.replace("\r", "").trim
+    val text =
+      """val a = true
+        |!(<caret>true != a)"""
+    val result =
+      """val a = true
+        |!(!a)"""
     doTest(text, result)
   }
 
@@ -78,13 +87,8 @@ class SimplifyBooleanExprWithLiteralTest extends ScalaIntentionTestBase{
         |  println("false")
         |}
         |
-      """.stripMargin.replace("\r", "").trim
+      """
 
     checkIntentionIsNotAvailable(text)
   }
-
-
-
-
-
 }

--- a/test/org/jetbrains/plugins/scala/codeInsight/intentions/controlflow/InvertIfConditionIntentionTest.scala
+++ b/test/org/jetbrains/plugins/scala/codeInsight/intentions/controlflow/InvertIfConditionIntentionTest.scala
@@ -1,212 +1,228 @@
 package org.jetbrains.plugins.scala.codeInsight.intentions.controlflow
 
 import org.jetbrains.plugins.scala.codeInsight.intentions.ScalaIntentionTestBase
-import org.jetbrains.plugins.scala.codeInsight.intention.controlflow.{InvertIfConditionIntention, SplitElseIfIntention}
+import org.jetbrains.plugins.scala.codeInsight.intention.controlflow.InvertIfConditionIntention
 
 /**
  * @author Ksenia.Sautina
  * @since 6/6/12
  */
 
-class InvertIfConditionIntentionTest  extends ScalaIntentionTestBase {
+class InvertIfConditionIntentionTest extends ScalaIntentionTestBase {
   val familyName = InvertIfConditionIntention.familyName
 
   def testInvertIf() {
-    val text  = """
-                  |class X {
-                  |  def f(a: Boolean, b: Boolean) {
-                  |    <caret>if (a) b = false
-                  |  }
-                  |}
-                """.stripMargin.replace("\r", "").trim
-    val resultText = """
-                       |class X {
-                       |  def f(a: Boolean, b: Boolean) {
-                       |    <caret>if (!a) {
-                       |
-                       |    } else {
-                       |      b = false
-                       |    }
-                       |  }
-                       |}
-                     """.stripMargin.replace("\r", "").trim
+    val text =
+      """
+        |class X {
+        |  def f(a: Boolean, b: Boolean) {
+        |    <caret>if (a) b = false
+        |  }
+        |}
+      """
+    val resultText =
+      """
+        |class X {
+        |  def f(a: Boolean, b: Boolean) {
+        |    <caret>if (!a) {
+        |
+        |    } else {
+        |      b = false
+        |    }
+        |  }
+        |}
+      """
 
     doTest(text, resultText)
   }
 
   def testInvertIf2() {
-    val text  = """
-                  |class X {
-                  |  def f(a: Boolean, b: Boolean) {
-                  |    i<caret>f (a) {
-                  |      b = false
-                  |    }
-                  |    System.out.println()
-                  |  }
-                  |}
-                """.stripMargin.replace("\r", "").trim
-    val resultText = """
-                       |class X {
-                       |  def f(a: Boolean, b: Boolean) {
-                       |    i<caret>f (!a) {
-                       |
-                       |    } else {
-                       |      b = false
-                       |    }
-                       |    System.out.println()
-                       |  }
-                       |}
-                     """.stripMargin.replace("\r", "").trim
+    val text =
+      """
+        |class X {
+        |  def f(a: Boolean, b: Boolean) {
+        |    i<caret>f (a) {
+        |      b = false
+        |    }
+        |    System.out.println()
+        |  }
+        |}
+      """
+    val resultText =
+      """
+        |class X {
+        |  def f(a: Boolean, b: Boolean) {
+        |    i<caret>f (!a) {
+        |
+        |    } else {
+        |      b = false
+        |    }
+        |    System.out.println()
+        |  }
+        |}
+      """
 
     doTest(text, resultText)
   }
 
   def testInvertIf3() {
-    val text  = """
-                  |class X {
-                  |  def f(a: Boolean, b: Boolean) {
-                  |    i<caret>f (a == b) {
-                  |      val c = false
-                  |    }
-                  |    println()
-                  |  }
-                  |}
-                """.stripMargin.replace("\r", "").trim
-    val resultText = """
-                       |class X {
-                       |  def f(a: Boolean, b: Boolean) {
-                       |    i<caret>f (a != b) {
-                       |
-                       |    } else {
-                       |      val c = false
-                       |    }
-                       |    println()
-                       |  }
-                       |}
-                     """.stripMargin.replace("\r", "").trim
+    val text =
+      """
+        |class X {
+        |  def f(a: Boolean, b: Boolean) {
+        |    i<caret>f (a == b) {
+        |      val c = false
+        |    }
+        |    println()
+        |  }
+        |}
+      """
+    val resultText =
+      """
+        |class X {
+        |  def f(a: Boolean, b: Boolean) {
+        |    i<caret>f (a != b) {
+        |
+        |    } else {
+        |      val c = false
+        |    }
+        |    println()
+        |  }
+        |}
+      """
 
     doTest(text, resultText)
   }
 
   def testInvertIf4() {
-    val text  = """
-                  |class X {
-                  |  def f(a: Boolean, b: Boolean) {
-                  |    i<caret>f (!a) b = false
-                  |  }
-                  |}
-                """.stripMargin.replace("\r", "").trim
-    val resultText = """
-                       |class X {
-                       |  def f(a: Boolean, b: Boolean) {
-                       |    i<caret>f (a) {
-                       |
-                       |    } else {
-                       |      b = false
-                       |    }
-                       |  }
-                       |}
-                     """.stripMargin.replace("\r", "").trim
+    val text =
+      """
+        |class X {
+        |  def f(a: Boolean, b: Boolean) {
+        |    i<caret>f (!a) b = false
+        |  }
+        |}
+      """
+    val resultText =
+      """
+        |class X {
+        |  def f(a: Boolean, b: Boolean) {
+        |    i<caret>f (a) {
+        |
+        |    } else {
+        |      b = false
+        |    }
+        |  }
+        |}
+      """
 
     doTest(text, resultText)
   }
 
   def testInvertIf5() {
-    val text  = """
-                  |class X {
-                  |  def f(a: Boolean, b: Boolean) {
-                  |    i<caret>f (true) b = false
-                  |  }
-                  |}
-                """.stripMargin.replace("\r", "").trim
-    val resultText = """
-                       |class X {
-                       |  def f(a: Boolean, b: Boolean) {
-                       |    i<caret>f (false) {
-                       |
-                       |    } else {
-                       |      b = false
-                       |    }
-                       |  }
-                       |}
-                     """.stripMargin.replace("\r", "").trim
+    val text =
+      """
+        |class X {
+        |  def f(a: Boolean, b: Boolean) {
+        |    i<caret>f (true) b = false
+        |  }
+        |}
+      """
+    val resultText =
+      """
+        |class X {
+        |  def f(a: Boolean, b: Boolean) {
+        |    i<caret>f (false) {
+        |
+        |    } else {
+        |      b = false
+        |    }
+        |  }
+        |}
+      """
 
     doTest(text, resultText)
   }
 
   def testInvertIf6() {
-    val text  = """
-                  |class X {
-                  |  def f(a: Boolean, b: Boolean) {
-                  |    i<caret>f (!(a == true)) b = false
-                  |  }
-                  |}
-                """.stripMargin.replace("\r", "").trim
-    val resultText = """
-                       |class X {
-                       |  def f(a: Boolean, b: Boolean) {
-                       |    i<caret>f (a == true) {
-                       |
-                       |    } else {
-                       |      b = false
-                       |    }
-                       |  }
-                       |}
-                     """.stripMargin.replace("\r", "").trim
+    val text =
+      """
+        |class X {
+        |  def f(a: Boolean, b: Boolean) {
+        |    i<caret>f (!(a == true)) b = false
+        |  }
+        |}
+      """
+    val resultText =
+      """
+        |class X {
+        |  def f(a: Boolean, b: Boolean) {
+        |    i<caret>f (a == true) {
+        |
+        |    } else {
+        |      b = false
+        |    }
+        |  }
+        |}
+      """
 
     doTest(text, resultText)
   }
 
   def testInvertIf7() {
-    val text  = """
-                  |class X {
-                  |  def f(a: Boolean, b: Boolean) {
-                  |    if<caret> (false) {
-                  |
-                  |    } else {
-                  |      System.out.print("else")
-                  |    }
-                  |  }
-                  |}
-                """.stripMargin.replace("\r", "").trim
-    val resultText = """
-                       |class X {
-                       |  def f(a: Boolean, b: Boolean) {
-                       |    if<caret> (true) {
-                       |      System.out.print("else")
-                       |    } else {
-                       |
-                       |    }
-                       |  }
-                       |}
-                     """.stripMargin.replace("\r", "").trim
+    val text =
+      """
+        |class X {
+        |  def f(a: Boolean, b: Boolean) {
+        |    if<caret> (false) {
+        |
+        |    } else {
+        |      System.out.print("else")
+        |    }
+        |  }
+        |}
+      """
+    val resultText =
+      """
+        |class X {
+        |  def f(a: Boolean, b: Boolean) {
+        |    if<caret> (true) {
+        |      System.out.print("else")
+        |    } else {
+        |
+        |    }
+        |  }
+        |}
+      """
 
     doTest(text, resultText)
   }
 
   def testInvertIf8() {
-    val text  = """
-                  |class X {
-                  |  def f(a: Boolean, b: Boolean) {
-                  |    i<caret>f (false) {
-                  |      System.out.print("if")
-                  |    } else {
-                  |      System.out.print("else")
-                  |    }
-                  |  }
-                  |}
-                """.stripMargin.replace("\r", "").trim
-    val resultText = """
-                       |class X {
-                       |  def f(a: Boolean, b: Boolean) {
-                       |    i<caret>f (true) {
-                       |      System.out.print("else")
-                       |    } else {
-                       |      System.out.print("if")
-                       |    }
-                       |  }
-                       |}
-                     """.stripMargin.replace("\r", "").trim
+    val text =
+      """
+        |class X {
+        |  def f(a: Boolean, b: Boolean) {
+        |    i<caret>f (false) {
+        |      System.out.print("if")
+        |    } else {
+        |      System.out.print("else")
+        |    }
+        |  }
+        |}
+      """
+    val resultText =
+      """
+        |class X {
+        |  def f(a: Boolean, b: Boolean) {
+        |    i<caret>f (true) {
+        |      System.out.print("else")
+        |    } else {
+        |      System.out.print("if")
+        |    }
+        |  }
+        |}
+      """
 
     doTest(text, resultText)
   }

--- a/test/org/jetbrains/plugins/scala/codeInsight/intentions/controlflow/MergeElseIfIntentionTest.scala
+++ b/test/org/jetbrains/plugins/scala/codeInsight/intentions/controlflow/MergeElseIfIntentionTest.scala
@@ -12,201 +12,213 @@ class MergeElseIfIntentionTest extends ScalaIntentionTestBase {
   val familyName = MergeElseIfIntention.familyName
 
   def testMergeElseIf() {
-    val text = """
-                 |class MergeElseIf {
-                 |  def mthd() {
-                 |    val a: Int = 0
-                 |    if (a == 9) {
-                 |      System.out.println("if1")
-                 |    } el<caret>se {
-                 |      if (a == 8) {
-                 |        System.out.println("if2")
-                 |      } else {
-                 |        System.out.println("else")
-                 |      }
-                 |    }
-                 |  }
-                 |}
-               """.stripMargin.replace("\r", "").trim
-    val resultText = """
-                       |class MergeElseIf {
-                       |  def mthd() {
-                       |    val a: Int = 0
-                       |    if (a == 9) {
-                       |      System.out.println("if1")
-                       |    } el<caret>se
-                       |    if (a == 8) {
-                       |      System.out.println("if2")
-                       |    } else {
-                       |      System.out.println("else")
-                       |    }
-                       |  }
-                       |}
-                     """.stripMargin.replace("\r", "").trim
+    val text =
+      """
+        |class MergeElseIf {
+        |  def mthd() {
+        |    val a: Int = 0
+        |    if (a == 9) {
+        |      System.out.println("if1")
+        |    } el<caret>se {
+        |      if (a == 8) {
+        |        System.out.println("if2")
+        |      } else {
+        |        System.out.println("else")
+        |      }
+        |    }
+        |  }
+        |}
+      """
+    val resultText =
+      """
+        |class MergeElseIf {
+        |  def mthd() {
+        |    val a: Int = 0
+        |    if (a == 9) {
+        |      System.out.println("if1")
+        |    } el<caret>se
+        |    if (a == 8) {
+        |      System.out.println("if2")
+        |    } else {
+        |      System.out.println("else")
+        |    }
+        |  }
+        |}
+      """
 
     doTest(text, resultText)
   }
 
   def testMergeElseIf2() {
-    val text = """
-                 |class MergeElseIf {
-                 |  def mthd() {
-                 |    val a: Int = 0
-                 |    if (a == 9) System.out.println("if1")
-                 |    el<caret>se {
-                 |      if (a == 8)
-                 |        System.out.println("if2")
-                 |      else
-                 |        System.out.println("else")
-                 |    }
-                 |  }
-                 |}
-               """.stripMargin.replace("\r", "").trim
-    val resultText = """
-                       |class MergeElseIf {
-                       |  def mthd() {
-                       |    val a: Int = 0
-                       |    if (a == 9) System.out.println("if1")
-                       |    el<caret>se
-                       |    if (a == 8)
-                       |      System.out.println("if2")
-                       |    else
-                       |      System.out.println("else")
-                       |  }
-                       |}
-                     """.stripMargin.replace("\r", "").trim
+    val text =
+      """
+        |class MergeElseIf {
+        |  def mthd() {
+        |    val a: Int = 0
+        |    if (a == 9) System.out.println("if1")
+        |    el<caret>se {
+        |      if (a == 8)
+        |        System.out.println("if2")
+        |      else
+        |        System.out.println("else")
+        |    }
+        |  }
+        |}
+      """
+    val resultText =
+      """
+        |class MergeElseIf {
+        |  def mthd() {
+        |    val a: Int = 0
+        |    if (a == 9) System.out.println("if1")
+        |    el<caret>se
+        |    if (a == 8)
+        |      System.out.println("if2")
+        |    else
+        |      System.out.println("else")
+        |  }
+        |}
+      """
 
     doTest(text, resultText)
   }
 
   def testMergeElseIf3() {
-    val text = """
-                 |class MergeElseIf {
-                 |  def mthd() {
-                 |    val a: Int = 0
-                 |    if (a == 9) {
-                 |      System.out.println("if1")
-                 |    } el<caret>se {
-                 |      if (a == 8)
-                 |        System.out.println("if2")
-                 |      else {
-                 |        System.out.println("else")
-                 |      }
-                 |    }
-                 |  }
-                 |}
-               """.stripMargin.replace("\r", "").trim
-    val resultText = """
-                       |class MergeElseIf {
-                       |  def mthd() {
-                       |    val a: Int = 0
-                       |    if (a == 9) {
-                       |      System.out.println("if1")
-                       |    } el<caret>se
-                       |    if (a == 8)
-                       |      System.out.println("if2")
-                       |    else {
-                       |      System.out.println("else")
-                       |    }
-                       |  }
-                       |}
-                     """.stripMargin.replace("\r", "").trim
+    val text =
+      """
+        |class MergeElseIf {
+        |  def mthd() {
+        |    val a: Int = 0
+        |    if (a == 9) {
+        |      System.out.println("if1")
+        |    } el<caret>se {
+        |      if (a == 8)
+        |        System.out.println("if2")
+        |      else {
+        |        System.out.println("else")
+        |      }
+        |    }
+        |  }
+        |}
+      """
+    val resultText =
+      """
+        |class MergeElseIf {
+        |  def mthd() {
+        |    val a: Int = 0
+        |    if (a == 9) {
+        |      System.out.println("if1")
+        |    } el<caret>se
+        |    if (a == 8)
+        |      System.out.println("if2")
+        |    else {
+        |      System.out.println("else")
+        |    }
+        |  }
+        |}
+      """
 
     doTest(text, resultText)
   }
 
   def testMergeElseIf4() {
-    val text = """
-                 |class MergeElseIf {
-                 |  def mthd() {
-                 |    val a: Int = 0
-                 |    if (a == 9) {
-                 |      System.out.println("if1")
-                 |    } el<caret>se {
-                 |      if (a == 8)
-                 |        System.out.println("if2")
-                 |      else
-                 |        System.out.println("else")
-                 |    }
-                 |  }
-                 |}
-               """.stripMargin.replace("\r", "").trim
-    val resultText = """
-                       |class MergeElseIf {
-                       |  def mthd() {
-                       |    val a: Int = 0
-                       |    if (a == 9) {
-                       |      System.out.println("if1")
-                       |    } el<caret>se
-                       |    if (a == 8)
-                       |      System.out.println("if2")
-                       |    else
-                       |      System.out.println("else")
-                       |  }
-                       |}
-                     """.stripMargin.replace("\r", "").trim
+    val text =
+      """
+        |class MergeElseIf {
+        |  def mthd() {
+        |    val a: Int = 0
+        |    if (a == 9) {
+        |      System.out.println("if1")
+        |    } el<caret>se {
+        |      if (a == 8)
+        |        System.out.println("if2")
+        |      else
+        |        System.out.println("else")
+        |    }
+        |  }
+        |}
+      """
+    val resultText =
+      """
+        |class MergeElseIf {
+        |  def mthd() {
+        |    val a: Int = 0
+        |    if (a == 9) {
+        |      System.out.println("if1")
+        |    } el<caret>se
+        |    if (a == 8)
+        |      System.out.println("if2")
+        |    else
+        |      System.out.println("else")
+        |  }
+        |}
+      """
 
     doTest(text, resultText)
   }
 
   def testMergeElseIf5() {
-    val text = """
-                 |class MergeElseIf {
-                 |  def mthd() {
-                 |    val a: Int = 0
-                 |    if (a == 9)
-                 |      System.out.println("if1")
-                 |    else<caret> {
-                 |      if (a == 8)
-                 |        System.out.println("if2")
-                 |      else
-                 |        System.out.println("else")
-                 |    }
-                 |  }
-                 |}
-               """.stripMargin.replace("\r", "").trim
-    val resultText = """
-                       |class MergeElseIf {
-                       |  def mthd() {
-                       |    val a: Int = 0
-                       |    if (a == 9) System.out.println("if1")
-                       |    else<caret>
-                       |    if (a == 8)
-                       |      System.out.println("if2")
-                       |    else
-                       |      System.out.println("else")
-                       |  }
-                       |}
-                     """.stripMargin.replace("\r", "").trim
+    val text =
+      """
+        |class MergeElseIf {
+        |  def mthd() {
+        |    val a: Int = 0
+        |    if (a == 9)
+        |      System.out.println("if1")
+        |    else<caret> {
+        |      if (a == 8)
+        |        System.out.println("if2")
+        |      else
+        |        System.out.println("else")
+        |    }
+        |  }
+        |}
+      """
+    val resultText =
+      """
+        |class MergeElseIf {
+        |  def mthd() {
+        |    val a: Int = 0
+        |    if (a == 9) System.out.println("if1")
+        |    else<caret>
+        |    if (a == 8)
+        |      System.out.println("if2")
+        |    else
+        |      System.out.println("else")
+        |  }
+        |}
+      """
 
     doTest(text, resultText)
   }
 
   def testMergeElseIf6() {
-    val text = """
-                 |class MergeElseIf {
-                 |  def mthd() {
-                 |    val a: Int = 0
-                 |    if (a == 9)
-                 |      System.out.println("if1")
-                 |    else<caret> {
-                 |      if (a == 8)
-                 |        System.out.println("if2")
-                 |    }
-                 |  }
-                 |}
-               """.stripMargin.replace("\r", "").trim
-    val resultText = """
-                       |class MergeElseIf {
-                       |  def mthd() {
-                       |    val a: Int = 0
-                       |    if (a == 9) System.out.println("if1")
-                       |    else<caret>
-                       |    if (a == 8)
-                       |      System.out.println("if2")
-                       |  }
-                       |}
-                     """.stripMargin.replace("\r", "").trim
+    val text =
+      """
+        |class MergeElseIf {
+        |  def mthd() {
+        |    val a: Int = 0
+        |    if (a == 9)
+        |      System.out.println("if1")
+        |    else<caret> {
+        |      if (a == 8)
+        |        System.out.println("if2")
+        |    }
+        |  }
+        |}
+      """
+    val resultText =
+      """
+        |class MergeElseIf {
+        |  def mthd() {
+        |    val a: Int = 0
+        |    if (a == 9) System.out.println("if1")
+        |    else<caret>
+        |    if (a == 8)
+        |      System.out.println("if2")
+        |  }
+        |}
+      """
 
     doTest(text, resultText)
   }

--- a/test/org/jetbrains/plugins/scala/codeInsight/intentions/controlflow/MergeIfToAndIntentionTest.scala
+++ b/test/org/jetbrains/plugins/scala/codeInsight/intentions/controlflow/MergeIfToAndIntentionTest.scala
@@ -12,101 +12,109 @@ class MergeIfToAndIntentionTest extends ScalaIntentionTestBase {
   val familyName = MergeIfToAndIntention.familyName
 
   def testMergeIfToAnd() {
-    val text = """
-                 |class MergeIfToAnd {
-                 |  def mthd() {
-                 |    val a: Int = 0
-                 |    i<caret>f (a == 9) {
-                 |      if (a == 7) {
-                 |        System.out.println("if")
-                 |      }
-                 |    }
-                 |  }
-                 |}
-               """.stripMargin.replace("\r", "").trim
-    val resultText = """
-                       |class MergeIfToAnd {
-                       |  def mthd() {
-                       |    val a: Int = 0
-                       |    i<caret>f (a == 9 && a == 7) {
-                       |      System.out.println("if")
-                       |    }
-                       |  }
-                       |}
-                     """.stripMargin.replace("\r", "").trim
+    val text =
+      """
+        |class MergeIfToAnd {
+        |  def mthd() {
+        |    val a: Int = 0
+        |    i<caret>f (a == 9) {
+        |      if (a == 7) {
+        |        System.out.println("if")
+        |      }
+        |    }
+        |  }
+        |}
+      """
+    val resultText =
+      """
+        |class MergeIfToAnd {
+        |  def mthd() {
+        |    val a: Int = 0
+        |    i<caret>f (a == 9 && a == 7) {
+        |      System.out.println("if")
+        |    }
+        |  }
+        |}
+      """
 
     doTest(text, resultText)
   }
 
   def testMergeIfToAnd2() {
-    val text = """
-                 |class MergeIfToAnd {
-                 |  def mthd() {
-                 |    val a: Int = 0
-                 |    i<caret>f (a == 9)
-                 |      if (a == 7)
-                 |        System.out.println("if")
-                 |  }
-                 |}
-               """.stripMargin.replace("\r", "").trim
-    val resultText = """
-                       |class MergeIfToAnd {
-                       |  def mthd() {
-                       |    val a: Int = 0
-                       |    i<caret>f (a == 9 && a == 7) System.out.println("if")
-                       |  }
-                       |}
-                     """.stripMargin.replace("\r", "").trim
+    val text =
+      """
+        |class MergeIfToAnd {
+        |  def mthd() {
+        |    val a: Int = 0
+        |    i<caret>f (a == 9)
+        |      if (a == 7)
+        |        System.out.println("if")
+        |  }
+        |}
+      """
+    val resultText =
+      """
+        |class MergeIfToAnd {
+        |  def mthd() {
+        |    val a: Int = 0
+        |    i<caret>f (a == 9 && a == 7) System.out.println("if")
+        |  }
+        |}
+      """
 
     doTest(text, resultText)
   }
 
   def testMergeIfToAnd3() {
-    val text = """
-                 |class MergeIfToAnd {
-                 |  def mthd() {
-                 |    val a: Int = 0
-                 |    i<caret>f (a == 9) {
-                 |      if (a == 7)
-                 |        System.out.println("if")
-                 |    }
-                 |  }
-                 |}
-               """.stripMargin.replace("\r", "").trim
-    val resultText = """
-                       |class MergeIfToAnd {
-                       |  def mthd() {
-                       |    val a: Int = 0
-                       |    i<caret>f (a == 9 && a == 7) System.out.println("if")
-                       |  }
-                       |}
-                     """.stripMargin.replace("\r", "").trim
+    val text =
+      """
+        |class MergeIfToAnd {
+        |  def mthd() {
+        |    val a: Int = 0
+        |    i<caret>f (a == 9) {
+        |      if (a == 7)
+        |        System.out.println("if")
+        |    }
+        |  }
+        |}
+      """
+    val resultText =
+      """
+        |class MergeIfToAnd {
+        |  def mthd() {
+        |    val a: Int = 0
+        |    i<caret>f (a == 9 && a == 7) System.out.println("if")
+        |  }
+        |}
+      """
 
     doTest(text, resultText)
   }
 
   def testMergeIfToAnd4() {
-    val text = """
-                 |class MergeIfToAnd {
-                 |  def mthd() {
-                 |    val a: Int = 0
-                 |    i<caret>f (a == 9)
-                 |      if (a == 7) {
-                 |        System.out.println("if")
-                 |      }
-                 |  }
-                 |}
-               """.stripMargin.replace("\r", "").trim
-    val resultText = """
-                       |class MergeIfToAnd {
-                       |  def mthd() {
-                       |    val a: Int = 0
-                       |    i<caret>f (a == 9 && a == 7) {
-                       |      System.out.println("if")
-                       |    }
-                       |  }
-                       |}
-                     """.stripMargin.replace("\r", "").trim
+    val text =
+      """
+        |class MergeIfToAnd {
+        |  def mthd() {
+        |    val a: Int = 0
+        |    i<caret>f (a == 9)
+        |      if (a == 7) {
+        |        System.out.println("if")
+        |      }
+        |  }
+        |}
+      """
+    val resultText =
+      """
+        |class MergeIfToAnd {
+        |  def mthd() {
+        |    val a: Int = 0
+        |    i<caret>f (a == 9 && a == 7) {
+        |      System.out.println("if")
+        |    }
+        |  }
+        |}
+      """
 
     doTest(text, resultText)
   }

--- a/test/org/jetbrains/plugins/scala/codeInsight/intentions/controlflow/MergeIfToOrIntentionTest.scala
+++ b/test/org/jetbrains/plugins/scala/codeInsight/intentions/controlflow/MergeIfToOrIntentionTest.scala
@@ -12,112 +12,120 @@ class MergeIfToOrIntentionTest extends ScalaIntentionTestBase {
   val familyName = MergeIfToOrIntention.familyName
 
   def testMergeIfToOr() {
-    val text  = """
-                  |class MergeIfToOr {
-                  |  def mthd {
-                  |    val a: Int = 0
-                  |    i<caret>f (a == 9) {
-                  |    } else if (a == 7) {
-                  |    }
-                  |  }
-                  |}
-                """.stripMargin.replace("\r", "").trim
-    val resultText = """
-                       |class MergeIfToOr {
-                       |  def mthd {
-                       |    val a: Int = 0
-                       |    <caret>if (a == 9 || a == 7) {
-                       |    }
-                       |  }
-                       |}
-                     """.stripMargin.replace("\r", "").trim
+    val text =
+      """
+        |class MergeIfToOr {
+        |  def mthd {
+        |    val a: Int = 0
+        |    i<caret>f (a == 9) {
+        |    } else if (a == 7) {
+        |    }
+        |  }
+        |}
+      """
+    val resultText =
+      """
+        |class MergeIfToOr {
+        |  def mthd {
+        |    val a: Int = 0
+        |    <caret>if (a == 9 || a == 7) {
+        |    }
+        |  }
+        |}
+      """
 
     doTest(text, resultText)
   }
 
   def testMergeIfToOr2() {
-    val text  = """
-                  |class MergeIfToOr {
-                  |  def mthd {
-                  |    val a: Int = 0
-                  |    i<caret>f (a == 9) {
-                  |      System.out.println("if")
-                  |    } else if (a == 7) {
-                  |      System.out.println("if")
-                  |    } else {
-                  |      System.out.println("else")
-                  |    }
-                  |  }
-                  |}
-                """.stripMargin.replace("\r", "").trim
-    val resultText = """
-                       |class MergeIfToOr {
-                       |  def mthd {
-                       |    val a: Int = 0
-                       |    <caret>if (a == 9 || a == 7) {
-                       |      System.out.println("if")
-                       |    } else {
-                       |      System.out.println("else")
-                       |    }
-                       |  }
-                       |}
-                     """.stripMargin.replace("\r", "").trim
+    val text =
+      """
+        |class MergeIfToOr {
+        |  def mthd {
+        |    val a: Int = 0
+        |    i<caret>f (a == 9) {
+        |      System.out.println("if")
+        |    } else if (a == 7) {
+        |      System.out.println("if")
+        |    } else {
+        |      System.out.println("else")
+        |    }
+        |  }
+        |}
+      """
+    val resultText =
+      """
+        |class MergeIfToOr {
+        |  def mthd {
+        |    val a: Int = 0
+        |    <caret>if (a == 9 || a == 7) {
+        |      System.out.println("if")
+        |    } else {
+        |      System.out.println("else")
+        |    }
+        |  }
+        |}
+      """
 
     doTest(text, resultText)
   }
 
   def testMergeIfToOr3() {
-    val text  = """
-                  |class MergeIfToOr {
-                  |  def mthd {
-                  |    val a: Int = 0
-                  |      i<caret>f (a == 9)
-                  |        System.out.println("if")
-                  |      else if (a == 7)
-                  |        System.out.println("if")
-                  |  }
-                  |}
-                """.stripMargin.replace("\r", "").trim
-    val resultText = """
-                       |class MergeIfToOr {
-                       |  def mthd {
-                       |    val a: Int = 0
-                       |    <caret>if (a == 9 || a == 7) System.out.println("if")
-                       |  }
-                       |}
-                     """.stripMargin.replace("\r", "").trim
+    val text =
+      """
+        |class MergeIfToOr {
+        |  def mthd {
+        |    val a: Int = 0
+        |      i<caret>f (a == 9)
+        |        System.out.println("if")
+        |      else if (a == 7)
+        |        System.out.println("if")
+        |  }
+        |}
+      """
+    val resultText =
+      """
+        |class MergeIfToOr {
+        |  def mthd {
+        |    val a: Int = 0
+        |    <caret>if (a == 9 || a == 7) System.out.println("if")
+        |  }
+        |}
+      """
 
     doTest(text, resultText)
   }
 
   def testMergeIfToOr4() {
-    val text  = """
-                  |class MergeIfToOr {
-                  |  def mthd {
-                  |    val a: Int = 0
-                  |      i<caret>f (a == 9)
-                  |        System.out.println("if")
-                  |      else if (a == 7)
-                  |        System.out.println("if")
-                  |      else if (a == 19)
-                  |        System.out.println("if")
-                  |      else
-                  |        System.out.println("if")
-                  |  }
-                  |}
-                """.stripMargin.replace("\r", "").trim
-    val resultText = """
-                       |class MergeIfToOr {
-                       |  def mthd {
-                       |    val a: Int = 0
-                       |    <caret>if (a == 9 || a == 7) System.out.println("if")
-                       |    else if (a == 19)
-                       |      System.out.println("if")
-                       |    else
-                       |      System.out.println("if")
-                       |  }
-                       |}
-                     """.stripMargin.replace("\r", "").trim
+    val text =
+      """
+        |class MergeIfToOr {
+        |  def mthd {
+        |    val a: Int = 0
+        |      i<caret>f (a == 9)
+        |        System.out.println("if")
+        |      else if (a == 7)
+        |        System.out.println("if")
+        |      else if (a == 19)
+        |        System.out.println("if")
+        |      else
+        |        System.out.println("if")
+        |  }
+        |}
+      """
+    val resultText =
+      """
+        |class MergeIfToOr {
+        |  def mthd {
+        |    val a: Int = 0
+        |    <caret>if (a == 9 || a == 7) System.out.println("if")
+        |    else if (a == 19)
+        |      System.out.println("if")
+        |    else
+        |      System.out.println("if")
+        |  }
+        |}
+      """
 
     doTest(text, resultText)
   }

--- a/test/org/jetbrains/plugins/scala/codeInsight/intentions/controlflow/RemoveRedundantElseIntentionTest.scala
+++ b/test/org/jetbrains/plugins/scala/codeInsight/intentions/controlflow/RemoveRedundantElseIntentionTest.scala
@@ -12,166 +12,178 @@ class RemoveRedundantElseIntentionTest extends ScalaIntentionTestBase {
   val familyName = RemoveRedundantElseIntention.familyName
 
   def testRemoveElse() {
-    val text = """
-                 |class X {
-                 |  def f(i: Int) {
-                 |    if (i == 0) {
-                 |      return
-                 |    } e<caret>lse {
-                 |      val j = 0
-                 |    }
-                 |  }
-                 |}
-               """.stripMargin.replace("\r", "").trim
-    val resultText = """
-                       |class X {
-                       |  def f(i: Int) {
-                       |    if (i == 0) {
-                       |      return
-                       |    }<caret>
-                       |    val j = 0
-                       |  }
-                       |}
-                     """.stripMargin.replace("\r", "").trim
+    val text =
+      """
+        |class X {
+        |  def f(i: Int) {
+        |    if (i == 0) {
+        |      return
+        |    } e<caret>lse {
+        |      val j = 0
+        |    }
+        |  }
+        |}
+      """
+    val resultText =
+      """
+        |class X {
+        |  def f(i: Int) {
+        |    if (i == 0) {
+        |      return
+        |    }<caret>
+        |    val j = 0
+        |  }
+        |}
+      """
 
     doTest(text, resultText)
   }
 
   def testRemoveElse2() {
-    val text = """
-                 |class X {
-                 |  def f(i: Int): Boolean = {
-                 |    if (i == 0) {
-                 |      return true
-                 |    } e<caret>lse {
-                 |      val j = 0
-                 |    }
-                 |    return false
-                 |  }
-                 |}
-               """.stripMargin.replace("\r", "").trim
-    val resultText = """
-                       |class X {
-                       |  def f(i: Int): Boolean = {
-                       |    if (i == 0) {
-                       |      return true
-                       |    }<caret>
-                       |    val j = 0
-                       |    return false
-                       |  }
-                       |}
-                     """.stripMargin.replace("\r", "").trim
+    val text =
+      """
+        |class X {
+        |  def f(i: Int): Boolean = {
+        |    if (i == 0) {
+        |      return true
+        |    } e<caret>lse {
+        |      val j = 0
+        |    }
+        |    return false
+        |  }
+        |}
+      """
+    val resultText =
+      """
+        |class X {
+        |  def f(i: Int): Boolean = {
+        |    if (i == 0) {
+        |      return true
+        |    }<caret>
+        |    val j = 0
+        |    return false
+        |  }
+        |}
+      """
 
     doTest(text, resultText)
   }
 
   def testRemoveElse3() {
-    val text = """
-                 |class X {
-                 |  def f(i: Int): Boolean = {
-                 |    if (i == 0) {
-                 |      System.out.println("if")
-                 |      return true
-                 |    } e<caret>lse {
-                 |      System.out.println("else")
-                 |      val j = 0
-                 |    }
-                 |    return false
-                 |  }
-                 |}
-               """.stripMargin.replace("\r", "").trim
-    val resultText = """
-                       |class X {
-                       |  def f(i: Int): Boolean = {
-                       |    if (i == 0) {
-                       |      System.out.println("if")
-                       |      return true
-                       |    }<caret>
-                       |    System.out.println("else")
-                       |    val j = 0
-                       |    return false
-                       |  }
-                       |}
-                     """.stripMargin.replace("\r", "").trim
+    val text =
+      """
+        |class X {
+        |  def f(i: Int): Boolean = {
+        |    if (i == 0) {
+        |      System.out.println("if")
+        |      return true
+        |    } e<caret>lse {
+        |      System.out.println("else")
+        |      val j = 0
+        |    }
+        |    return false
+        |  }
+        |}
+      """
+    val resultText =
+      """
+        |class X {
+        |  def f(i: Int): Boolean = {
+        |    if (i == 0) {
+        |      System.out.println("if")
+        |      return true
+        |    }<caret>
+        |    System.out.println("else")
+        |    val j = 0
+        |    return false
+        |  }
+        |}
+      """
 
     doTest(text, resultText)
   }
 
   def testRemoveElse4() {
-    val text = """
-                 |class X {
-                 |  def f(i: Int): Boolean = {
-                 |    if (i == 0) return true
-                 |    e<caret>lse {
-                 |      System.out.println("else")
-                 |      val j = 0
-                 |    }
-                 |    return false
-                 |  }
-                 |}
-               """.stripMargin.replace("\r", "").trim
-    val resultText = """
-                       |class X {
-                       |  def f(i: Int): Boolean = {
-                       |    if (i == 0) return true<caret>
-                       |    System.out.println("else")
-                       |    val j = 0
-                       |    return false
-                       |  }
-                       |}
-                     """.stripMargin.replace("\r", "").trim
+    val text =
+      """
+        |class X {
+        |  def f(i: Int): Boolean = {
+        |    if (i == 0) return true
+        |    e<caret>lse {
+        |      System.out.println("else")
+        |      val j = 0
+        |    }
+        |    return false
+        |  }
+        |}
+      """
+    val resultText =
+      """
+        |class X {
+        |  def f(i: Int): Boolean = {
+        |    if (i == 0) return true<caret>
+        |    System.out.println("else")
+        |    val j = 0
+        |    return false
+        |  }
+        |}
+      """
 
     doTest(text, resultText)
   }
 
   def testRemoveElse5() {
-    val text = """
-                 |class X {
-                 |  def f(i: Int): Boolean = {
-                 |    if (i == 0)
-                 |      return true
-                 |    e<caret>lse
-                 |      System.out.println("else")
-                 |    return false
-                 |  }
-                 |}
-               """.stripMargin.replace("\r", "").trim
-    val resultText = """
-                       |class X {
-                       |  def f(i: Int): Boolean = {
-                       |    if (i == 0)
-                       |      return true<caret>
-                       |    System.out.println("else")
-                       |    return false
-                       |  }
-                       |}
-                     """.stripMargin.replace("\r", "").trim
+    val text =
+      """
+        |class X {
+        |  def f(i: Int): Boolean = {
+        |    if (i == 0)
+        |      return true
+        |    e<caret>lse
+        |      System.out.println("else")
+        |    return false
+        |  }
+        |}
+      """
+    val resultText =
+      """
+        |class X {
+        |  def f(i: Int): Boolean = {
+        |    if (i == 0)
+        |      return true<caret>
+        |    System.out.println("else")
+        |    return false
+        |  }
+        |}
+      """
 
     doTest(text, resultText)
   }
 
   def testRemoveElse6() {
-    val text = """
-                 |class X {
-                 |  def f(i: Int): Boolean = {
-                 |    if (i == 0)
-                 |      throw new Exception
-                 |    e<caret>lse
-                 |      System.out.println("else")
-                 |    return false
-                 |  }
-                 |}
-               """.stripMargin.replace("\r", "").trim
-    val resultText = """
-                       |class X {
-                       |  def f(i: Int): Boolean = {
-                       |    if (i == 0)
-                       |      throw new Exception<caret>
-                       |    System.out.println("else")
-                       |    return false
-                       |  }
-                       |}
-                     """.stripMargin.replace("\r", "").trim
+    val text =
+      """
+        |class X {
+        |  def f(i: Int): Boolean = {
+        |    if (i == 0)
+        |      throw new Exception
+        |    e<caret>lse
+        |      System.out.println("else")
+        |    return false
+        |  }
+        |}
+      """
+    val resultText =
+      """
+        |class X {
+        |  def f(i: Int): Boolean = {
+        |    if (i == 0)
+        |      throw new Exception<caret>
+        |    System.out.println("else")
+        |    return false
+        |  }
+        |}
+      """
 
     doTest(text, resultText)
   }

--- a/test/org/jetbrains/plugins/scala/codeInsight/intentions/controlflow/ReplaceDoWhileWithWhileIntentionTest.scala
+++ b/test/org/jetbrains/plugins/scala/codeInsight/intentions/controlflow/ReplaceDoWhileWithWhileIntentionTest.scala
@@ -8,240 +8,258 @@ import org.jetbrains.plugins.scala.codeInsight.intention.controlflow.ReplaceDoWh
  * Nikolay.Tropin
  * 4/17/13
  */
-class ReplaceDoWhileWithWhileIntentionTest extends ScalaIntentionTestBase{
+class ReplaceDoWhileWithWhileIntentionTest extends ScalaIntentionTestBase {
   def familyName: String = ReplaceDoWhileWithWhileIntention.familyName
 
   def testReplaceDoWhile() {
-    val text  = """
-                  |class X {
-                  |  val flag: Boolean
-                  |
-                  |  def f {
-                  |    <caret>do {
-                  |       print("")
-                  |      //comment
-                  |    } while(flag)
-                  |  }
-                  |}
-                """.stripMargin.replace("\r", "").trim
-    val resultText = """
-                       |class X {
-                       |  val flag: Boolean
-                       |
-                       |  def f {
-                       |    print("")
-                       |    //comment
-                       |    while (flag) {
-                       |      print("")
-                       |      //comment
-                       |    }
-                       |  }
-                       |}
-                     """.stripMargin.replace("\r", "").trim
+    val text =
+      """
+        |class X {
+        |  val flag: Boolean
+        |
+        |  def f {
+        |    <caret>do {
+        |       print("")
+        |      //comment
+        |    } while(flag)
+        |  }
+        |}
+      """
+    val resultText =
+      """
+        |class X {
+        |  val flag: Boolean
+        |
+        |  def f {
+        |    print("")
+        |    //comment
+        |    while (flag) {
+        |      print("")
+        |      //comment
+        |    }
+        |  }
+        |}
+      """
     doTest(text, resultText)
   }
 
   def testReplaceDoWhile2() {
-    val text  = """
-                  |class X {
-                  |  val flag: Boolean
-                  |
-                  |  def f {
-                  |    do<caret> {
-                  |      print("")
-                  |      //comment
-                  |    } while(flag)
-                  |  }
-                  |}
-                """.stripMargin.replace("\r", "").trim
-    val resultText = """
-                       |class X {
-                       |  val flag: Boolean
-                       |
-                       |  def f {
-                       |    print("")
-                       |    //comment
-                       |    while (flag) {
-                       |      print("")
-                       |      //comment
-                       |    }
-                       |  }
-                       |}
-                     """.stripMargin.replace("\r", "").trim
+    val text =
+      """
+        |class X {
+        |  val flag: Boolean
+        |
+        |  def f {
+        |    do<caret> {
+        |      print("")
+        |      //comment
+        |    } while(flag)
+        |  }
+        |}
+      """
+    val resultText =
+      """
+        |class X {
+        |  val flag: Boolean
+        |
+        |  def f {
+        |    print("")
+        |    //comment
+        |    while (flag) {
+        |      print("")
+        |      //comment
+        |    }
+        |  }
+        |}
+      """
     doTest(text, resultText)
   }
 
   def testReplaceDoWhile3() {
-    val text  = """
-                  |class X {
-                  |  val flag: Boolean
-                  |
-                  |  def f {
-                  |    do {
-                  |      print("")
-                  |      //comment
-                  |    } <caret>while(flag)
-                  |  }
-                  |}
-                """.stripMargin.replace("\r", "").trim
-    val resultText = """
-                       |class X {
-                       |  val flag: Boolean
-                       |
-                       |  def f {
-                       |    print("")
-                       |    //comment
-                       |    while (flag) {
-                       |      print("")
-                       |      //comment
-                       |    }
-                       |  }
-                       |}
-                     """.stripMargin.replace("\r", "").trim
+    val text =
+      """
+        |class X {
+        |  val flag: Boolean
+        |
+        |  def f {
+        |    do {
+        |      print("")
+        |      //comment
+        |    } <caret>while(flag)
+        |  }
+        |}
+      """
+    val resultText =
+      """
+        |class X {
+        |  val flag: Boolean
+        |
+        |  def f {
+        |    print("")
+        |    //comment
+        |    while (flag) {
+        |      print("")
+        |      //comment
+        |    }
+        |  }
+        |}
+      """
     doTest(text, resultText)
   }
 
   def testReplaceDoWhile4() {
-    val text  = """
-                  |class X {
-                  |  val flag: Boolean
-                  |
-                  |  def f {
-                  |    do {
-                  |      print("")
-                  |      //comment
-                  |    } while<caret>(flag)
-                  |  }
-                  |}
-                """.stripMargin.replace("\r", "").trim
-    val resultText = """
-                       |class X {
-                       |  val flag: Boolean
-                       |
-                       |  def f {
-                       |    print("")
-                       |    //comment
-                       |    while (flag) {
-                       |      print("")
-                       |      //comment
-                       |    }
-                       |  }
-                       |}
-                     """.stripMargin.replace("\r", "").trim
+    val text =
+      """
+        |class X {
+        |  val flag: Boolean
+        |
+        |  def f {
+        |    do {
+        |      print("")
+        |      //comment
+        |    } while<caret>(flag)
+        |  }
+        |}
+      """
+    val resultText =
+      """
+        |class X {
+        |  val flag: Boolean
+        |
+        |  def f {
+        |    print("")
+        |    //comment
+        |    while (flag) {
+        |      print("")
+        |      //comment
+        |    }
+        |  }
+        |}
+      """
     doTest(text, resultText)
   }
 
   def testReplaceDoWhile5() {
-    val text  = """
-                  |class X {
-                  |  val flag: Boolean
-                  |
-                  |  def f {
-                  |    if (true)
-                  |      do {
-                  |        print("")
-                  |      } while<caret>(flag)
-                  |  }
-                  |}
-                """.stripMargin.replace("\r", "").trim
-    val resultText = """
-                       |class X {
-                       |  val flag: Boolean
-                       |
-                       |  def f {
-                       |    if (true) {
-                       |      print("")
-                       |      while (flag) {
-                       |        print("")
-                       |      }
-                       |    }
-                       |  }
-                       |}
-                     """.stripMargin.replace("\r", "").trim
+    val text =
+      """
+        |class X {
+        |  val flag: Boolean
+        |
+        |  def f {
+        |    if (true)
+        |      do {
+        |        print("")
+        |      } while<caret>(flag)
+        |  }
+        |}
+      """
+    val resultText =
+      """
+        |class X {
+        |  val flag: Boolean
+        |
+        |  def f {
+        |    if (true) {
+        |      print("")
+        |      while (flag) {
+        |        print("")
+        |      }
+        |    }
+        |  }
+        |}
+      """
     doTest(text, resultText)
   }
 
   def testReplaceDoWhile6() {
-    val text  = """
-                  |class X {
-                  |  val flag: Boolean
-                  |
-                  |  def f {
-                  |    <caret>do print("")
-                  |    while(flag)
-                  |  }
-                  |}
-                """.stripMargin.replace("\r", "").trim
-    val resultText = """
-                       |class X {
-                       |  val flag: Boolean
-                       |
-                       |  def f {
-                       |    print("")
-                       |    while (flag) print("")
-                       |  }
-                       |}
-                     """.stripMargin.replace("\r", "").trim
+    val text =
+      """
+        |class X {
+        |  val flag: Boolean
+        |
+        |  def f {
+        |    <caret>do print("")
+        |    while(flag)
+        |  }
+        |}
+      """
+    val resultText =
+      """
+        |class X {
+        |  val flag: Boolean
+        |
+        |  def f {
+        |    print("")
+        |    while (flag) print("")
+        |  }
+        |}
+      """
     doTest(text, resultText)
   }
 
   def testReplaceDoWhile7() {
-    val text  = """
-                  |class X {
-                  |  val flag: Boolean
-                  |
-                  |  def f {
-                  |    <caret>do print("") while(flag)
-                  |  }
-                  |}
-                """.stripMargin.replace("\r", "").trim
-    val resultText = """
-                       |class X {
-                       |  val flag: Boolean
-                       |
-                       |  def f {
-                       |    print("")
-                       |    while (flag) print("")
-                       |  }
-                       |}
-                     """.stripMargin.replace("\r", "").trim
+    val text =
+      """
+        |class X {
+        |  val flag: Boolean
+        |
+        |  def f {
+        |    <caret>do print("") while(flag)
+        |  }
+        |}
+      """
+    val resultText =
+      """
+        |class X {
+        |  val flag: Boolean
+        |
+        |  def f {
+        |    print("")
+        |    while (flag) print("")
+        |  }
+        |}
+      """
     doTest(text, resultText)
   }
 
   def testReplaceDoWhile8() {
-    val text  = """
-                  |class X {
-                  |  1 match {
-                  |  case 1 =>
-                  |    <caret>do {
-                  |      print("")
-                  |    } while (true)
-                  |  }
-                  |}
-                """.stripMargin.replace("\r", "").trim
-    val resultText = """
-                       |class X {
-                       |  1 match {
-                       |    case 1 =>
-                       |      print("")
-                       |      while (true) {
-                       |        print("")
-                       |      }
-                       |  }
-                       |}
-                     """.stripMargin.replace("\r", "").trim
+    val text =
+      """
+        |class X {
+        |  1 match {
+        |  case 1 =>
+        |    <caret>do {
+        |      print("")
+        |    } while (true)
+        |  }
+        |}
+      """
+    val resultText =
+      """
+        |class X {
+        |  1 match {
+        |    case 1 =>
+        |      print("")
+        |      while (true) {
+        |        print("")
+        |      }
+        |  }
+        |}
+      """
     doTest(text, resultText)
   }
 
   def testReplaceDoWhile9() {
-    val text  = """
-                  |do println("")
-                  |while (true)
-                """.stripMargin.replace("\r", "").trim
-    val resultText = """
-                       |println("")
-                       |while (true) println("")
-                     """.stripMargin.replace("\r", "").trim
+    val text =
+      """
+        |do println("")
+        |while (true)
+      """
+    val resultText =
+      """
+        |println("")
+        |while (true) println("")
+      """
     doTest(text, resultText)
   }
 

--- a/test/org/jetbrains/plugins/scala/codeInsight/intentions/controlflow/ReplaceWhileWithDoWhileIntentionTest.scala
+++ b/test/org/jetbrains/plugins/scala/codeInsight/intentions/controlflow/ReplaceWhileWithDoWhileIntentionTest.scala
@@ -8,86 +8,92 @@ import org.jetbrains.plugins.scala.codeInsight.intention.controlflow.ReplaceWhil
  * User: Nikolay.Tropin
  * Date: 4/17/13
  */
-class ReplaceWhileWithDoWhileIntentionTest extends ScalaIntentionTestBase{
+class ReplaceWhileWithDoWhileIntentionTest extends ScalaIntentionTestBase {
   def familyName: String = ReplaceWhileWithDoWhileIntention.familyName
 
   def testReplaceWhile() {
-    val text  = """
-                  |class X {
-                  |  val flag: Boolean
-                  |
-                  |  def f {
-                  |    <caret>while(flag) {
-                  |      //looping
-                  |    }
-                  |  }
-                  |}
-                """.stripMargin.replace("\r", "").trim
-    val resultText = """
-                       |class X {
-                       |  val flag: Boolean
-                       |
-                       |  def f {
-                       |    if (flag) {
-                       |      do {
-                       |        //looping
-                       |      } while (flag)
-                       |    }
-                       |  }
-                       |}
-                     """.stripMargin.replace("\r", "").trim
+    val text =
+      """
+        |class X {
+        |  val flag: Boolean
+        |
+        |  def f {
+        |    <caret>while(flag) {
+        |      //looping
+        |    }
+        |  }
+        |}
+      """
+    val resultText =
+      """
+        |class X {
+        |  val flag: Boolean
+        |
+        |  def f {
+        |    if (flag) {
+        |      do {
+        |        //looping
+        |      } while (flag)
+        |    }
+        |  }
+        |}
+      """
     doTest(text, resultText)
   }
 
   def testReplaceWhile2() {
-    val text  = """
-                  |class X {
-                  |  val flag: Boolean
-                  |
-                  |  def f {
-                  |    while<caret>(flag) {
-                  |      //looping
-                  |    }
-                  |  }
-                  |}
-                """.stripMargin.replace("\r", "").trim
-    val resultText = """
-                       |class X {
-                       |  val flag: Boolean
-                       |
-                       |  def f {
-                       |    if (flag) {
-                       |      do {
-                       |        //looping
-                       |      } while (flag)
-                       |    }
-                       |  }
-                       |}
-                     """.stripMargin.replace("\r", "").trim
+    val text =
+      """
+        |class X {
+        |  val flag: Boolean
+        |
+        |  def f {
+        |    while<caret>(flag) {
+        |      //looping
+        |    }
+        |  }
+        |}
+      """
+    val resultText =
+      """
+        |class X {
+        |  val flag: Boolean
+        |
+        |  def f {
+        |    if (flag) {
+        |      do {
+        |        //looping
+        |      } while (flag)
+        |    }
+        |  }
+        |}
+      """
     doTest(text, resultText)
   }
 
   def testReplaceWhile3() {
-    val text  = """
-                  |class X {
-                  |  val flag: Boolean
-                  |
-                  |  def f {
-                  |    while<caret>(flag) print("")
-                  |  }
-                  |}
-                """.stripMargin.replace("\r", "").trim
-    val resultText = """
-                       |class X {
-                       |  val flag: Boolean
-                       |
-                       |  def f {
-                       |    if (flag) {
-                       |      do print("") while (flag)
-                       |    }
-                       |  }
-                       |}
-                     """.stripMargin.replace("\r", "").trim
+    val text =
+      """
+        |class X {
+        |  val flag: Boolean
+        |
+        |  def f {
+        |    while<caret>(flag) print("")
+        |  }
+        |}
+      """
+    val resultText =
+      """
+        |class X {
+        |  val flag: Boolean
+        |
+        |  def f {
+        |    if (flag) {
+        |      do print("") while (flag)
+        |    }
+        |  }
+        |}
+      """
     doTest(text, resultText)
   }
 }

--- a/test/org/jetbrains/plugins/scala/codeInsight/intentions/controlflow/SplitElseIfIntentionTest.scala
+++ b/test/org/jetbrains/plugins/scala/codeInsight/intentions/controlflow/SplitElseIfIntentionTest.scala
@@ -12,125 +12,133 @@ class SplitElseIfIntentionTest extends ScalaIntentionTestBase {
   val familyName = SplitElseIfIntention.familyName
 
   def testSplitElseIf() {
-    val text  = """
-                       |class SplitElseIf {
-                       |  def mthd {
-                       |    val a: Int = 0
-                       |    if (a == 9) {
-                       |      System.out.println("if1")
-                       |    } el<caret>se if (a == 8) {
-                       |      System.out.println("if2")
-                       |    } else {
-                       |      System.out.println("else")
-                       |    }
-                       |  }
-                       |}
-                     """.stripMargin.replace("\r", "").trim
-    val resultText = """
-                       |class SplitElseIf {
-                       |  def mthd {
-                       |    val a: Int = 0
-                       |    if (a == 9) {
-                       |      System.out.println("if1")
-                       |    } el<caret>se {
-                       |      if (a == 8) {
-                       |        System.out.println("if2")
-                       |      } else {
-                       |        System.out.println("else")
-                       |      }
-                       |    }
-                       |  }
-                       |}
-                     """.stripMargin.replace("\r", "").trim
+    val text =
+      """
+        |class SplitElseIf {
+        |  def mthd {
+        |    val a: Int = 0
+        |    if (a == 9) {
+        |      System.out.println("if1")
+        |    } el<caret>se if (a == 8) {
+        |      System.out.println("if2")
+        |    } else {
+        |      System.out.println("else")
+        |    }
+        |  }
+        |}
+      """
+    val resultText =
+      """
+        |class SplitElseIf {
+        |  def mthd {
+        |    val a: Int = 0
+        |    if (a == 9) {
+        |      System.out.println("if1")
+        |    } el<caret>se {
+        |      if (a == 8) {
+        |        System.out.println("if2")
+        |      } else {
+        |        System.out.println("else")
+        |      }
+        |    }
+        |  }
+        |}
+      """
 
     doTest(text, resultText)
   }
 
   def testSplitElseIf2() {
-    val text  = """
-                  |class SplitElseIf {
-                  |  def mthd {
-                  |    val a: Int = 0
-                  |    if (a == 9)
-                  |      System.out.println("if1")
-                  |    el<caret>se if (a == 8)
-                  |      System.out.println("if2")
-                  |    else
-                  |      System.out.println("else")
-                  |  }
-                  |}
-                """.stripMargin.replace("\r", "").trim
-    val resultText = """
-                       |class SplitElseIf {
-                       |  def mthd {
-                       |    val a: Int = 0
-                       |    if (a == 9) System.out.println("if1")
-                       |    el<caret>se {
-                       |      if (a == 8)
-                       |        System.out.println("if2")
-                       |      else
-                       |        System.out.println("else")
-                       |    }
-                       |  }
-                       |}
-                     """.stripMargin.replace("\r", "").trim
+    val text =
+      """
+        |class SplitElseIf {
+        |  def mthd {
+        |    val a: Int = 0
+        |    if (a == 9)
+        |      System.out.println("if1")
+        |    el<caret>se if (a == 8)
+        |      System.out.println("if2")
+        |    else
+        |      System.out.println("else")
+        |  }
+        |}
+      """
+    val resultText =
+      """
+        |class SplitElseIf {
+        |  def mthd {
+        |    val a: Int = 0
+        |    if (a == 9) System.out.println("if1")
+        |    el<caret>se {
+        |      if (a == 8)
+        |        System.out.println("if2")
+        |      else
+        |        System.out.println("else")
+        |    }
+        |  }
+        |}
+      """
 
     doTest(text, resultText)
   }
 
   def testSplitElseIf3() {
-    val text  = """
-                       |class SplitElseIf {
-                       |  def mthd {
-                       |    val a: Int = 0
-                       |    if (a == 9)
-                       |      System.out.println("if1")
-                       |    el<caret>se if (a == 8)
-                       |      System.out.println("if2")
-                       |  }
-                       |}
-                     """.stripMargin.replace("\r", "").trim
-    val resultText = """
-                       |class SplitElseIf {
-                       |  def mthd {
-                       |    val a: Int = 0
-                       |    if (a == 9) System.out.println("if1")
-                       |    el<caret>se {
-                       |      if (a == 8)
-                       |        System.out.println("if2")
-                       |    }
-                       |  }
-                       |}
-                     """.stripMargin.replace("\r", "").trim
+    val text =
+      """
+        |class SplitElseIf {
+        |  def mthd {
+        |    val a: Int = 0
+        |    if (a == 9)
+        |      System.out.println("if1")
+        |    el<caret>se if (a == 8)
+        |      System.out.println("if2")
+        |  }
+        |}
+      """
+    val resultText =
+      """
+        |class SplitElseIf {
+        |  def mthd {
+        |    val a: Int = 0
+        |    if (a == 9) System.out.println("if1")
+        |    el<caret>se {
+        |      if (a == 8)
+        |        System.out.println("if2")
+        |    }
+        |  }
+        |}
+      """
 
     doTest(text, resultText)
   }
 
   def testSplitElseIf4() {
-    val text  = """
-                  |class SplitElseIf {
-                  |  def mthd {
-                  |    val a: Int = 0
-                  |    if (a == 9)
-                  |      System.out.println("if1")
-                  |    el<caret>se
-                  |      if (a == 8)
-                  |        System.out.println("if2")
-                  |  }
-                  |}
-                """.stripMargin.replace("\r", "").trim
-    val resultText = """
-                       |class SplitElseIf {
-                       |  def mthd {
-                       |    val a: Int = 0
-                       |    if (a == 9) System.out.println("if1")
-                       |    el<caret>se {
-                       |      if (a == 8)
-                       |        System.out.println("if2")
-                       |    }
-                       |  }
-                       |}
-                     """.stripMargin.replace("\r", "").trim
+    val text =
+      """
+        |class SplitElseIf {
+        |  def mthd {
+        |    val a: Int = 0
+        |    if (a == 9)
+        |      System.out.println("if1")
+        |    el<caret>se
+        |      if (a == 8)
+        |        System.out.println("if2")
+        |  }
+        |}
+      """
+    val resultText =
+      """
+        |class SplitElseIf {
+        |  def mthd {
+        |    val a: Int = 0
+        |    if (a == 9) System.out.println("if1")
+        |    el<caret>se {
+        |      if (a == 8)
+        |        System.out.println("if2")
+        |    }
+        |  }
+        |}
+      """
 
     doTest(text, resultText)
   }

--- a/test/org/jetbrains/plugins/scala/codeInsight/intentions/controlflow/SplitIfIntentionTest.scala
+++ b/test/org/jetbrains/plugins/scala/codeInsight/intentions/controlflow/SplitIfIntentionTest.scala
@@ -12,214 +12,230 @@ class SplitIfIntentionTest extends ScalaIntentionTestBase {
   val familyName = SplitIfIntention.familyName
 
   def testSplitIf() {
-    val text  = """
-                  |class X {
-                  |  def f(a: Boolean, b: Boolean) {
-                  |    if (a &<caret>& b) return
-                  |  }
-                  |}
-                """.stripMargin.replace("\r", "").trim
-    val resultText = """
-                       |class X {
-                       |  def f(a: Boolean, b: Boolean) {
-                       |    if (<caret>a)
-                       |      if (b) return
-                       |  }
-                       |}
-                     """.stripMargin.replace("\r", "").trim
+    val text =
+      """
+        |class X {
+        |  def f(a: Boolean, b: Boolean) {
+        |    if (a &<caret>& b) return
+        |  }
+        |}
+      """
+    val resultText =
+      """
+        |class X {
+        |  def f(a: Boolean, b: Boolean) {
+        |    if (<caret>a)
+        |      if (b) return
+        |  }
+        |}
+      """
 
     doTest(text, resultText)
   }
 
   def testSplitIf2() {
-    val text  = """
-                  |class X {
-                  |  def f(a: Boolean, b: Boolean) {
-                  |    if (a &<caret>& b) {
-                  |      return
-                  |    } else {
-                  |      System.out.println()
-                  |    }
-                  |  }
-                  |}
-                """.stripMargin.replace("\r", "").trim
-    val resultText = """
-                       |class X {
-                       |  def f(a: Boolean, b: Boolean) {
-                       |    if (<caret>a)
-                       |      if (b) {
-                       |        return
-                       |      } else {
-                       |        System.out.println()
-                       |      }
-                       |    else {
-                       |      System.out.println()
-                       |    }
-                       |  }
-                       |}
-                     """.stripMargin.replace("\r", "").trim
+    val text =
+      """
+        |class X {
+        |  def f(a: Boolean, b: Boolean) {
+        |    if (a &<caret>& b) {
+        |      return
+        |    } else {
+        |      System.out.println()
+        |    }
+        |  }
+        |}
+      """
+    val resultText =
+      """
+        |class X {
+        |  def f(a: Boolean, b: Boolean) {
+        |    if (<caret>a)
+        |      if (b) {
+        |        return
+        |      } else {
+        |        System.out.println()
+        |      }
+        |    else {
+        |      System.out.println()
+        |    }
+        |  }
+        |}
+      """
 
     doTest(text, resultText)
   }
 
   def testSplitIf3() {
-    val text  = """
-                  |class X {
-                  |  def f(a: Boolean, b: Boolean) {
-                  |    if (a &<caret>& b) {
-                  |      return
-                  |    }
-                  |  }
-                  |}
-                """.stripMargin.replace("\r", "").trim
-    val resultText = """
-                       |class X {
-                       |  def f(a: Boolean, b: Boolean) {
-                       |    if (<caret>a)
-                       |      if (b) {
-                       |        return
-                       |      }
-                       |  }
-                       |}
-                     """.stripMargin.replace("\r", "").trim
+    val text =
+      """
+        |class X {
+        |  def f(a: Boolean, b: Boolean) {
+        |    if (a &<caret>& b) {
+        |      return
+        |    }
+        |  }
+        |}
+      """
+    val resultText =
+      """
+        |class X {
+        |  def f(a: Boolean, b: Boolean) {
+        |    if (<caret>a)
+        |      if (b) {
+        |        return
+        |      }
+        |  }
+        |}
+      """
 
     doTest(text, resultText)
   }
 
   def testSplitIf4() {
-    val text  = """
-                  |class X {
-                  |  def f(a: Boolean, b: Boolean) {
-                  |    if (a &<caret>& b)
-                  |      System.out.println("if")
-                  |    else
-                  |      System.out.println("else")
-                  |  }
-                  |}
-                """.stripMargin.replace("\r", "").trim
-    val resultText = """
-                       |class X {
-                       |  def f(a: Boolean, b: Boolean) {
-                       |    if (<caret>a)
-                       |      if (b) System.out.println("if")
-                       |      else System.out.println("else")
-                       |    else System.out.println("else")
-                       |  }
-                       |}
-                     """.stripMargin.replace("\r", "").trim
+    val text =
+      """
+        |class X {
+        |  def f(a: Boolean, b: Boolean) {
+        |    if (a &<caret>& b)
+        |      System.out.println("if")
+        |    else
+        |      System.out.println("else")
+        |  }
+        |}
+      """
+    val resultText =
+      """
+        |class X {
+        |  def f(a: Boolean, b: Boolean) {
+        |    if (<caret>a)
+        |      if (b) System.out.println("if")
+        |      else System.out.println("else")
+        |    else System.out.println("else")
+        |  }
+        |}
+      """
 
     doTest(text, resultText)
   }
 
   def testSplitIf5() {
-    val text  = """
-                  |class X {
-                  |  def f(a: Boolean, b: Boolean) {
-                  |    if (a &<caret>& b) {
-                  |      System.out.println("if")
-                  |    } else
-                  |      System.out.println("else")
-                  |  }
-                  |}
-                """.stripMargin.replace("\r", "").trim
-    val resultText = """
-                       |class X {
-                       |  def f(a: Boolean, b: Boolean) {
-                       |    if (<caret>a)
-                       |      if (b) {
-                       |        System.out.println("if")
-                       |      } else System.out.println("else")
-                       |    else System.out.println("else")
-                       |  }
-                       |}
-                     """.stripMargin.replace("\r", "").trim
+    val text =
+      """
+        |class X {
+        |  def f(a: Boolean, b: Boolean) {
+        |    if (a &<caret>& b) {
+        |      System.out.println("if")
+        |    } else
+        |      System.out.println("else")
+        |  }
+        |}
+      """
+    val resultText =
+      """
+        |class X {
+        |  def f(a: Boolean, b: Boolean) {
+        |    if (<caret>a)
+        |      if (b) {
+        |        System.out.println("if")
+        |      } else System.out.println("else")
+        |    else System.out.println("else")
+        |  }
+        |}
+      """
 
     doTest(text, resultText)
   }
 
   def testSplitIf6() {
-    val text  = """
-                  |class X {
-                  |  def f(a: Boolean, b: Boolean) {
-                  |    if (a &<caret>& b) System.out.println("if")
-                  |    else {
-                  |      System.out.println("else")
-                  |    }
-                  |  }
-                  |}
-                """.stripMargin.replace("\r", "").trim
-    val resultText = """
-                       |class X {
-                       |  def f(a: Boolean, b: Boolean) {
-                       |    if (<caret>a)
-                       |      if (b) System.out.println("if")
-                       |      else {
-                       |        System.out.println("else")
-                       |      }
-                       |    else {
-                       |      System.out.println("else")
-                       |    }
-                       |  }
-                       |}
-                     """.stripMargin.replace("\r", "").trim
+    val text =
+      """
+        |class X {
+        |  def f(a: Boolean, b: Boolean) {
+        |    if (a &<caret>& b) System.out.println("if")
+        |    else {
+        |      System.out.println("else")
+        |    }
+        |  }
+        |}
+      """
+    val resultText =
+      """
+        |class X {
+        |  def f(a: Boolean, b: Boolean) {
+        |    if (<caret>a)
+        |      if (b) System.out.println("if")
+        |      else {
+        |        System.out.println("else")
+        |      }
+        |    else {
+        |      System.out.println("else")
+        |    }
+        |  }
+        |}
+      """
 
     doTest(text, resultText)
   }
 
   def testSplitIf7() {
-    val text  = """
-                  |class X {
-                  |  def f(a: Boolean, b: Boolean) {
-                  |    if ((a || b) &<caret>& b) System.out.println("if")
-                  |    else {
-                  |      System.out.println("else")
-                  |    }
-                  |  }
-                  |}
-                """.stripMargin.replace("\r", "").trim
-    val resultText = """
-                       |class X {
-                       |  def f(a: Boolean, b: Boolean) {
-                       |    if (<caret>a || b)
-                       |      if (b) System.out.println("if")
-                       |      else {
-                       |        System.out.println("else")
-                       |      }
-                       |    else {
-                       |      System.out.println("else")
-                       |    }
-                       |  }
-                       |}
-                     """.stripMargin.replace("\r", "").trim
+    val text =
+      """
+        |class X {
+        |  def f(a: Boolean, b: Boolean) {
+        |    if ((a || b) &<caret>& b) System.out.println("if")
+        |    else {
+        |      System.out.println("else")
+        |    }
+        |  }
+        |}
+      """
+    val resultText =
+      """
+        |class X {
+        |  def f(a: Boolean, b: Boolean) {
+        |    if (<caret>a || b)
+        |      if (b) System.out.println("if")
+        |      else {
+        |        System.out.println("else")
+        |      }
+        |    else {
+        |      System.out.println("else")
+        |    }
+        |  }
+        |}
+      """
 
     doTest(text, resultText)
   }
 
   def testSplitIf8() {
-    val text  = """
-                  |class X {
-                  |  def f(a: Boolean, b: Boolean) {
-                  |    if ((a || b) &<caret>& (b && a)) System.out.println("if")
-                  |    else {
-                  |      System.out.println("else")
-                  |    }
-                  |  }
-                  |}
-                """.stripMargin.replace("\r", "").trim
-    val resultText = """
-                       |class X {
-                       |  def f(a: Boolean, b: Boolean) {
-                       |    if (<caret>a || b)
-                       |      if (b && a) System.out.println("if")
-                       |      else {
-                       |        System.out.println("else")
-                       |      }
-                       |    else {
-                       |      System.out.println("else")
-                       |    }
-                       |  }
-                       |}
-                     """.stripMargin.replace("\r", "").trim
+    val text =
+      """
+        |class X {
+        |  def f(a: Boolean, b: Boolean) {
+        |    if ((a || b) &<caret>& (b && a)) System.out.println("if")
+        |    else {
+        |      System.out.println("else")
+        |    }
+        |  }
+        |}
+      """
+    val resultText =
+      """
+        |class X {
+        |  def f(a: Boolean, b: Boolean) {
+        |    if (<caret>a || b)
+        |      if (b && a) System.out.println("if")
+        |      else {
+        |        System.out.println("else")
+        |      }
+        |    else {
+        |      System.out.println("else")
+        |    }
+        |  }
+        |}
+      """
 
     doTest(text, resultText)
   }

--- a/test/org/jetbrains/plugins/scala/codeInsight/intentions/expression/IntroduceExplicitParameterIntentionTest.scala
+++ b/test/org/jetbrains/plugins/scala/codeInsight/intentions/expression/IntroduceExplicitParameterIntentionTest.scala
@@ -38,12 +38,12 @@ class IntroduceExplicitParameterIntentionTest extends ScalaIntentionTestBase{
       """
         |val name: String = "gfgfgfgfg"
         |val nameHasUpperCase = name.exists(<caret>_.isUpper)
-      """.stripMargin.replace("\r", "").trim
+      """
     val resultText =
       """
         |val name: String = "gfgfgfgfg"
         |val nameHasUpperCase = name.exists(c => c.isUpper)
-      """.stripMargin.replace("\r", "").trim
+      """
 
     doTest(text, resultText)
   }

--- a/test/org/jetbrains/plugins/scala/codeInsight/intentions/expression/IntroduceImplicitParameterIntentionTest.scala
+++ b/test/org/jetbrains/plugins/scala/codeInsight/intentions/expression/IntroduceImplicitParameterIntentionTest.scala
@@ -63,7 +63,7 @@ class IntroduceImplicitParameterIntentionTest  extends ScalaIntentionTestBase{
     |     }
     |   }
     | }
-    """.stripMargin.replace("\r", "").trim
+    """
     val resultText= """
     | val x: Int => Int = i => {
     |   i + {
@@ -72,7 +72,7 @@ class IntroduceImplicitParameterIntentionTest  extends ScalaIntentionTestBase{
     |     }
     |   }
     | }
-    """.stripMargin.replace("\r", "").trim
+    """
 
     try {
       doTest(text, resultText)
@@ -117,14 +117,14 @@ class IntroduceImplicitParameterIntentionTest  extends ScalaIntentionTestBase{
     |    1
     |  }
     |}
-    """.stripMargin.replace("\r", "").trim
+    """
     val resultText = """
     |val x: Int => Int = <caret>{
     |  _ + {
     |    1
     |  }
     |}
-    """.stripMargin.replace("\r", "").trim
+    """
 
     doTest(text, resultText)
   }

--- a/test/org/jetbrains/plugins/scala/codeInsight/intentions/expression/RemoveApplyIntentionTest.scala
+++ b/test/org/jetbrains/plugins/scala/codeInsight/intentions/expression/RemoveApplyIntentionTest.scala
@@ -27,39 +27,43 @@ class RemoveApplyIntentionTest extends ScalaIntentionTestBase {
   }
 
   def testRemoveApply3() {
-    val text = """
-                 |object D {
-                 |  def foo() = B
-                 |
-                 |  foo.ap<caret>ply(1)
-                 |}
-               """.stripMargin.replace("\r", "").trim
-    val resultText = """
-                       |object D {
-                       |  def foo() = B
-                       |
-                       |  foo()<caret>(1)
-                       |}
-                     """.stripMargin.replace("\r", "").trim
+    val text =
+      """
+        |object D {
+        |  def foo() = B
+        |
+        |  foo.ap<caret>ply(1)
+        |}
+      """
+    val resultText =
+      """
+        |object D {
+        |  def foo() = B
+        |
+        |  foo()<caret>(1)
+        |}
+      """
 
     doTest(text, resultText)
   }
 
   def testRemoveApply4() {
-    val text = """
-                 |object D {
-                 |  def foo() = B
-                 |
-                 |  foo().ap<caret>ply(1)
-                 |}
-               """.stripMargin.replace("\r", "").trim
-    val resultText = """
-                       |object D {
-                       |  def foo() = B
-                       |
-                       |  foo()<caret>(1)
-                       |}
-                     """.stripMargin.replace("\r", "").trim
+    val text =
+      """
+        |object D {
+        |  def foo() = B
+        |
+        |  foo().ap<caret>ply(1)
+        |}
+      """
+    val resultText =
+      """
+        |object D {
+        |  def foo() = B
+        |
+        |  foo()<caret>(1)
+        |}
+      """
 
     doTest(text, resultText)
   }
@@ -72,20 +76,22 @@ class RemoveApplyIntentionTest extends ScalaIntentionTestBase {
   }
 
   def testRemoveApply6() {
-    val text = """
-                 |object D {
-                 |  def foo()(implicit x: String) = B
-                 |  implicit val s: String = ""
-                 |  foo().<caret>apply(1)
-                 |}
-               """.stripMargin.replace("\r", "").trim
-    val resultText = """
-                       |object D {
-                       |  def foo()(implicit x: String) = B
-                       |  implicit val s: String = ""
-                       |  foo().<caret>apply(1)
-                       |}
-                     """.stripMargin.replace("\r", "").trim
+    val text =
+      """
+        |object D {
+        |  def foo()(implicit x: String) = B
+        |  implicit val s: String = ""
+        |  foo().<caret>apply(1)
+        |}
+      """
+    val resultText =
+      """
+        |object D {
+        |  def foo()(implicit x: String) = B
+        |  implicit val s: String = ""
+        |  foo().<caret>apply(1)
+        |}
+      """
 
     try {
       doTest(text, resultText)
@@ -95,30 +101,32 @@ class RemoveApplyIntentionTest extends ScalaIntentionTestBase {
   }
 
   def testRemoveApply7() {
-    val text = """
-                 |object P {
-                 |  class AAAA()(implicit s: String) extends (Int => Int) {
-                 |    def this(x: Int) {
-                 |      this()
-                 |    }
-                 |    def apply(v1: Int) = v1 + 1
-                 |  }
-                 |  implicit val s: String = "text"
-                 |  (new AAAA()).ap<caret>ply(1)
-                 |}
-               """.stripMargin.replace("\r", "").trim
-    val resultText = """
-                       |object P {
-                       |  class AAAA()(implicit s: String) extends (Int => Int) {
-                       |    def this(x: Int) {
-                       |      this()
-                       |    }
-                       |    def apply(v1: Int) = v1 + 1
-                       |  }
-                       |  implicit val s: String = "text"
-                       |  (new AAAA()).ap<caret>ply(1)
-                       |}
-                     """.stripMargin.replace("\r", "").trim
+    val text =
+      """
+        |object P {
+        |  class AAAA()(implicit s: String) extends (Int => Int) {
+        |    def this(x: Int) {
+        |      this()
+        |    }
+        |    def apply(v1: Int) = v1 + 1
+        |  }
+        |  implicit val s: String = "text"
+        |  (new AAAA()).ap<caret>ply(1)
+        |}
+      """
+    val resultText =
+      """
+        |object P {
+        |  class AAAA()(implicit s: String) extends (Int => Int) {
+        |    def this(x: Int) {
+        |      this()
+        |    }
+        |    def apply(v1: Int) = v1 + 1
+        |  }
+        |  implicit val s: String = "text"
+        |  (new AAAA()).ap<caret>ply(1)
+        |}
+      """
 
     try {
       doTest(text, resultText)
@@ -128,20 +136,22 @@ class RemoveApplyIntentionTest extends ScalaIntentionTestBase {
   }
 
   def testRemoveApply8() {
-    val text = """
-                 |object A {
-                 |  def foo = B
-                 |  def foo(x: Int) = B
-                 |  foo.a<caret>pply(1)
-                 |}
-               """.stripMargin.replace("\r", "").trim
-    val resultText = """
-                       |object A {
-                       |  def foo = B
-                       |  def foo(x: Int) = B
-                       |  foo.a<apply>pply(1)
-                       |}
-                     """.stripMargin.replace("\r", "").trim
+    val text =
+      """
+        |object A {
+        |  def foo = B
+        |  def foo(x: Int) = B
+        |  foo.a<caret>pply(1)
+        |}
+      """
+    val resultText =
+      """
+        |object A {
+        |  def foo = B
+        |  def foo(x: Int) = B
+        |  foo.a<apply>pply(1)
+        |}
+      """
 
     try {
       doTest(text, resultText)

--- a/test/org/jetbrains/plugins/scala/codeInsight/intentions/expression/RemoveUnnecessaryParenthesesIntentionTest.scala
+++ b/test/org/jetbrains/plugins/scala/codeInsight/intentions/expression/RemoveUnnecessaryParenthesesIntentionTest.scala
@@ -24,50 +24,56 @@ class RemoveUnnecessaryParenthesesIntentionTest extends ScalaIntentionTestBase {
   }
 
   def test_3() {
-    val text  = """
-                  |def f(n: Int): Int = n match {
-                  |  case even if (<caret>even % 2 == 0) => (even + 1)
-                  |  case odd =>  1 + (odd * 3)
-                  |}
-                """.stripMargin.replace("\r", "").trim
-    val result = """
-                   |def f(n: Int): Int = n match {
-                   |  case even if even % 2 == 0 => (even + 1)
-                   |  case odd => 1 + (odd * 3)
-                   |}
-                 """.stripMargin.replace("\r", "").trim
+    val text =
+      """
+        |def f(n: Int): Int = n match {
+        |  case even if (<caret>even % 2 == 0) => (even + 1)
+        |  case odd =>  1 + (odd * 3)
+        |}
+      """
+    val result =
+      """
+        |def f(n: Int): Int = n match {
+        |  case even if even % 2 == 0 => (even + 1)
+        |  case odd => 1 + (odd * 3)
+        |}
+      """
     doTest(text, result)
   }
 
   def test_4() {
-    val text  = """
-                  |def f(n: Int): Int = n match {
-                  |  case even if (even % 2 == 0) => (even + 1<caret>)
-                  |  case odd => 1 + (odd * 3)
-                  |}
-                """.stripMargin.replace("\r", "").trim
-    val result = """
-                   |def f(n: Int): Int = n match {
-                   |  case even if (even % 2 == 0) => even + 1
-                   |  case odd => 1 + (odd * 3)
-                   |}
-                 """.stripMargin.replace("\r", "").trim
+    val text =
+      """
+        |def f(n: Int): Int = n match {
+        |  case even if (even % 2 == 0) => (even + 1<caret>)
+        |  case odd => 1 + (odd * 3)
+        |}
+      """
+    val result =
+      """
+        |def f(n: Int): Int = n match {
+        |  case even if (even % 2 == 0) => even + 1
+        |  case odd => 1 + (odd * 3)
+        |}
+      """
     doTest(text, result)
   }
 
   def test_5() {
-    val text  = """
-                  |def f(n: Int): Int = n match {
-                  |  case even if (even % 2 == 0) => (even + 1)
-                  |  case odd =>  1 + (odd * 3<caret>)
-                  |}
-                """.stripMargin.replace("\r", "").trim
-    val result = """
-                   |def f(n: Int): Int = n match {
-                   |  case even if (even % 2 == 0) => (even + 1)
-                   |  case odd => 1 + odd * 3
-                   |}
-                 """.stripMargin.replace("\r", "").trim
+    val text =
+      """
+        |def f(n: Int): Int = n match {
+        |  case even if (even % 2 == 0) => (even + 1)
+        |  case odd =>  1 + (odd * 3<caret>)
+        |}
+      """
+    val result =
+      """
+        |def f(n: Int): Int = n match {
+        |  case even if (even % 2 == 0) => (even + 1)
+        |  case odd => 1 + odd * 3
+        |}
+      """
     doTest(text, result)
   }
 

--- a/test/org/jetbrains/plugins/scala/codeInsight/intentions/expression/ReplaceTypeCheckWithMatchIntentionTest.scala
+++ b/test/org/jetbrains/plugins/scala/codeInsight/intentions/expression/ReplaceTypeCheckWithMatchIntentionTest.scala
@@ -3,234 +3,256 @@ package codeInsight.intentions.expression
 
 import org.jetbrains.plugins.scala.codeInsight.intentions.ScalaIntentionTestBase
 import org.jetbrains.plugins.scala.codeInsight.intention.expression.ReplaceTypeCheckWithMatchIntention
-import org.jetbrains.plugins.scala.codeInspection.typeChecking.TypeCheckCanBeMatchInspection
 
 /**
  * Nikolay.Tropin
  * 5/16/13
  */
-class ReplaceTypeCheckWithMatchIntentionTest  extends ScalaIntentionTestBase{
+class ReplaceTypeCheckWithMatchIntentionTest extends ScalaIntentionTestBase {
   def familyName: String = ReplaceTypeCheckWithMatchIntention.familyName
+
   def test_1() {
-    val text = """val x = 0
-                 |if (<caret>x.isInstanceOf[Int]) {
-                 |  x.toString
-                 |}""".stripMargin.replace("\r", "").trim
-    val result = """val x = 0
-                   |x match {
-                   |  case _: Int =>
-                   |    x.toString
-                   |  case _ =>
-                   |}""".stripMargin.replace("\r", "").trim
+    val text =
+      """val x = 0
+        |if (<caret>x.isInstanceOf[Int]) {
+        |  x.toString
+        |}"""
+    val result =
+      """val x = 0
+        |x match {
+        |  case _: Int =>
+        |    x.toString
+        |  case _ =>
+        |}"""
     doTest(text, result)
   }
 
   def test_2() {
-    val text = """val x = 0
-                 |if (x.isInstanc<caret>eOf[Int]) {
-                 |  x.asInstanceOf[Int].toString
-                 |  println(x.asInstanceOf[Int])
-                 |}""".stripMargin.replace("\r", "").trim
-    val result = """val x = 0
-                   |x match {
-                   |  case i: Int =>
-                   |    i.toString
-                   |    println(i)
-                   |  case _ =>
-                   |}""".stripMargin.replace("\r", "").trim
+    val text =
+      """val x = 0
+        |if (x.isInstanc<caret>eOf[Int]) {
+        |  x.asInstanceOf[Int].toString
+        |  println(x.asInstanceOf[Int])
+        |}"""
+    val result =
+      """val x = 0
+        |x match {
+        |  case i: Int =>
+        |    i.toString
+        |    println(i)
+        |  case _ =>
+        |}"""
     doTest(text, result)
   }
 
   def test_3() {
-    val text = """val x = 0
-                 |if (x.isInstanc<caret>eOf[Int]) {
-                 |  val y = x.asInstanceOf[Int]
-                 |  x.asInstanceOf[Int].toString
-                 |  println(y)
-                 |}""".stripMargin.replace("\r", "").trim
-    val result = """val x = 0
-                   |x match {
-                   |  case y: Int =>
-                   |    y.toString
-                   |    println(y)
-                   |  case _ =>
-                   |}""".stripMargin.replace("\r", "").trim
+    val text =
+      """val x = 0
+        |if (x.isInstanc<caret>eOf[Int]) {
+        |  val y = x.asInstanceOf[Int]
+        |  x.asInstanceOf[Int].toString
+        |  println(y)
+        |}"""
+    val result =
+      """val x = 0
+        |x match {
+        |  case y: Int =>
+        |    y.toString
+        |    println(y)
+        |  case _ =>
+        |}"""
     doTest(text, result)
   }
 
   def test_4() {
-    val text = """val x = 0
-                 |if (<caret>x.isInstanceOf[Int] && x.asInstanceOf[Int] == 1) {
-                 |  val y = x.asInstanceOf[Int]
-                 |  println(y)
-                 |}""".stripMargin.replace("\r", "").trim
-    val result = """val x = 0
-                   |x match {
-                   |  case y: Int if y == 1 =>
-                   |    println(y)
-                   |  case _ =>
-                   |}""".stripMargin.replace("\r", "").trim
+    val text =
+      """val x = 0
+        |if (<caret>x.isInstanceOf[Int] && x.asInstanceOf[Int] == 1) {
+        |  val y = x.asInstanceOf[Int]
+        |  println(y)
+        |}"""
+    val result =
+      """val x = 0
+        |x match {
+        |  case y: Int if y == 1 =>
+        |    println(y)
+        |  case _ =>
+        |}"""
     doTest(text, result)
   }
 
   def test_5() {
-    val text = """val x = 0
-                 |if (x > 0 && (<caret>x.isInstanceOf[Int] && x.asInstanceOf[Int] == 1)) {
-                 |  val y = x.asInstanceOf[Int]
-                 |  println(y)
-                 |}""".stripMargin.replace("\r", "").trim
-    val result = """val x = 0
-                   |x match {
-                   |  case y: Int if x > 0 && y == 1 =>
-                   |    println(y)
-                   |  case _ =>
-                   |}""".stripMargin.replace("\r", "").trim
+    val text =
+      """val x = 0
+        |if (x > 0 && (<caret>x.isInstanceOf[Int] && x.asInstanceOf[Int] == 1)) {
+        |  val y = x.asInstanceOf[Int]
+        |  println(y)
+        |}"""
+    val result =
+      """val x = 0
+        |x match {
+        |  case y: Int if x > 0 && y == 1 =>
+        |    println(y)
+        |  case _ =>
+        |}"""
     doTest(text, result)
   }
 
   def test_6() {
-    val text = """val x = 0
-                 |if (<caret>x.isInstanceOf[Int]) {
-                 |  val y = x.asInstanceOf[Int]
-                 |  println(y)
-                 |} else if (x.isInstanceOf[Long]) {
-                 |  println(x)
-                 |} else println()""".stripMargin.replace("\r", "").trim
-    val result = """val x = 0
-                   |x match {
-                   |  case y: Int =>
-                   |    println(y)
-                   |  case _: Long =>
-                   |    println(x)
-                   |  case _ => println()
-                   |}""".stripMargin.replace("\r", "").trim
+    val text =
+      """val x = 0
+        |if (<caret>x.isInstanceOf[Int]) {
+        |  val y = x.asInstanceOf[Int]
+        |  println(y)
+        |} else if (x.isInstanceOf[Long]) {
+        |  println(x)
+        |} else println()"""
+    val result =
+      """val x = 0
+        |x match {
+        |  case y: Int =>
+        |    println(y)
+        |  case _: Long =>
+        |    println(x)
+        |  case _ => println()
+        |}"""
     doTest(text, result)
   }
 
   def test_7() {
-    val text = """val x = 0
-                 |if (<caret>x.isInstanceOf[Int] && x.asInstanceOf[Long] == 1) {
-                 |  val y = x.asInstanceOf[Int]
-                 |  println(y)
-                 |} else if (x.isInstanceOf[Long]) {
-                 |  val y = x.asInstanceOf[Int]
-                 |  println(y)
-                 |} else {
-                 |  println(x)
-                 |  println()
-                 |}""".stripMargin.replace("\r", "").trim
-    val result = """val x = 0
-                   |x match {
-                   |  case y: Int if x.asInstanceOf[Long] == 1 =>
-                   |    println(y)
-                   |  case _: Long =>
-                   |    val y = x.asInstanceOf[Int]
-                   |    println(y)
-                   |  case _ =>
-                   |    println(x)
-                   |    println()
-                   |}""".stripMargin.replace("\r", "").trim
+    val text =
+      """val x = 0
+        |if (<caret>x.isInstanceOf[Int] && x.asInstanceOf[Long] == 1) {
+        |  val y = x.asInstanceOf[Int]
+        |  println(y)
+        |} else if (x.isInstanceOf[Long]) {
+        |  val y = x.asInstanceOf[Int]
+        |  println(y)
+        |} else {
+        |  println(x)
+        |  println()
+        |}"""
+    val result =
+      """val x = 0
+        |x match {
+        |  case y: Int if x.asInstanceOf[Long] == 1 =>
+        |    println(y)
+        |  case _: Long =>
+        |    val y = x.asInstanceOf[Int]
+        |    println(y)
+        |  case _ =>
+        |    println(x)
+        |    println()
+        |}"""
     doTest(text, result)
   }
 
   def test_8a() {
-    val text = """val x1 = 0
-                 |val x2 = 0
-                 |if (x<caret>1.isInstanceOf[Int] && x2.isInstanceOf[Int]) {
-                 |  val y1 = x1.asInstanceOf[Int]
-                 |  val y2 = x2.asInstanceOf[Int]
-                 |  println(y1 + y2)
-                 |} else if (x1.isInstanceOf[Long] && x2.isInstanceOf[Long]) {
-                 |  val y1 = x1.asInstanceOf[Int]
-                 |  val y2 = x2.asInstanceOf[Int]
-                 |  println(y1 + y2)
-                 |}""".stripMargin.replace("\r", "").trim
-    val result = """val x1 = 0
-                   |val x2 = 0
-                   |x1 match {
-                   |  case y1: Int if x2.isInstanceOf[Int] =>
-                   |    val y2 = x2.asInstanceOf[Int]
-                   |    println(y1 + y2)
-                   |  case _: Long if x2.isInstanceOf[Long] =>
-                   |    val y1 = x1.asInstanceOf[Int]
-                   |    val y2 = x2.asInstanceOf[Int]
-                   |    println(y1 + y2)
-                   |  case _ =>
-                   |}""".stripMargin.replace("\r", "").trim
+    val text =
+      """val x1 = 0
+        |val x2 = 0
+        |if (x<caret>1.isInstanceOf[Int] && x2.isInstanceOf[Int]) {
+        |  val y1 = x1.asInstanceOf[Int]
+        |  val y2 = x2.asInstanceOf[Int]
+        |  println(y1 + y2)
+        |} else if (x1.isInstanceOf[Long] && x2.isInstanceOf[Long]) {
+        |  val y1 = x1.asInstanceOf[Int]
+        |  val y2 = x2.asInstanceOf[Int]
+        |  println(y1 + y2)
+        |}"""
+    val result =
+      """val x1 = 0
+        |val x2 = 0
+        |x1 match {
+        |  case y1: Int if x2.isInstanceOf[Int] =>
+        |    val y2 = x2.asInstanceOf[Int]
+        |    println(y1 + y2)
+        |  case _: Long if x2.isInstanceOf[Long] =>
+        |    val y1 = x1.asInstanceOf[Int]
+        |    val y2 = x2.asInstanceOf[Int]
+        |    println(y1 + y2)
+        |  case _ =>
+        |}"""
     doTest(text, result)
   }
 
   def test_8b() {
-    val text = s"""val x1 = 0
-                 |val x2 = 0
-                 |if (x1.isInstanceOf[Int] && <caret>x2.isInstanceOf[Int]) {
-                 |  val y1 = x1.asInstanceOf[Int]
-                 |  val y2 = x2.asInstanceOf[Int]
-                 |  println(y1 + y2)
-                 |} else if (x1.isInstanceOf[Long] && x2.isInstanceOf[Long]) {
-                 |  val y1 = x1.asInstanceOf[Int]
-                 |  val y2 = x2.asInstanceOf[Int]
-                 |  println(y1 + y2)
-                 |}""".stripMargin.replace("\r", "").trim
-    val result = """val x1 = 0
-                   |val x2 = 0
-                   |x2 match {
-                   |  case y2: Int if x1.isInstanceOf[Int] =>
-                   |    val y1 = x1.asInstanceOf[Int]
-                   |    println(y1 + y2)
-                   |  case _: Long if x1.isInstanceOf[Long] =>
-                   |    val y1 = x1.asInstanceOf[Int]
-                   |    val y2 = x2.asInstanceOf[Int]
-                   |    println(y1 + y2)
-                   |  case _ =>
-                   |} """.stripMargin.replace("\r", "").trim
+    val text =
+      """val x1 = 0
+        |val x2 = 0
+        |if (x1.isInstanceOf[Int] && <caret>x2.isInstanceOf[Int]) {
+        |  val y1 = x1.asInstanceOf[Int]
+        |  val y2 = x2.asInstanceOf[Int]
+        |  println(y1 + y2)
+        |} else if (x1.isInstanceOf[Long] && x2.isInstanceOf[Long]) {
+        |  val y1 = x1.asInstanceOf[Int]
+        |  val y2 = x2.asInstanceOf[Int]
+        |  println(y1 + y2)
+        |}"""
+    val result =
+      """val x1 = 0
+        |val x2 = 0
+        |x2 match {
+        |  case y2: Int if x1.isInstanceOf[Int] =>
+        |    val y1 = x1.asInstanceOf[Int]
+        |    println(y1 + y2)
+        |  case _: Long if x1.isInstanceOf[Long] =>
+        |    val y1 = x1.asInstanceOf[Int]
+        |    val y2 = x2.asInstanceOf[Int]
+        |    println(y1 + y2)
+        |  case _ =>
+        |} """
     doTest(text, result)
   }
 
   def test_8c() {
-    val text = s"""val x1 = 0
-                 |val x2 = 0
-                 |if (x1.isInstanceOf[Int] && x2.isInstanceOf[Int]) {
-                 |  val y1 = x1.asInstanceOf[Int]
-                 |  val y2 = x2.asInstanceOf[Int]
-                 |  println(y1 + y2)
-                 |} else if (<caret>x1.isInstanceOf[Long] && x2.isInstanceOf[Long]) {
-                 |  val y1 = x1.asInstanceOf[Int]
-                 |  val y2 = x2.asInstanceOf[Int]
-                 |  println(y1 + y2)
-                 |}""".stripMargin.replace("\r", "").trim
-    val result = """val x1 = 0
-                   |val x2 = 0
-                   |if (x1.isInstanceOf[Int] && x2.isInstanceOf[Int]) {
-                   |  val y1 = x1.asInstanceOf[Int]
-                   |  val y2 = x2.asInstanceOf[Int]
-                   |  println(y1 + y2)
-                   |} else x1 match {
-                   |  case _: Long if x2.isInstanceOf[Long] =>
-                   |    val y1 = x1.asInstanceOf[Int]
-                   |    val y2 = x2.asInstanceOf[Int]
-                   |    println(y1 + y2)
-                   |  case _ =>
-                   |}
-                   |""".stripMargin.replace("\r", "").trim
+    val text =
+      """val x1 = 0
+        |val x2 = 0
+        |if (x1.isInstanceOf[Int] && x2.isInstanceOf[Int]) {
+        |  val y1 = x1.asInstanceOf[Int]
+        |  val y2 = x2.asInstanceOf[Int]
+        |  println(y1 + y2)
+        |} else if (<caret>x1.isInstanceOf[Long] && x2.isInstanceOf[Long]) {
+        |  val y1 = x1.asInstanceOf[Int]
+        |  val y2 = x2.asInstanceOf[Int]
+        |  println(y1 + y2)
+        |}"""
+    val result =
+      """val x1 = 0
+        |val x2 = 0
+        |if (x1.isInstanceOf[Int] && x2.isInstanceOf[Int]) {
+        |  val y1 = x1.asInstanceOf[Int]
+        |  val y2 = x2.asInstanceOf[Int]
+        |  println(y1 + y2)
+        |} else x1 match {
+        |  case _: Long if x2.isInstanceOf[Long] =>
+        |    val y1 = x1.asInstanceOf[Int]
+        |    val y2 = x2.asInstanceOf[Int]
+        |    println(y1 + y2)
+        |  case _ =>
+        |}
+        | """
     doTest(text, result)
   }
 
   def test_9() {
-    val text = """val x = 0
-                 |val i = 0
-                 |if (x.isInstanc<caret>eOf[Int]) {
-                 |  x.asInstanceOf[Int].toString
-                 |  println(x.asInstanceOf[Int])
-                 |}""".stripMargin.replace("\r", "").trim
-    val result = """val x = 0
-                   |val i = 0
-                   |x match {
-                   |  case i1: Int =>
-                   |    i1.toString
-                   |    println(i1)
-                   |  case _ =>
-                   |}""".stripMargin.replace("\r", "").trim
+    val text =
+      """val x = 0
+        |val i = 0
+        |if (x.isInstanc<caret>eOf[Int]) {
+        |  x.asInstanceOf[Int].toString
+        |  println(x.asInstanceOf[Int])
+        |}"""
+    val result =
+      """val x = 0
+        |val i = 0
+        |x match {
+        |  case i1: Int =>
+        |    i1.toString
+        |    println(i1)
+        |  case _ =>
+        |}"""
     doTest(text, result)
   }
 


### PR DESCRIPTION
my previous commit made it unnecessary to add `.stripMargin.replace("\r", "").trim` to every code snippet in intention tests
this commit is basically a cleanup
