### PR TITLE
Upgraded to support latest scala; also fixed all DL links

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -243,6 +243,7 @@
     <inspection_tool class="VoidMethodAnnotatedWithGET" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="W3CssValidation" enabled="false" level="WARNING" enabled_by_default="false">
       <option name="myCssVersion" value="css3" />
+      <option name="myIgnoreVendorSpecificProperties" value="false" />
     </inspection_tool>
     <inspection_tool class="WSReferenceInspection" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="XmlDuplicatedId" enabled="false" level="WARNING" enabled_by_default="false" />

--- a/.idea/libraries/specs2.xml
+++ b/.idea/libraries/specs2.xml
@@ -1,13 +1,13 @@
 <component name="libraryTable">
   <library name="specs2">
     <CLASSES>
-        <root url="jar://$PROJECT_DIR$/SDK/runners-lib/specs2_2.9.2-1.12.2-SNAPSHOT.jar!/" />
-        <root url="jar://$PROJECT_DIR$/SDK/runners-lib/specs2-scalaz-core_2.9.2-6.0.1.jar!/" />
+      <root url="jar://$PROJECT_DIR$/SDK/runners-lib/specs2_2.9.2-1.12.2-SNAPSHOT.jar!/" />
+      <root url="jar://$PROJECT_DIR$/SDK/runners-lib/specs2-scalaz-core_2.9.2-6.0.1.jar!/" />
     </CLASSES>
     <JAVADOC />
     <SOURCES>
-        <root url="jar://$PROJECT_DIR$/SDK/sources/specs2-scalaz-core_2.9.2-6.0.1-sources.jar!/" />
-        <root url="jar://$PROJECT_DIR$/SDK/sources/specs2_2.9.2-1.12.2-SNAPSHOT-sources.jar!/" />
+      <root url="jar://$PROJECT_DIR$/SDK/sources/specs2-scalaz-core_2.9.2-6.0.1-sources.jar!/" />
+      <root url="jar://$PROJECT_DIR$/SDK/sources/specs2_2.9.2-1.12.2-SNAPSHOT-sources.jar!/" />
     </SOURCES>
   </library>
 </component>

--- a/src/org/jetbrains/plugins/scala/config/ScalaVersionUtil.scala
+++ b/src/org/jetbrains/plugins/scala/config/ScalaVersionUtil.scala
@@ -13,6 +13,7 @@ object ScalaVersionUtil {
   val SCALA_2_8 = "2.8"
   val SCALA_2_9 = "2.9"
   val SCALA_2_10 = "2.10"
+  val SCALA_2_11 = "2.11"
 
   def isGeneric(element: PsiElement, defaultValue: Boolean, versionText: String*): Boolean = {
     val module: Module = ModuleUtilCore.findModuleForPsiElement(element)

--- a/src/org/jetbrains/plugins/scala/config/scalaProjectTemplate/scalaDownloader/scalaDownloadable.xml
+++ b/src/org/jetbrains/plugins/scala/config/scalaProjectTemplate/scalaDownloader/scalaDownloadable.xml
@@ -1,14 +1,20 @@
 <artifacts>
     <artifact name="Scala_2_9_Win" version="2.9.2">
-        <item name="scala-2.9.2.zip" url="http://www.scala-lang.org/downloads/distrib/files/scala-2.9.2.zip"/>
+        <item name="scala-2.9.2.zip" url="http://www.scala-lang.org/files/archive/scala-2.9.2.zip"/>
     </artifact>
     <artifact name="Scala_2_9" version="2.9.2">
-        <item name="scala-2.9.2.tgz" url="http://www.scala-lang.org/downloads/distrib/files/scala-2.9.2.tgz"/>
+        <item name="scala-2.9.2.tgz" url="http://www.scala-lang.org/files/archive/scala-2.9.2.tgz"/>
     </artifact>
     <artifact name="Scala_2_10_Win" version="2.10.0-RC2">
-        <item name="scala-2.10.0-RC.zip" url="http://www.scala-lang.org/downloads/distrib/files/scala-2.10.0-RC2.zip"/>
+        <item name="scala-2.10.2-RC2.zip" url="http://www.scala-lang.org/files/archive/scala-2.10.2-RC2.zip"/>
     </artifact>
-    <artifact name="Scala_2_10" version="2.10.0-RC2">
-        <item name="scala-2.10.0-RC.tgz" url="http://www.scala-lang.org/downloads/distrib/files/scala-2.10.0-RC2.tgz"/>
+    <artifact name="Scala_2_10" version="2.10.2-RC2">
+        <item name="2.10.2-RC2.tgz" url="http://www.scala-lang.org/files/archive/scala-2.10.2-RC2.tgz"/>
+    </artifact>
+    <artifact name="Scala_2_11_Win" version="2.11.0-M4">
+        <item name="scala-2.11.0-M4.zip" url="http://www.scala-lang.org/files/archive/scala-2.11.0-M4.zip"/>
+    </artifact>
+    <artifact name="Scala_2_11" version="2.11.0-M4">
+        <item name="scala-2.11.0-M4.tgz" url="http://www.scala-lang.org/files/archive/scala-2.11.0-M4.tgz"/>
     </artifact>
 </artifacts>

--- a/src/org/jetbrains/plugins/scala/config/ui/ScalaSupportUiBase.java
+++ b/src/org/jetbrains/plugins/scala/config/ui/ScalaSupportUiBase.java
@@ -138,9 +138,9 @@ public class ScalaSupportUiBase {
 
     String version = distribution.version();
 
-    boolean versionOkay = version.startsWith("2.8") || version.startsWith("2.9") || version.startsWith("2.10");
+    boolean versionOkay = version.startsWith("2.8") || version.startsWith("2.9") || version.startsWith("2.10") || version.startsWith("2.11");
     if(!versionOkay) {
-      stateLabel.setText("(version " + version + ", 2.8-2.10 required)");
+      stateLabel.setText("(version " + version + ", 2.8-2.11 required)");
       stateLabel.setIcon(Icons.WARNING);
       return;
     }


### PR DESCRIPTION
Current auto DL option doesn't work due to changed endpoints on scala-lang.org. Also, neither version currently supported is latest. Now added support for latest.
