### PR TITLE
SCL-4336 fix in-place rename of back-ticked references

### DIFF
--- a/src/org/jetbrains/plugins/scala/lang/psi/api/base/ScReferenceElement.scala
+++ b/src/org/jetbrains/plugins/scala/lang/psi/api/base/ScReferenceElement.scala
@@ -32,17 +32,28 @@ trait ScReferenceElement extends ScalaPsiElement with ResolvableReferenceElement
   def nameId: PsiElement
 
   def refName: String = {
+    val text: String = nameId.getText
+    if (isBackQuoted) text.substring(1, text.length - 1)
+    else text
+  }
+
+  private def isBackQuoted = {
     val id: PsiElement = nameId
     assert(id != null, s"nameId is null for reference with text: $getText")
     val text: String = id.getText
-    if (text.charAt(0) == '`' && text.length > 1) text.substring(1, text.length - 1)
-    else text
+    text.charAt(0) == '`' && text.length > 1
   }
 
   def getElement = this
 
-  def getRangeInElement: TextRange =
-    new TextRange(nameId.getTextRange.getStartOffset - getTextRange.getStartOffset, getTextLength)
+  def getRangeInElement: TextRange = {
+    val start = nameId.getTextRange.getStartOffset - getTextRange.getStartOffset
+    val len = getTextLength
+    if (isBackQuoted)
+      new TextRange(start + 1, len - 1)
+    else
+      new TextRange(start, len)
+  }
 
   def getCanonicalText: String = {
     resolve() match {

--- a/src/org/jetbrains/plugins/scala/lang/refactoring/ScalaRefactoringSupportProvider.scala
+++ b/src/org/jetbrains/plugins/scala/lang/refactoring/ScalaRefactoringSupportProvider.scala
@@ -23,7 +23,7 @@ import org.jetbrains.plugins.scala.lang.refactoring.introduceField.ScalaIntroduc
 
 class ScalaRefactoringSupportProvider extends RefactoringSupportProvider {
   override def isInplaceRenameAvailable(element: PsiElement, context: PsiElement) = {
-    ScalaInplaceRenameUtil.myRenameInPlace(element, context)
+    false // handled by ScalaInplaceRenameHandler
   }
 
   override def getIntroduceConstantHandler: RefactoringActionHandler = null
@@ -33,6 +33,11 @@ class ScalaRefactoringSupportProvider extends RefactoringSupportProvider {
   override def getIntroduceFieldHandler: RefactoringActionHandler = new ScalaIntroduceFieldFromExpressionHandler
 
   override def getIntroduceParameterHandler: RefactoringActionHandler = new ScalaIntroduceParameterHandler
+
+  override def isAvailable(context: PsiElement): Boolean = {
+    val available: Boolean = super.isAvailable(context)
+    available
+  }
 
   override def isSafeDeleteAvailable(element: PsiElement): Boolean = element match {
     case _: ScTypeDefinition | _: ScFunction | _: ScFieldId | _: ScReferencePattern => true

--- a/src/org/jetbrains/plugins/scala/lang/refactoring/rename/inplace/ScalaInplaceRenameUtil.scala
+++ b/src/org/jetbrains/plugins/scala/lang/refactoring/rename/inplace/ScalaInplaceRenameUtil.scala
@@ -37,30 +37,5 @@ object ScalaInplaceRenameUtil {
       case e: Exception => false
     }
   }
-
-  def myRenameInPlace(element: PsiElement, context: PsiElement): Boolean = {
-    element match {
-      case named: ScNamedElement if isLocallyDefined(named) =>
-        val stringToSearch = named.name
-        val usages = new util.ArrayList[UsageInfo]
-        // See: SCL-4336
-        var hasBackTickedRef = false
-        if (stringToSearch != null) {
-          TextOccurrencesUtil.addUsagesInStringsAndComments(element, stringToSearch, usages, new TextOccurrencesUtil.UsageInfoFactory {
-            def createUsageInfo(usage: PsiElement, startOffset: Int, endOffset: Int): UsageInfo = new UsageInfo(usage)
-          })
-          ReferencesSearch.search(element).forEach(new Processor[PsiReference] {
-            def process(t: PsiReference): Boolean = {
-              if (t.getElement.getText.contains("`")) {
-                hasBackTickedRef = true
-                false
-              } else true
-            }
-          })
-        }
-        usages.isEmpty && !hasBackTickedRef
-
-      case _ => false
-    }
-  }
 }
+


### PR DESCRIPTION
Preserves the backticks in references after the rename.

```
class Test {
  def test {
    val yyyy = 1
    val (`yyyy`, 0) = (1, 2)

    val xxxxxx = 0
    xxxxxx
    `xxxxxx`
  }
}
```

Previously, I had disabled in place renaming if back ticked references existed (aad00a9f95). That no longer worked after the addition of `ScalaInplaceRenamer`.

This commit adjusts `ScReference#getTextRange` to exclude backticks.

During the fix, I noticed another problem. In the code below, the usage search for `xxxx` comes up empty.

```
// File1.scala
object O {
  val xxxx = 0
}

// File2.scala
object Test {  O.`xxxx` }
```

Review by @niktrop, @alefas
