### PR TITLE
Removed annoying spaces from Scala Console

### DIFF
--- a/src/org/jetbrains/plugins/scala/console/ScalaConsoleRunConfiguration.scala
+++ b/src/org/jetbrains/plugins/scala/console/ScalaConsoleRunConfiguration.scala
@@ -129,7 +129,7 @@ class ScalaConsoleRunConfiguration(val project: Project, val configurationFactor
     val consoleBuilder = new TextConsoleBuilderImpl(project) {
       override def getConsole: ConsoleView = {
         val consoleView = new ScalaLanguageConsoleView(getProject)
-        consoleView.getConsole.setPrompt("")
+        consoleView.getConsole.setPrompt(null)
         consoleView
       }
     }


### PR DESCRIPTION
The existing Scala Console places an annoying space before the first line of the text editor window:

![screen shot 2013-09-22 at 10 47 16 pm](https://f.cloud.github.com/assets/934140/1189462/aed62480-2413-11e3-9996-8d9a93ca0129.png)

This space is extremely ugly. Note also the double space after the `scala>` prompt. These are a result of a [hardcoded hack in the IntelliJ platform](https://github.com/JetBrains/intellij-community/blob/master/platform/lang-impl/src/com/intellij/execution/console/LanguageConsoleImpl.java#L330), which inserts a space if the prompt doesn't end with one (or is empty).

This changes the prompt string to `null` instead of `""`, which provides us the correct behavior. No strange indents inside the rectangular text entry area, and a single space after the `scala>` prompt

![screen shot 2013-09-22 at 10 46 16 pm](https://f.cloud.github.com/assets/934140/1189461/ac44cd48-2413-11e3-84be-75e7bbf48d9b.png)
