### PR TITLE
Fix misleading quick fix messages

### DIFF
--- a/META-INF/scala-plugin-common.xml
+++ b/META-INF/scala-plugin-common.xml
@@ -885,7 +885,7 @@
                        shortName="ComparingUnrelatedTypes" level="WARNING"
                        enabledByDefault="true" language="Scala"/>
       <localInspection implementationClass="org.jetbrains.plugins.scala.codeInspection.functionExpressions.MatchToPartialFunctionInspection"
-                       displayName="Match statement convertible to partial function" groupName="Scala: General"
+                       displayName="Match statement convertible to pattern matching anonymous function" groupName="Scala: General"
                        shortName="MatchToPartialFunction" level="WARNING"
                        enabledByDefault="true" language="Scala"/>
       <localInspection implementationClass="org.jetbrains.plugins.scala.codeInspection.controlFlow.ScalaUnreachableCodeInspection"

--- a/src/org/jetbrains/plugins/scala/codeInspection/functionExpressions/MatchToPartialFunctionInspection.scala
+++ b/src/org/jetbrains/plugins/scala/codeInspection/functionExpressions/MatchToPartialFunctionInspection.scala
@@ -64,7 +64,7 @@ class MatchToPartialFunctionInspection extends AbstractInspection(inspectionId){
 
 object MatchToPartialFunctionInspection {
   val inspectionId = "MatchToPartialFunction"
-  val inspectionName = "Convert match statement to partial function"
+  val inspectionName = "Convert match statement to pattern matching anonymous function"
 }
 
 class MatchToPartialFunctionQuickFix(matchStmt: ScMatchStmt, fExprToReplace: ScExpression)


### PR DESCRIPTION
- Actually, the quick fix doesn't `Convert match statement to partial function` but `Convert match statement to pattern matching anonymous function`.
- About `pattern matching anonymous function`, please see SLS 8.5
