### PR TITLE
SCL-4798 Move test arguments to the end to ensure they aren't mistaken as tests

### DIFF
--- a/src/org/jetbrains/plugins/scala/testingSupport/test/AbstractTestRunConfiguration.scala
+++ b/src/org/jetbrains/plugins/scala/testingSupport/test/AbstractTestRunConfiguration.scala
@@ -390,14 +390,15 @@ abstract class AbstractTestRunConfiguration(val project: Project,
               }
             }
 
-            val parms: Array[String] = ParametersList.parse(getTestArgs)
-            for (parm <- parms) {
-              printer.println(parm)
-            }
             printer.println("-showProgressMessages")
             printer.println(showProgressMessages.toString)
             printer.println("-C")
             printer.println(reporterClass)
+
+            val parms: Array[String] = ParametersList.parse(getTestArgs)
+            for (parm <- parms) {
+              printer.println(parm)
+            }
 
             printer.close()
             params.getProgramParametersList.add("@" + fileWithParams.getPath)
@@ -423,12 +424,13 @@ abstract class AbstractTestRunConfiguration(val project: Project,
             }
           }
 
-          params.getProgramParametersList.addParametersString(getTestArgs)
           params.getProgramParametersList.add("-showProgressMessages")
           params.getProgramParametersList.add(showProgressMessages.toString)
 
           params.getProgramParametersList.add("-C")
           params.getProgramParametersList.add(reporterClass)
+
+          params.getProgramParametersList.addParametersString(getTestArgs)
         }
 
         for (ext <- Extensions.getExtensions(RunConfigurationExtension.EP_NAME)) {


### PR DESCRIPTION
Let me know if this isn't quite right. At the moment though the arguments are impossible to distinguish from tests if there isn't any `-` arguments (eg no `-testName`)
