### PR TITLE
Fix empty resolvers list for just opened project when auto-import is disabled

### DIFF
--- a/SBT/src/main/scala/org/jetbrains/sbt/project/module/SbtModule.scala
+++ b/SBT/src/main/scala/org/jetbrains/sbt/project/module/SbtModule.scala
@@ -14,7 +14,7 @@ object SbtModule {
 
   private val Delimiter = ", "
 
-  private val ResolversKey: Key[Set[SbtResolver]] = new Key("sbt.resolvers")
+  private val ResolversKey = "sbt.resolvers"
 
   def getImportsFrom(module: Module): Seq[String] =
     Option(module.getOptionValue(ImportsKey)).fold(Sbt.DefaultImplicitImports)(_.split(Delimiter))
@@ -23,8 +23,12 @@ object SbtModule {
     module.setOption(ImportsKey, imports.mkString(Delimiter))
 
   def getResolversFrom(module: Module): Set[SbtResolver] =
-    Option(module.getUserData(ResolversKey)).getOrElse(Set.empty)
+    Option(module.getOptionValue(ResolversKey)).map { str =>
+      str.split(Delimiter).map(SbtResolver.fromString).collect {
+        case Some(r) => r
+      }.toSet
+    }.getOrElse(Set.empty)
 
   def setResolversTo(module: Module, resolvers: Set[SbtResolver]) =
-    module.putUserData(ResolversKey, resolvers)
+    module.setOption(ResolversKey, resolvers.map(_.toString).mkString(Delimiter))
 }

--- a/SBT/src/main/scala/org/jetbrains/sbt/resolvers/SbtResolver.scala
+++ b/SBT/src/main/scala/org/jetbrains/sbt/resolvers/SbtResolver.scala
@@ -1,11 +1,28 @@
 package org.jetbrains.sbt
 package resolvers
 
+import java.util.regex.Pattern
+
 /**
  * @author Nikolay Obedin
  * @since 7/25/14.
  */
 case class SbtResolver(name: String, root: String) {
+  import SbtResolver._
+
   def associatedIndex = SbtResolverIndexesManager().find(this)
+
+  override def toString = s"$root$DELIMITER$name"
+}
+
+object SbtResolver {
+  val DELIMITER = "|"
+  def fromString(str: String): Option[SbtResolver] = {
+    str.split(Pattern.quote(DELIMITER), 2).toSeq match {
+      case Seq(root, name) => Some(new SbtResolver(name, root))
+      case Seq(root) => Some(new SbtResolver("", root))
+      case _ => None
+    }
+  }
 }
 


### PR DESCRIPTION
Saving them just as imports list
