### PR TITLE
add option to have spaces in import braces, sort all grouped names together

### DIFF
--- a/src/org/jetbrains/plugins/scala/editor/importOptimizer/ScalaImportOptimizer.scala
+++ b/src/org/jetbrains/plugins/scala/editor/importOptimizer/ScalaImportOptimizer.scala
@@ -233,6 +233,7 @@ class ScalaImportOptimizer extends ImportOptimizer {
     val collectImports = settings.isCollectImports
     val groups = settings.getImportLayout
     val isUnicodeArrow = settings.REPLACE_CASE_ARROW_WITH_UNICODE_CHAR
+    val spacesInImports = settings.SPACES_IN_IMPORTS
 
     val sortedImportsInfo: mutable.Map[TextRange, Seq[ImportInfo]] =
       for ((range, (names, _importInfos)) <- importsInfo) yield {
@@ -278,8 +279,8 @@ class ScalaImportOptimizer extends ImportOptimizer {
             while (i + 1 < buffer.length) {
               val l: String = buffer(i).prefixQualifier
               val r: String = buffer(i + 1).prefixQualifier
-              val lText = getImportTextCreator.getImportText(buffer(i), isUnicodeArrow)
-              val rText = getImportTextCreator.getImportText(buffer(i + 1), isUnicodeArrow)
+              val lText = getImportTextCreator.getImportText(buffer(i), isUnicodeArrow, spacesInImports)
+              val rText = getImportTextCreator.getImportText(buffer(i + 1), isUnicodeArrow, spacesInImports)
               if (greater(l, r, lText, rText, project) && swap(i)) changed = true
               i = i + 1
             }
@@ -383,7 +384,7 @@ class ScalaImportOptimizer extends ImportOptimizer {
           var currentGroupIndex = -1
           val text = importInfos.map { info =>
             val index: Int = findGroupIndex(info.prefixQualifier, project)
-            if (index <= currentGroupIndex) textCreator.getImportText(info, isUnicodeArrow)
+            if (index <= currentGroupIndex) textCreator.getImportText(info, isUnicodeArrow, spacesInImports)
             else {
               var blankLines = ""
               def iteration() {
@@ -395,7 +396,7 @@ class ScalaImportOptimizer extends ImportOptimizer {
               }
               while (currentGroupIndex != -1 && blankLines.isEmpty && currentGroupIndex < index) iteration()
               currentGroupIndex = index
-              blankLines + textCreator.getImportText(info, isUnicodeArrow)
+              blankLines + textCreator.getImportText(info, isUnicodeArrow, spacesInImports)
             }
           }.mkString(splitter)
           val newRange: TextRange = if (text.isEmpty) {
@@ -482,42 +483,31 @@ object ScalaImportOptimizer {
   }
 
   class ImportTextCreator {
-    def getImportText(importInfo: ImportInfo, isUnicodeArrow: Boolean): String = {
+    def getImportText(importInfo: ImportInfo, isUnicodeArrow: Boolean, spacesInImports: Boolean): String = {
       import importInfo._
 
       val groupStrings = new ArrayBuffer[String]
-      groupStrings ++= singleNames.toSeq.sorted
+      groupStrings ++= singleNames
       val arrow = if (isUnicodeArrow) ScalaTypedHandler.unicodeCaseArrow else "=>"
-      groupStrings ++= renames.map(pair => s"${pair._1} $arrow ${pair._2}").toSeq.sorted
-      groupStrings ++= hidedNames.map(_ + s" $arrow _").toSeq.sorted
-      if (hasWildcard) groupStrings += "_"
+      groupStrings ++= renames.map(pair => s"${pair._1} $arrow ${pair._2}")
+      groupStrings ++= hidedNames.map(_ + s" $arrow _")
+      val sortedGroupStrings = groupStrings.sorted
+      if (hasWildcard) sortedGroupStrings += "_"
+      val space = if (spacesInImports) " " else ""
+      val root = if (rootUsed) "_root_." else ""
       val postfix =
-        if (groupStrings.length > 1 || renames.nonEmpty || hidedNames.nonEmpty) groupStrings.mkString("{", ", ", "}")
-        else groupStrings(0)
-      "import " + (if (rootUsed) "_root_." else "") + relative.getOrElse(prefixQualifier) + "." + postfix
+        if (sortedGroupStrings.length > 1 || renames.nonEmpty || hidedNames.nonEmpty) sortedGroupStrings.mkString(s"{$space", ", ", s"$space}")
+        else sortedGroupStrings(0)
+      s"import $root${relative.getOrElse(prefixQualifier)}.$postfix"
     }
   }
 
-  class ImportInfo(val importUsed: Set[ImportUsed], val prefixQualifier: String,
-                   val relative: Option[String], val allNames: Set[String],
-                   val singleNames: Set[String], val renames: Map[String, String],
-                   val hidedNames: Set[String], val hasWildcard: Boolean, val rootUsed: Boolean) {
-    def withoutRelative(holderNames: Set[String]): ImportInfo = {
-      if (relative.isDefined || rootUsed) {
-        val id = getFirstId(prefixQualifier)
-        val rootUsed = holderNames.contains(id)
-        this.copy(relative = None)
-      } else this
-    }
-
-    def copy(importUsed: Set[ImportUsed] = importUsed, prefixQualifier: String = prefixQualifier,
-             relative: Option[String] = relative, allNames: Set[String] = allNames,
-             singleNames: Set[String] = singleNames, renames: Map[String, String] = renames,
-             hidedNames: Set[String] = hidedNames, hasWildcard: Boolean = hasWildcard,
-             rootUsed: Boolean = rootUsed): ImportInfo = {
-      new ImportInfo(importUsed, prefixQualifier, relative, allNames,
-        singleNames, renames, hidedNames, hasWildcard, rootUsed)
-    }
+  case class ImportInfo(importUsed: Set[ImportUsed], prefixQualifier: String,
+                   relative: Option[String], allNames: Set[String],
+                   singleNames: Set[String], renames: Map[String, String],
+                   hidedNames: Set[String], hasWildcard: Boolean, rootUsed: Boolean) {
+    def withoutRelative(holderNames: Set[String]): ImportInfo =
+      if (relative.isDefined || rootUsed) copy(relative = None) else this
   }
 
   def name(s: String): String = {

--- a/src/org/jetbrains/plugins/scala/lang/formatting/settings/ScalaCodeStyleSettings.java
+++ b/src/org/jetbrains/plugins/scala/lang/formatting/settings/ScalaCodeStyleSettings.java
@@ -45,7 +45,7 @@ public class ScalaCodeStyleSettings extends CustomCodeStyleSettings {
   public boolean SPACE_AFTER_TYPE_COLON = true;
 
   //todo: add to spacing settings
-  //spcaing settings:
+  //spacing settings:
   public boolean SPACE_BEFORE_BRACE_METHOD_CALL = true;
   public boolean SPACE_BEFORE_MATCH_LBRACE = true;
   public boolean KEEP_ONE_LINE_LAMBDAS_IN_ARG_LIST = false;
@@ -56,6 +56,7 @@ public class ScalaCodeStyleSettings extends CustomCodeStyleSettings {
   public boolean SPACE_BEFORE_INFIX_LIKE_METHOD_PARENTHESES = false;
 
   public boolean SPACES_IN_ONE_LINE_BLOCKS = false;
+  public boolean SPACES_IN_IMPORTS = false;
 
   //xml formatting
   public boolean KEEP_XML_FORMATTING = false;

--- a/src/org/jetbrains/plugins/scala/lang/formatting/settings/ScalaLanguageCodeStyleSettingsProvider.scala
+++ b/src/org/jetbrains/plugins/scala/lang/formatting/settings/ScalaLanguageCodeStyleSettingsProvider.scala
@@ -160,6 +160,8 @@ class ScalaLanguageCodeStyleSettingsProvider extends LanguageCodeStyleSettingsPr
         CodeStyleSettingsCustomizable.SPACES_BEFORE_PARENTHESES)
       showCustomOption("SPACE_BEFORE_BRACE_METHOD_CALL", "Space before method call brace",
         CodeStyleSettingsCustomizable.SPACES_BEFORE_PARENTHESES)
+      showCustomOption("SPACES_IN_IMPORTS", "Spaces after open and before close braces in imports",
+        CodeStyleSettingsCustomizable.SPACES_OTHER)
     }
 
   }

--- a/test/org/jetbrains/plugins/scala/editor/importOptimizer/ImportTextCreatorTest.scala
+++ b/test/org/jetbrains/plugins/scala/editor/importOptimizer/ImportTextCreatorTest.scala
@@ -1,0 +1,44 @@
+package org.jetbrains.plugins.scala.editor.importOptimizer
+
+import junit.framework.TestCase
+import org.jetbrains.plugins.scala.editor.importOptimizer.ScalaImportOptimizer._
+import org.junit.Assert
+
+class ImportTextCreatorTest extends TestCase {
+
+  val textCreator = new ImportTextCreator()
+
+  def testGetImportText_Root_And_Wildcard(): Unit = {
+    val info = ImportInfo(Set.empty, "scala.collection", None, Set.empty, Set.empty, Map.empty, Set.empty, true, true)
+    Assert.assertEquals("import _root_.scala.collection._", textCreator.getImportText(info, false, false))
+  }
+
+  def testGetImportText_Hidden(): Unit = {
+    val info = ImportInfo(Set.empty, "scala", None, Set.empty, Set.empty, Map.empty, Set("Long"), false, false)
+    Assert.assertEquals("import scala.{Long => _}", textCreator.getImportText(info, false, false))
+  }
+
+  def testGetImportText_Renames(): Unit = {
+    val info = ImportInfo(Set.empty, "java.lang", None, Set.empty, Set.empty, Map("Long" -> "JLong"), Set.empty, false, false)
+    Assert.assertEquals("import java.lang.{Long => JLong}", textCreator.getImportText(info, false, false))
+  }
+
+  def testGetImportText_UnicodeArrowAndSpaces(): Unit = {
+    val info = ImportInfo(Set.empty, "java.lang", None, Set.empty, Set.empty, Map("Long" -> "JLong"), Set.empty, false, false)
+    Assert.assertEquals("import java.lang.{ Long ⇒ JLong }", textCreator.getImportText(info, true, true))
+  }
+
+  def testGetImportText_SortSingles(): Unit = {
+    val info = ImportInfo(Set.empty, "java.lang", None, Set.empty,
+      Set("Long", "Integer", "Float", "Short"), Map.empty, Set.empty, false, false)
+    Assert.assertEquals("import java.lang.{Float, Integer, Long, Short}", textCreator.getImportText(info, false, false))
+  }
+
+  def testGetImportText_Renames_Hidden_Singles_Wildcard_Spaces(): Unit = {
+    val info = ImportInfo(Set.empty, "java.lang", None, Set.empty, Set("Integer", "Character", "Runtime"),
+      Map("Long" -> "JLong", "Float" -> "JFloat"), Set("System"), true, false)
+    Assert.assertEquals("import java.lang.{ Character, Float => JFloat, Integer, Long => JLong, Runtime, System => _, _ }",
+      textCreator.getImportText(info, false, true))
+  }
+
+}


### PR DESCRIPTION
- added new checkbox to scala code style Spaces tab, allowing to format imports like
  
  `import java.util.{ EnumSet, HashSet }`. 

Scala ide and some auto formatters can do it, so it can be quite important to maintain same style with idea.
- order of import names in one line is changed from

`java.util.{EnumSet, ArrayList => JArrayList, List => JList, BitSet => _}`

to
`java.util.{ArrayList => JArrayList, BitSet => _, EnumSet, List => JList}`

by sorting all tokens together instead of sorting singles, renames and hidden separately
- Some basic unit tests added
