### PR TITLE
add ability to define ScalaTest default super class per project.

### DIFF
--- a/src/org/jetbrains/plugins/scala/settings/ScalaProjectSettings.java
+++ b/src/org/jetbrains/plugins/scala/settings/ScalaProjectSettings.java
@@ -26,6 +26,7 @@ public class ScalaProjectSettings  implements PersistentStateComponent<ScalaProj
   private int IMPLICIT_PARAMETERS_SEARCH_DEPTH = -1;
 
   private String BASE_PACKAGE = "";
+  private String SCALATEST_DEFAULT_SUPERCLASS = "org.scalatest.FunSuite";
   
   private boolean SEARCH_ALL_SYMBOLS = false;
 
@@ -212,6 +213,14 @@ public class ScalaProjectSettings  implements PersistentStateComponent<ScalaProj
 
   public String getBasePackage() {
     return BASE_PACKAGE;
+  }
+
+  public String getScalaTestDefaultSuperClass() {
+    return SCALATEST_DEFAULT_SUPERCLASS;
+  }
+
+  public void setScalaTestDefaultSuperClass(String superClassName) {
+    SCALATEST_DEFAULT_SUPERCLASS = superClassName;
   }
 
   public void setBasePackage(String name) {

--- a/src/org/jetbrains/plugins/scala/settings/ScalaProjectSettingsPanel.form
+++ b/src/org/jetbrains/plugins/scala/settings/ScalaProjectSettingsPanel.form
@@ -17,7 +17,7 @@
         <properties/>
         <border type="none"/>
         <children>
-          <grid id="daf84" layout-manager="GridLayoutManager" row-count="20" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+          <grid id="daf84" layout-manager="GridLayoutManager" row-count="21" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
             <margin top="9" left="9" bottom="0" right="0"/>
             <constraints>
               <tabbedpane title="Core"/>
@@ -156,7 +156,7 @@
               <grid id="27b8d" layout-manager="GridLayoutManager" row-count="1" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
                 <margin top="0" left="0" bottom="0" right="0"/>
                 <constraints>
-                  <grid row="19" column="2" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+                  <grid row="20" column="2" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties/>
                 <border type="none"/>
@@ -226,12 +226,28 @@
               <grid id="62ee1" binding="injectionJPanel" custom-create="true" layout-manager="GridLayoutManager" row-count="1" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
                 <margin top="0" left="0" bottom="0" right="0"/>
                 <constraints>
-                  <grid row="19" column="0" row-span="1" col-span="2" vsize-policy="3" hsize-policy="7" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+                  <grid row="20" column="0" row-span="1" col-span="2" vsize-policy="3" hsize-policy="7" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties/>
                 <border type="none"/>
                 <children/>
               </grid>
+              <component id="8e4cd" class="javax.swing.JLabel">
+                <constraints>
+                  <grid row="19" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                </constraints>
+                <properties>
+                  <text value="ScalaTest default super class:"/>
+                </properties>
+              </component>
+              <component id="12bd3" class="javax.swing.JTextField" binding="scalaTestDefaultSuperClass">
+                <constraints>
+                  <grid row="19" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+                    <preferred-size width="150" height="-1"/>
+                  </grid>
+                </constraints>
+                <properties/>
+              </component>
             </children>
           </grid>
           <grid id="ff810" layout-manager="GridLayoutManager" row-count="4" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">

--- a/src/org/jetbrains/plugins/scala/settings/ScalaProjectSettingsPanel.java
+++ b/src/org/jetbrains/plugins/scala/settings/ScalaProjectSettingsPanel.java
@@ -19,340 +19,350 @@ import java.util.ResourceBundle;
  * Date: 30.07.2008
  */
 public class ScalaProjectSettingsPanel {
-    public final static String INJECTION_SETTINGS_NAME = "DependencyAwareInjectionSettings";
+  public final static String INJECTION_SETTINGS_NAME = "DependencyAwareInjectionSettings";
 
-    private JPanel myPanel;
-    private JCheckBox searchAllSymbolsIncludeCheckBox;
-    private JCheckBox enableConversionOnCopyCheckBox;
-    private JCheckBox donTShowDialogCheckBox;
-    private JCheckBox showImplicitConversionsInCheckBox;
-    private JCheckBox myResolveToAllClassesCheckBox;
-    private JCheckBox showArgumentsToByNameParametersCheckBox;
-    private JCheckBox includeBlockExpressionsExpressionsCheckBox;
-    private JCheckBox includeLiteralsCheckBox;
-    private JCheckBox treatDocCommentAsBlockComment;
-    private JCheckBox myDisableLanguageInjection;
-    private JCheckBox useScalaClassesPriorityCheckBox;
-    private JComboBox collectionHighlightingChooser;
-    private JPanel injectionJPanel;
-    private JSpinner outputSpinner;
-    private JSpinner implicitParametersSearchDepthSpinner;
-    private JCheckBox myDontCacheCompound;
-    private JCheckBox runWorksheetInTheCheckBox;
-    private JTextField myBasePackage;
-    private JCheckBox worksheetInteractiveModeCheckBox;
-    private ScalaUiWithDependency.ComponentWithSettings injectionPrefixTable;
-    private Project myProject;
+  private JPanel myPanel;
+  private JCheckBox searchAllSymbolsIncludeCheckBox;
+  private JCheckBox enableConversionOnCopyCheckBox;
+  private JCheckBox donTShowDialogCheckBox;
+  private JCheckBox showImplicitConversionsInCheckBox;
+  private JCheckBox myResolveToAllClassesCheckBox;
+  private JCheckBox showArgumentsToByNameParametersCheckBox;
+  private JCheckBox includeBlockExpressionsExpressionsCheckBox;
+  private JCheckBox includeLiteralsCheckBox;
+  private JCheckBox treatDocCommentAsBlockComment;
+  private JCheckBox myDisableLanguageInjection;
+  private JCheckBox useScalaClassesPriorityCheckBox;
+  private JComboBox collectionHighlightingChooser;
+  private JPanel injectionJPanel;
+  private JSpinner outputSpinner;
+  private JSpinner implicitParametersSearchDepthSpinner;
+  private JCheckBox myDontCacheCompound;
+  private JCheckBox runWorksheetInTheCheckBox;
+  private JTextField myBasePackage;
+  private JCheckBox worksheetInteractiveModeCheckBox;
+  private JTextField scalaTestDefaultSuperClass;
+  private ScalaUiWithDependency.ComponentWithSettings injectionPrefixTable;
+  private Project myProject;
 
-    public ScalaProjectSettingsPanel(Project project) {
-        myProject = project;
-        $$$setupUI$$$();
-        outputSpinner.setModel(new SpinnerNumberModel(35, 1, null, 1));
+  public ScalaProjectSettingsPanel(Project project) {
+    myProject = project;
+    $$$setupUI$$$();
+    outputSpinner.setModel(new SpinnerNumberModel(35, 1, null, 1));
 
-        ScalaUiWithDependency[] deps = DependencyAwareInjectionSettings.EP_NAME.getExtensions();
-        for (ScalaUiWithDependency uiWithDependency : deps) {
-            if (INJECTION_SETTINGS_NAME.equals(uiWithDependency.getName())) {
-                injectionPrefixTable = uiWithDependency.createComponent(injectionJPanel);
-                break;
-            }
+    ScalaUiWithDependency[] deps = DependencyAwareInjectionSettings.EP_NAME.getExtensions();
+    for (ScalaUiWithDependency uiWithDependency : deps) {
+      if (INJECTION_SETTINGS_NAME.equals(uiWithDependency.getName())) {
+        injectionPrefixTable = uiWithDependency.createComponent(injectionJPanel);
+        break;
+      }
+    }
+    if (injectionPrefixTable == null) injectionPrefixTable = new ScalaUiWithDependency.NullComponentWithSettings();
+
+    setSettings();
+  }
+
+  @NotNull
+  protected FileType getFileType() {
+    return ScalaFileType.SCALA_FILE_TYPE;
+  }
+
+  public void apply() {
+    if (!isModified()) return;
+
+    final ScalaProjectSettings scalaProjectSettings = ScalaProjectSettings.getInstance(myProject);
+    scalaProjectSettings.setBasePackage(myBasePackage.getText());
+    scalaProjectSettings.setScalaTestDefaultSuperClass(scalaTestDefaultSuperClass.getText());
+    scalaProjectSettings.setImplicitParametersSearchDepth((Integer) implicitParametersSearchDepthSpinner.getValue());
+    scalaProjectSettings.setOutputLimit((Integer) outputSpinner.getValue());
+    scalaProjectSettings.setInProcessMode(runWorksheetInTheCheckBox.isSelected());
+    scalaProjectSettings.setInteractiveMode(worksheetInteractiveModeCheckBox.isSelected());
+
+    scalaProjectSettings.setSearchAllSymbols(searchAllSymbolsIncludeCheckBox.isSelected());
+    scalaProjectSettings.setEnableJavaToScalaConversion(enableConversionOnCopyCheckBox.isSelected());
+    scalaProjectSettings.setDontShowConversionDialog(donTShowDialogCheckBox.isSelected());
+    scalaProjectSettings.setTreatDocCommentAsBlockComment(treatDocCommentAsBlockComment.isSelected());
+
+    scalaProjectSettings.setShowImplisitConversions(showImplicitConversionsInCheckBox.isSelected());
+    scalaProjectSettings.setShowArgumentsToByNameParams(showArgumentsToByNameParametersCheckBox.isSelected());
+    scalaProjectSettings.setIncludeBlockExpressions(includeBlockExpressionsExpressionsCheckBox.isSelected());
+    scalaProjectSettings.setIncludeLiterals(includeLiteralsCheckBox.isSelected());
+
+    scalaProjectSettings.setIgnorePerformance(myResolveToAllClassesCheckBox.isSelected());
+    scalaProjectSettings.setDisableLangInjection(myDisableLanguageInjection.isSelected());
+    scalaProjectSettings.setDontCacheCompoundTypes(myDontCacheCompound.isSelected());
+    scalaProjectSettings.setScalaPriority(useScalaClassesPriorityCheckBox.isSelected());
+    scalaProjectSettings.setCollectionTypeHighlightingLevel(collectionHighlightingChooser.getSelectedIndex());
+    injectionPrefixTable.saveSettings(scalaProjectSettings);
+  }
+
+  @SuppressWarnings({"ConstantConditions", "RedundantIfStatement"})
+  public boolean isModified() {
+
+    final ScalaProjectSettings scalaProjectSettings = ScalaProjectSettings.getInstance(myProject);
+
+    if (!scalaProjectSettings.getBasePackage().equals(
+        myBasePackage.getText())) return true;
+    if (!scalaProjectSettings.getScalaTestDefaultSuperClass().equals(
+        scalaTestDefaultSuperClass.getText())) return true;
+    if (scalaProjectSettings.isShowImplisitConversions() !=
+        showImplicitConversionsInCheckBox.isSelected()) return true;
+    if (scalaProjectSettings.isShowArgumentsToByNameParams() !=
+        showArgumentsToByNameParametersCheckBox.isSelected()) return true;
+    if (scalaProjectSettings.isIncludeBlockExpressions() !=
+        includeBlockExpressionsExpressionsCheckBox.isSelected()) return true;
+    if (scalaProjectSettings.isIncludeLiterals() !=
+        includeLiteralsCheckBox.isSelected()) return true;
+
+    if (scalaProjectSettings.getImplicitParametersSearchDepth() !=
+        (Integer) implicitParametersSearchDepthSpinner.getValue()) return true;
+    if (scalaProjectSettings.getOutputLimit() !=
+        (Integer) outputSpinner.getValue()) return true;
+    if (scalaProjectSettings.isInProcessMode() !=
+        runWorksheetInTheCheckBox.isSelected()) return true;
+    if (scalaProjectSettings.isInteractiveMode() != worksheetInteractiveModeCheckBox.isSelected()) return true;
+
+    if (scalaProjectSettings.isSearchAllSymbols() !=
+        searchAllSymbolsIncludeCheckBox.isSelected()) return true;
+    if (scalaProjectSettings.isEnableJavaToScalaConversion() !=
+        enableConversionOnCopyCheckBox.isSelected()) return true;
+    if (scalaProjectSettings.isDontShowConversionDialog() !=
+        donTShowDialogCheckBox.isSelected()) return true;
+    if (scalaProjectSettings.isTreatDocCommentAsBlockComment() !=
+        treatDocCommentAsBlockComment.isSelected()) return true;
+
+    if (scalaProjectSettings.isIgnorePerformance() != myResolveToAllClassesCheckBox.isSelected())
+      return true;
+
+    if (scalaProjectSettings.isDisableLangInjection() != myDisableLanguageInjection.isSelected())
+      return true;
+
+
+    if (scalaProjectSettings.isDontCacheCompoundTypes() != myDontCacheCompound.isSelected()) return true;
+
+    if (scalaProjectSettings.isScalaPriority() != useScalaClassesPriorityCheckBox.isSelected())
+      return true;
+
+    if (scalaProjectSettings.getCollectionTypeHighlightingLevel() !=
+        collectionHighlightingChooser.getSelectedIndex()) return true;
+
+    if (injectionPrefixTable.isModified(scalaProjectSettings)) return true;
+
+    return false;
+  }
+
+  public JComponent getPanel() {
+    return myPanel;
+  }
+
+  protected void resetImpl() {
+    setSettings();
+  }
+
+  private void setSettings() {
+    final ScalaProjectSettings scalaProjectSettings = ScalaProjectSettings.getInstance(myProject);
+
+    setValue(myBasePackage, scalaProjectSettings.getBasePackage());
+    setValue(scalaTestDefaultSuperClass, scalaProjectSettings.getScalaTestDefaultSuperClass());
+    setValue(implicitParametersSearchDepthSpinner, scalaProjectSettings.getImplicitParametersSearchDepth());
+    setValue(outputSpinner, scalaProjectSettings.getOutputLimit());
+    setValue(runWorksheetInTheCheckBox, scalaProjectSettings.isInProcessMode());
+    setValue(worksheetInteractiveModeCheckBox, scalaProjectSettings.isInteractiveMode());
+
+    setValue(searchAllSymbolsIncludeCheckBox, scalaProjectSettings.isSearchAllSymbols());
+    setValue(enableConversionOnCopyCheckBox, scalaProjectSettings.isEnableJavaToScalaConversion());
+    setValue(donTShowDialogCheckBox, scalaProjectSettings.isDontShowConversionDialog());
+    setValue(treatDocCommentAsBlockComment, scalaProjectSettings.isTreatDocCommentAsBlockComment());
+
+    setValue(showImplicitConversionsInCheckBox, scalaProjectSettings.isShowImplisitConversions());
+    setValue(showArgumentsToByNameParametersCheckBox, scalaProjectSettings.isShowArgumentsToByNameParams());
+    setValue(includeBlockExpressionsExpressionsCheckBox, scalaProjectSettings.isIncludeBlockExpressions());
+    setValue(includeLiteralsCheckBox, scalaProjectSettings.isIncludeLiterals());
+
+    setValue(myResolveToAllClassesCheckBox, scalaProjectSettings.isIgnorePerformance());
+
+    setValue(myDisableLanguageInjection, scalaProjectSettings.isDisableLangInjection());
+    setValue(myDontCacheCompound, scalaProjectSettings.isDontCacheCompoundTypes());
+    setValue(useScalaClassesPriorityCheckBox, scalaProjectSettings.isScalaPriority());
+    collectionHighlightingChooser.setSelectedIndex(scalaProjectSettings.getCollectionTypeHighlightingLevel());
+
+    injectionPrefixTable.loadSettings(scalaProjectSettings);
+  }
+
+  private static void setValue(JSpinner spinner, int value) {
+    spinner.setValue(value);
+  }
+
+  private static void setValue(final JCheckBox box, final boolean value) {
+    box.setSelected(value);
+  }
+
+  private static void setValue(final JComboBox box, final int value) {
+    box.setSelectedIndex(value);
+  }
+
+  private static void setValue(final JTextField field, final String value) {
+    field.setText(value);
+  }
+
+  private void createUIComponents() {
+    injectionJPanel = new JPanel(new GridLayout(1, 1));
+    injectionJPanel.setPreferredSize(new Dimension(200, 500));
+    injectionJPanel.setBorder(BorderFactory.createEmptyBorder(5, 5, 0, 0));
+  }
+
+  /**
+   * Method generated by IntelliJ IDEA GUI Designer
+   * >>> IMPORTANT!! <<<
+   * DO NOT edit this method OR call it in your code!
+   *
+   * @noinspection ALL
+   */
+  private void $$$setupUI$$$() {
+    createUIComponents();
+    myPanel = new JPanel();
+    myPanel.setLayout(new GridLayoutManager(1, 1, new Insets(0, 0, 0, 0), -1, -1));
+    final JTabbedPane tabbedPane1 = new JTabbedPane();
+    myPanel.add(tabbedPane1, new GridConstraints(0, 0, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_BOTH, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, null, new Dimension(200, 200), null, 0, false));
+    final JPanel panel1 = new JPanel();
+    panel1.setLayout(new GridLayoutManager(21, 3, new Insets(9, 9, 0, 0), -1, -1));
+    tabbedPane1.addTab("Core", panel1);
+    searchAllSymbolsIncludeCheckBox = new JCheckBox();
+    searchAllSymbolsIncludeCheckBox.setText("Search all symbols (include locals)");
+    panel1.add(searchAllSymbolsIncludeCheckBox, new GridConstraints(1, 0, 1, 3, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
+    final JLabel label1 = new JLabel();
+    label1.setText("Java to Scala conversions settings:");
+    panel1.add(label1, new GridConstraints(2, 0, 1, 3, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_FIXED, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
+    enableConversionOnCopyCheckBox = new JCheckBox();
+    enableConversionOnCopyCheckBox.setSelected(true);
+    enableConversionOnCopyCheckBox.setText("Enable Conversion on Copy");
+    panel1.add(enableConversionOnCopyCheckBox, new GridConstraints(3, 0, 1, 3, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
+    donTShowDialogCheckBox = new JCheckBox();
+    donTShowDialogCheckBox.setText("Don't show dialog on paste and automatically convert to Scala code");
+    panel1.add(donTShowDialogCheckBox, new GridConstraints(4, 0, 1, 3, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
+    final JLabel label2 = new JLabel();
+    label2.setText("Highlighting options:");
+    panel1.add(label2, new GridConstraints(5, 0, 1, 3, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_FIXED, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
+    showImplicitConversionsInCheckBox = new JCheckBox();
+    showImplicitConversionsInCheckBox.setSelected(true);
+    showImplicitConversionsInCheckBox.setText("Highlight methods added via implicit conversion  in  code completion dialog");
+    panel1.add(showImplicitConversionsInCheckBox, new GridConstraints(6, 0, 1, 3, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
+    final JLabel label3 = new JLabel();
+    label3.setText("Performance-related options:");
+    panel1.add(label3, new GridConstraints(10, 0, 1, 3, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_FIXED, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
+    myResolveToAllClassesCheckBox = new JCheckBox();
+    myResolveToAllClassesCheckBox.setText("Resolve to all classes, even in wrong directories (this may cause performance problems)");
+    panel1.add(myResolveToAllClassesCheckBox, new GridConstraints(12, 0, 1, 3, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
+    showArgumentsToByNameParametersCheckBox = new JCheckBox();
+    showArgumentsToByNameParametersCheckBox.setSelected(true);
+    showArgumentsToByNameParametersCheckBox.setText("Highlight arguments to by-name parameters");
+    panel1.add(showArgumentsToByNameParametersCheckBox, new GridConstraints(7, 0, 1, 3, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
+    includeBlockExpressionsExpressionsCheckBox = new JCheckBox();
+    includeBlockExpressionsExpressionsCheckBox.setSelected(true);
+    includeBlockExpressionsExpressionsCheckBox.setText("Include block expressions");
+    includeBlockExpressionsExpressionsCheckBox.setToolTipText("Include expressions enclosed in in curly braces");
+    panel1.add(includeBlockExpressionsExpressionsCheckBox, new GridConstraints(8, 0, 1, 3, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 1, false));
+    includeLiteralsCheckBox = new JCheckBox();
+    includeLiteralsCheckBox.setSelected(true);
+    includeLiteralsCheckBox.setText("Include literals ");
+    includeLiteralsCheckBox.setToolTipText("Include string, number, etc");
+    panel1.add(includeLiteralsCheckBox, new GridConstraints(9, 0, 1, 3, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 1, false));
+    treatDocCommentAsBlockComment = new JCheckBox();
+    treatDocCommentAsBlockComment.setText("Disable parsing of documentation comments. This may improve editor performance for very large files. (SCL-2900)");
+    panel1.add(treatDocCommentAsBlockComment, new GridConstraints(13, 0, 1, 3, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
+    myDisableLanguageInjection = new JCheckBox();
+    myDisableLanguageInjection.setText("Disable language injection in Scala files (injected languages may freeze typing with auto popup completion)");
+    panel1.add(myDisableLanguageInjection, new GridConstraints(14, 0, 1, 3, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
+    final JLabel label4 = new JLabel();
+    label4.setText("Completion options:");
+    panel1.add(label4, new GridConstraints(16, 0, 1, 3, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_FIXED, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
+    useScalaClassesPriorityCheckBox = new JCheckBox();
+    useScalaClassesPriorityCheckBox.setSelected(true);
+    useScalaClassesPriorityCheckBox.setText("Use Scala classes priority over Java classes");
+    panel1.add(useScalaClassesPriorityCheckBox, new GridConstraints(17, 0, 1, 3, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
+    final JPanel panel2 = new JPanel();
+    panel2.setLayout(new GridLayoutManager(1, 1, new Insets(0, 0, 0, 0), -1, -1));
+    panel1.add(panel2, new GridConstraints(20, 2, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_BOTH, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, null, null, null, 0, false));
+    final JLabel label5 = new JLabel();
+    label5.setText("Implicit parameters search depth:");
+    panel1.add(label5, new GridConstraints(11, 0, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_FIXED, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
+    implicitParametersSearchDepthSpinner = new JSpinner();
+    panel1.add(implicitParametersSearchDepthSpinner, new GridConstraints(11, 1, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_HORIZONTAL, GridConstraints.SIZEPOLICY_WANT_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
+    myDontCacheCompound = new JCheckBox();
+    myDontCacheCompound.setText("Don't cache compound types (use it in case of big pauses in GC)");
+    panel1.add(myDontCacheCompound, new GridConstraints(15, 0, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
+    final JLabel label6 = new JLabel();
+    label6.setText("Base package clause:");
+    panel1.add(label6, new GridConstraints(0, 0, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_FIXED, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
+    myBasePackage = new JTextField();
+    myBasePackage.setColumns(50);
+    panel1.add(myBasePackage, new GridConstraints(0, 1, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_WANT_GROW, GridConstraints.SIZEPOLICY_FIXED, null, new Dimension(150, -1), null, 0, false));
+    final JLabel label7 = new JLabel();
+    this.$$$loadLabelText$$$(label7, ResourceBundle.getBundle("org/jetbrains/plugins/scala/ScalaBundle").getString("collection.type.highlighting.option"));
+    panel1.add(label7, new GridConstraints(18, 0, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_FIXED, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
+    collectionHighlightingChooser = new JComboBox();
+    final DefaultComboBoxModel defaultComboBoxModel1 = new DefaultComboBoxModel();
+    defaultComboBoxModel1.addElement("None");
+    defaultComboBoxModel1.addElement("Only non-qualified");
+    defaultComboBoxModel1.addElement("All");
+    collectionHighlightingChooser.setModel(defaultComboBoxModel1);
+    panel1.add(collectionHighlightingChooser, new GridConstraints(18, 1, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_HORIZONTAL, GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
+    panel1.add(injectionJPanel, new GridConstraints(20, 0, 1, 2, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_BOTH, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_WANT_GROW, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, null, null, null, 0, false));
+    final JLabel label8 = new JLabel();
+    label8.setText("ScalaTest default super class:");
+    panel1.add(label8, new GridConstraints(19, 0, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_FIXED, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
+    scalaTestDefaultSuperClass = new JTextField();
+    panel1.add(scalaTestDefaultSuperClass, new GridConstraints(19, 1, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_HORIZONTAL, GridConstraints.SIZEPOLICY_WANT_GROW, GridConstraints.SIZEPOLICY_FIXED, null, new Dimension(150, -1), null, 0, false));
+    final JPanel panel3 = new JPanel();
+    panel3.setLayout(new GridLayoutManager(4, 2, new Insets(9, 9, 0, 0), -1, -1));
+    tabbedPane1.addTab("Worksheet", panel3);
+    final Spacer spacer1 = new Spacer();
+    panel3.add(spacer1, new GridConstraints(3, 0, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_VERTICAL, 1, GridConstraints.SIZEPOLICY_WANT_GROW, null, null, null, 0, false));
+    runWorksheetInTheCheckBox = new JCheckBox();
+    runWorksheetInTheCheckBox.setSelected(true);
+    runWorksheetInTheCheckBox.setText("Run worksheet in the compiler process");
+    panel3.add(runWorksheetInTheCheckBox, new GridConstraints(1, 0, 1, 2, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
+    worksheetInteractiveModeCheckBox = new JCheckBox();
+    worksheetInteractiveModeCheckBox.setText("Run worksheet in the interactive mode");
+    panel3.add(worksheetInteractiveModeCheckBox, new GridConstraints(2, 0, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
+    final JLabel label9 = new JLabel();
+    label9.setText("Output cutoff limit: ");
+    panel3.add(label9, new GridConstraints(0, 0, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_FIXED, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
+    outputSpinner = new JSpinner();
+    panel3.add(outputSpinner, new GridConstraints(0, 1, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_WANT_GROW, GridConstraints.SIZEPOLICY_FIXED, null, new Dimension(218, 24), null, 0, false));
+  }
+
+  /**
+   * @noinspection ALL
+   */
+  private void $$$loadLabelText$$$(JLabel component, String text) {
+    StringBuffer result = new StringBuffer();
+    boolean haveMnemonic = false;
+    char mnemonic = '\0';
+    int mnemonicIndex = -1;
+    for (int i = 0; i < text.length(); i++) {
+      if (text.charAt(i) == '&') {
+        i++;
+        if (i == text.length()) break;
+        if (!haveMnemonic && text.charAt(i) != '&') {
+          haveMnemonic = true;
+          mnemonic = text.charAt(i);
+          mnemonicIndex = result.length();
         }
-        if (injectionPrefixTable == null) injectionPrefixTable = new ScalaUiWithDependency.NullComponentWithSettings();
-
-        setSettings();
+      }
+      result.append(text.charAt(i));
     }
-
-    @NotNull
-    protected FileType getFileType() {
-        return ScalaFileType.SCALA_FILE_TYPE;
+    component.setText(result.toString());
+    if (haveMnemonic) {
+      component.setDisplayedMnemonic(mnemonic);
+      component.setDisplayedMnemonicIndex(mnemonicIndex);
     }
+  }
 
-    public void apply() {
-        if (!isModified()) return;
-
-        final ScalaProjectSettings scalaProjectSettings = ScalaProjectSettings.getInstance(myProject);
-        scalaProjectSettings.setBasePackage(myBasePackage.getText());
-        scalaProjectSettings.setImplicitParametersSearchDepth((Integer) implicitParametersSearchDepthSpinner.getValue());
-        scalaProjectSettings.setOutputLimit((Integer) outputSpinner.getValue());
-        scalaProjectSettings.setInProcessMode(runWorksheetInTheCheckBox.isSelected());
-        scalaProjectSettings.setInteractiveMode(worksheetInteractiveModeCheckBox.isSelected());
-
-        scalaProjectSettings.setSearchAllSymbols(searchAllSymbolsIncludeCheckBox.isSelected());
-        scalaProjectSettings.setEnableJavaToScalaConversion(enableConversionOnCopyCheckBox.isSelected());
-        scalaProjectSettings.setDontShowConversionDialog(donTShowDialogCheckBox.isSelected());
-        scalaProjectSettings.setTreatDocCommentAsBlockComment(treatDocCommentAsBlockComment.isSelected());
-
-        scalaProjectSettings.setShowImplisitConversions(showImplicitConversionsInCheckBox.isSelected());
-        scalaProjectSettings.setShowArgumentsToByNameParams(showArgumentsToByNameParametersCheckBox.isSelected());
-        scalaProjectSettings.setIncludeBlockExpressions(includeBlockExpressionsExpressionsCheckBox.isSelected());
-        scalaProjectSettings.setIncludeLiterals(includeLiteralsCheckBox.isSelected());
-
-        scalaProjectSettings.setIgnorePerformance(myResolveToAllClassesCheckBox.isSelected());
-        scalaProjectSettings.setDisableLangInjection(myDisableLanguageInjection.isSelected());
-        scalaProjectSettings.setDontCacheCompoundTypes(myDontCacheCompound.isSelected());
-        scalaProjectSettings.setScalaPriority(useScalaClassesPriorityCheckBox.isSelected());
-        scalaProjectSettings.setCollectionTypeHighlightingLevel(collectionHighlightingChooser.getSelectedIndex());
-        injectionPrefixTable.saveSettings(scalaProjectSettings);
-    }
-
-    @SuppressWarnings({"ConstantConditions", "RedundantIfStatement"})
-    public boolean isModified() {
-
-        final ScalaProjectSettings scalaProjectSettings = ScalaProjectSettings.getInstance(myProject);
-
-        if (!scalaProjectSettings.getBasePackage().equals(
-                myBasePackage.getText())) return true;
-        if (scalaProjectSettings.isShowImplisitConversions() !=
-                showImplicitConversionsInCheckBox.isSelected()) return true;
-        if (scalaProjectSettings.isShowArgumentsToByNameParams() !=
-                showArgumentsToByNameParametersCheckBox.isSelected()) return true;
-        if (scalaProjectSettings.isIncludeBlockExpressions() !=
-                includeBlockExpressionsExpressionsCheckBox.isSelected()) return true;
-        if (scalaProjectSettings.isIncludeLiterals() !=
-                includeLiteralsCheckBox.isSelected()) return true;
-
-        if (scalaProjectSettings.getImplicitParametersSearchDepth() !=
-                (Integer) implicitParametersSearchDepthSpinner.getValue()) return true;
-        if (scalaProjectSettings.getOutputLimit() !=
-                (Integer) outputSpinner.getValue()) return true;
-        if (scalaProjectSettings.isInProcessMode() !=
-                runWorksheetInTheCheckBox.isSelected()) return true;
-        if (scalaProjectSettings.isInteractiveMode() != worksheetInteractiveModeCheckBox.isSelected()) return true;
-
-        if (scalaProjectSettings.isSearchAllSymbols() !=
-                searchAllSymbolsIncludeCheckBox.isSelected()) return true;
-        if (scalaProjectSettings.isEnableJavaToScalaConversion() !=
-                enableConversionOnCopyCheckBox.isSelected()) return true;
-        if (scalaProjectSettings.isDontShowConversionDialog() !=
-                donTShowDialogCheckBox.isSelected()) return true;
-        if (scalaProjectSettings.isTreatDocCommentAsBlockComment() !=
-                treatDocCommentAsBlockComment.isSelected()) return true;
-
-        if (scalaProjectSettings.isIgnorePerformance() != myResolveToAllClassesCheckBox.isSelected())
-            return true;
-
-        if (scalaProjectSettings.isDisableLangInjection() != myDisableLanguageInjection.isSelected())
-            return true;
-
-
-        if (scalaProjectSettings.isDontCacheCompoundTypes() != myDontCacheCompound.isSelected()) return true;
-
-        if (scalaProjectSettings.isScalaPriority() != useScalaClassesPriorityCheckBox.isSelected())
-            return true;
-
-        if (scalaProjectSettings.getCollectionTypeHighlightingLevel() !=
-                collectionHighlightingChooser.getSelectedIndex()) return true;
-
-        if (injectionPrefixTable.isModified(scalaProjectSettings)) return true;
-
-        return false;
-    }
-
-    public JComponent getPanel() {
-        return myPanel;
-    }
-
-    protected void resetImpl() {
-        setSettings();
-    }
-
-    private void setSettings() {
-        final ScalaProjectSettings scalaProjectSettings = ScalaProjectSettings.getInstance(myProject);
-
-        setValue(myBasePackage, scalaProjectSettings.getBasePackage());
-        setValue(implicitParametersSearchDepthSpinner, scalaProjectSettings.getImplicitParametersSearchDepth());
-        setValue(outputSpinner, scalaProjectSettings.getOutputLimit());
-        setValue(runWorksheetInTheCheckBox, scalaProjectSettings.isInProcessMode());
-        setValue(worksheetInteractiveModeCheckBox, scalaProjectSettings.isInteractiveMode());
-
-        setValue(searchAllSymbolsIncludeCheckBox, scalaProjectSettings.isSearchAllSymbols());
-        setValue(enableConversionOnCopyCheckBox, scalaProjectSettings.isEnableJavaToScalaConversion());
-        setValue(donTShowDialogCheckBox, scalaProjectSettings.isDontShowConversionDialog());
-        setValue(treatDocCommentAsBlockComment, scalaProjectSettings.isTreatDocCommentAsBlockComment());
-
-        setValue(showImplicitConversionsInCheckBox, scalaProjectSettings.isShowImplisitConversions());
-        setValue(showArgumentsToByNameParametersCheckBox, scalaProjectSettings.isShowArgumentsToByNameParams());
-        setValue(includeBlockExpressionsExpressionsCheckBox, scalaProjectSettings.isIncludeBlockExpressions());
-        setValue(includeLiteralsCheckBox, scalaProjectSettings.isIncludeLiterals());
-
-        setValue(myResolveToAllClassesCheckBox, scalaProjectSettings.isIgnorePerformance());
-
-        setValue(myDisableLanguageInjection, scalaProjectSettings.isDisableLangInjection());
-        setValue(myDontCacheCompound, scalaProjectSettings.isDontCacheCompoundTypes());
-        setValue(useScalaClassesPriorityCheckBox, scalaProjectSettings.isScalaPriority());
-        collectionHighlightingChooser.setSelectedIndex(scalaProjectSettings.getCollectionTypeHighlightingLevel());
-
-        injectionPrefixTable.loadSettings(scalaProjectSettings);
-    }
-
-    private static void setValue(JSpinner spinner, int value) {
-        spinner.setValue(value);
-    }
-
-    private static void setValue(final JCheckBox box, final boolean value) {
-        box.setSelected(value);
-    }
-
-    private static void setValue(final JComboBox box, final int value) {
-        box.setSelectedIndex(value);
-    }
-
-    private static void setValue(final JTextField field, final String value) {
-        field.setText(value);
-    }
-
-    private void createUIComponents() {
-        injectionJPanel = new JPanel(new GridLayout(1, 1));
-        injectionJPanel.setPreferredSize(new Dimension(200, 500));
-        injectionJPanel.setBorder(BorderFactory.createEmptyBorder(5, 5, 0, 0));
-    }
-
-    /**
-     * Method generated by IntelliJ IDEA GUI Designer
-     * >>> IMPORTANT!! <<<
-     * DO NOT edit this method OR call it in your code!
-     *
-     * @noinspection ALL
-     */
-    private void $$$setupUI$$$() {
-        createUIComponents();
-        myPanel = new JPanel();
-        myPanel.setLayout(new GridLayoutManager(1, 1, new Insets(0, 0, 0, 0), -1, -1));
-        final JTabbedPane tabbedPane1 = new JTabbedPane();
-        myPanel.add(tabbedPane1, new GridConstraints(0, 0, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_BOTH, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, null, new Dimension(200, 200), null, 0, false));
-        final JPanel panel1 = new JPanel();
-        panel1.setLayout(new GridLayoutManager(20, 3, new Insets(9, 9, 0, 0), -1, -1));
-        tabbedPane1.addTab("Core", panel1);
-        searchAllSymbolsIncludeCheckBox = new JCheckBox();
-        searchAllSymbolsIncludeCheckBox.setText("Search all symbols (include locals)");
-        panel1.add(searchAllSymbolsIncludeCheckBox, new GridConstraints(1, 0, 1, 3, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
-        final JLabel label1 = new JLabel();
-        label1.setText("Java to Scala conversions settings:");
-        panel1.add(label1, new GridConstraints(2, 0, 1, 3, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_FIXED, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
-        enableConversionOnCopyCheckBox = new JCheckBox();
-        enableConversionOnCopyCheckBox.setSelected(true);
-        enableConversionOnCopyCheckBox.setText("Enable Conversion on Copy");
-        panel1.add(enableConversionOnCopyCheckBox, new GridConstraints(3, 0, 1, 3, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
-        donTShowDialogCheckBox = new JCheckBox();
-        donTShowDialogCheckBox.setText("Don't show dialog on paste and automatically convert to Scala code");
-        panel1.add(donTShowDialogCheckBox, new GridConstraints(4, 0, 1, 3, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
-        final JLabel label2 = new JLabel();
-        label2.setText("Highlighting options:");
-        panel1.add(label2, new GridConstraints(5, 0, 1, 3, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_FIXED, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
-        showImplicitConversionsInCheckBox = new JCheckBox();
-        showImplicitConversionsInCheckBox.setSelected(true);
-        showImplicitConversionsInCheckBox.setText("Highlight methods added via implicit conversion  in  code completion dialog");
-        panel1.add(showImplicitConversionsInCheckBox, new GridConstraints(6, 0, 1, 3, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
-        final JLabel label3 = new JLabel();
-        label3.setText("Performance-related options:");
-        panel1.add(label3, new GridConstraints(10, 0, 1, 3, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_FIXED, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
-        myResolveToAllClassesCheckBox = new JCheckBox();
-        myResolveToAllClassesCheckBox.setText("Resolve to all classes, even in wrong directories (this may cause performance problems)");
-        panel1.add(myResolveToAllClassesCheckBox, new GridConstraints(12, 0, 1, 3, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
-        showArgumentsToByNameParametersCheckBox = new JCheckBox();
-        showArgumentsToByNameParametersCheckBox.setSelected(true);
-        showArgumentsToByNameParametersCheckBox.setText("Highlight arguments to by-name parameters");
-        panel1.add(showArgumentsToByNameParametersCheckBox, new GridConstraints(7, 0, 1, 3, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
-        includeBlockExpressionsExpressionsCheckBox = new JCheckBox();
-        includeBlockExpressionsExpressionsCheckBox.setSelected(true);
-        includeBlockExpressionsExpressionsCheckBox.setText("Include block expressions");
-        includeBlockExpressionsExpressionsCheckBox.setToolTipText("Include expressions enclosed in in curly braces");
-        panel1.add(includeBlockExpressionsExpressionsCheckBox, new GridConstraints(8, 0, 1, 3, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 1, false));
-        includeLiteralsCheckBox = new JCheckBox();
-        includeLiteralsCheckBox.setSelected(true);
-        includeLiteralsCheckBox.setText("Include literals ");
-        includeLiteralsCheckBox.setToolTipText("Include string, number, etc");
-        panel1.add(includeLiteralsCheckBox, new GridConstraints(9, 0, 1, 3, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 1, false));
-        treatDocCommentAsBlockComment = new JCheckBox();
-        treatDocCommentAsBlockComment.setText("Disable parsing of documentation comments. This may improve editor performance for very large files. (SCL-2900)");
-        panel1.add(treatDocCommentAsBlockComment, new GridConstraints(13, 0, 1, 3, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
-        myDisableLanguageInjection = new JCheckBox();
-        myDisableLanguageInjection.setText("Disable language injection in Scala files (injected languages may freeze typing with auto popup completion)");
-        panel1.add(myDisableLanguageInjection, new GridConstraints(14, 0, 1, 3, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
-        final JLabel label4 = new JLabel();
-        label4.setText("Completion options:");
-        panel1.add(label4, new GridConstraints(16, 0, 1, 3, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_FIXED, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
-        useScalaClassesPriorityCheckBox = new JCheckBox();
-        useScalaClassesPriorityCheckBox.setSelected(true);
-        useScalaClassesPriorityCheckBox.setText("Use Scala classes priority over Java classes");
-        panel1.add(useScalaClassesPriorityCheckBox, new GridConstraints(17, 0, 1, 3, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
-        final JPanel panel2 = new JPanel();
-        panel2.setLayout(new GridLayoutManager(1, 1, new Insets(0, 0, 0, 0), -1, -1));
-        panel1.add(panel2, new GridConstraints(19, 2, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_BOTH, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, null, null, null, 0, false));
-        final JLabel label5 = new JLabel();
-        label5.setText("Implicit parameters search depth:");
-        panel1.add(label5, new GridConstraints(11, 0, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_FIXED, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
-        implicitParametersSearchDepthSpinner = new JSpinner();
-        panel1.add(implicitParametersSearchDepthSpinner, new GridConstraints(11, 1, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_HORIZONTAL, GridConstraints.SIZEPOLICY_WANT_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
-        myDontCacheCompound = new JCheckBox();
-        myDontCacheCompound.setText("Don't cache compound types (use it in case of big pauses in GC)");
-        panel1.add(myDontCacheCompound, new GridConstraints(15, 0, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
-        final JLabel label6 = new JLabel();
-        label6.setText("Base package clause:");
-        panel1.add(label6, new GridConstraints(0, 0, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_FIXED, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
-        myBasePackage = new JTextField();
-        myBasePackage.setColumns(50);
-        panel1.add(myBasePackage, new GridConstraints(0, 1, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_WANT_GROW, GridConstraints.SIZEPOLICY_FIXED, null, new Dimension(150, -1), null, 0, false));
-        final JLabel label7 = new JLabel();
-        this.$$$loadLabelText$$$(label7, ResourceBundle.getBundle("org/jetbrains/plugins/scala/ScalaBundle").getString("collection.type.highlighting.option"));
-        panel1.add(label7, new GridConstraints(18, 0, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_FIXED, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
-        collectionHighlightingChooser = new JComboBox();
-        final DefaultComboBoxModel defaultComboBoxModel1 = new DefaultComboBoxModel();
-        defaultComboBoxModel1.addElement("None");
-        defaultComboBoxModel1.addElement("Only non-qualified");
-        defaultComboBoxModel1.addElement("All");
-        collectionHighlightingChooser.setModel(defaultComboBoxModel1);
-        panel1.add(collectionHighlightingChooser, new GridConstraints(18, 1, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_HORIZONTAL, GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
-        panel1.add(injectionJPanel, new GridConstraints(19, 0, 1, 2, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_BOTH, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_WANT_GROW, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, null, null, null, 0, false));
-        final JPanel panel3 = new JPanel();
-        panel3.setLayout(new GridLayoutManager(4, 2, new Insets(9, 9, 0, 0), -1, -1));
-        tabbedPane1.addTab("Worksheet", panel3);
-        final Spacer spacer1 = new Spacer();
-        panel3.add(spacer1, new GridConstraints(3, 0, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_VERTICAL, 1, GridConstraints.SIZEPOLICY_WANT_GROW, null, null, null, 0, false));
-        runWorksheetInTheCheckBox = new JCheckBox();
-        runWorksheetInTheCheckBox.setSelected(true);
-        runWorksheetInTheCheckBox.setText("Run worksheet in the compiler process");
-        panel3.add(runWorksheetInTheCheckBox, new GridConstraints(1, 0, 1, 2, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
-        worksheetInteractiveModeCheckBox = new JCheckBox();
-        worksheetInteractiveModeCheckBox.setText("Run worksheet in the interactive mode");
-        panel3.add(worksheetInteractiveModeCheckBox, new GridConstraints(2, 0, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
-        final JLabel label8 = new JLabel();
-        label8.setText("Output cutoff limit: ");
-        panel3.add(label8, new GridConstraints(0, 0, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_FIXED, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
-        outputSpinner = new JSpinner();
-        panel3.add(outputSpinner, new GridConstraints(0, 1, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_WANT_GROW, GridConstraints.SIZEPOLICY_FIXED, null, new Dimension(218, 24), null, 0, false));
-    }
-
-    /**
-     * @noinspection ALL
-     */
-    private void $$$loadLabelText$$$(JLabel component, String text) {
-        StringBuffer result = new StringBuffer();
-        boolean haveMnemonic = false;
-        char mnemonic = '\0';
-        int mnemonicIndex = -1;
-        for (int i = 0; i < text.length(); i++) {
-            if (text.charAt(i) == '&') {
-                i++;
-                if (i == text.length()) break;
-                if (!haveMnemonic && text.charAt(i) != '&') {
-                    haveMnemonic = true;
-                    mnemonic = text.charAt(i);
-                    mnemonicIndex = result.length();
-                }
-            }
-            result.append(text.charAt(i));
-        }
-        component.setText(result.toString());
-        if (haveMnemonic) {
-            component.setDisplayedMnemonic(mnemonic);
-            component.setDisplayedMnemonicIndex(mnemonicIndex);
-        }
-    }
-
-    /**
-     * @noinspection ALL
-     */
-    public JComponent $$$getRootComponent$$$() {
-        return myPanel;
-    }
+  /**
+   * @noinspection ALL
+   */
+  public JComponent $$$getRootComponent$$$() {
+    return myPanel;
+  }
 }

--- a/src/org/jetbrains/plugins/scala/testingSupport/test/scalatest/ScalaTestTestFramework.scala
+++ b/src/org/jetbrains/plugins/scala/testingSupport/test/scalatest/ScalaTestTestFramework.scala
@@ -1,6 +1,9 @@
 package org.jetbrains.plugins.scala
 package testingSupport.test.scalatest
 
+import com.intellij.ide.DataManager
+import com.intellij.openapi.actionSystem.CommonDataKeys
+import org.jetbrains.plugins.scala.settings.ScalaProjectSettings
 import org.jetbrains.plugins.scala.testingSupport.test.AbstractTestFramework
 
 /**
@@ -10,7 +13,11 @@ import org.jetbrains.plugins.scala.testingSupport.test.AbstractTestFramework
 
 class ScalaTestTestFramework extends AbstractTestFramework {
 
-  def getDefaultSuperClass: String = "org.scalatest.FunSuite"
+  def getDefaultSuperClass: String = {
+    val project = CommonDataKeys.PROJECT.getData(DataManager.getInstance().getDataContext())
+    val scalaProjectSettings = ScalaProjectSettings.getInstance(project)
+    scalaProjectSettings.getScalaTestDefaultSuperClass
+  }
 
   def getName: String = "ScalaTest"
 

--- a/test/org/jetbrains/plugins/scala/annotator/TypeCollectionAnotatorTest.scala
+++ b/test/org/jetbrains/plugins/scala/annotator/TypeCollectionAnotatorTest.scala
@@ -1,7 +1,7 @@
 package org.jetbrains.plugins.scala
 package annotator
 
-import org.jetbrains.plugins.scala.base.ScalaLightPlatformCodeInsightTestCaseAdapter
+import org.jetbrains.plugins.scala.base.{TestScalaProjectSettings, ScalaLightPlatformCodeInsightTestCaseAdapter}
 import org.jetbrains.plugins.scala.highlighter.AnnotatorHighlighter
 import org.jetbrains.plugins.scala.lang.psi.api.ScalaFile
 import org.jetbrains.plugins.scala.lang.psi.api.base.ScReferenceElement
@@ -12,7 +12,7 @@ import org.jetbrains.plugins.scala.settings.ScalaProjectSettings
  * Date: 3/26/12
  */
 
-class TypeCollectionAnotatorTest extends ScalaLightPlatformCodeInsightTestCaseAdapter {
+class TypeCollectionAnotatorTest extends ScalaLightPlatformCodeInsightTestCaseAdapter with TestScalaProjectSettings {
   private val immutableCollectionMessage = ScalaBundle.message("scala.immutable.collection")
   private val mutableCollectionMessage = ScalaBundle.message("scala.mutable.collection")
   private val javaCollectionMessage = ScalaBundle.message("java.collection")
@@ -20,7 +20,7 @@ class TypeCollectionAnotatorTest extends ScalaLightPlatformCodeInsightTestCaseAd
   protected override def setUp() {
     super.setUp()
 
-    ScalaProjectSettings.getInstance(getProjectAdapter).
+    scalaProjectSettings.
       setCollectionTypeHighlightingLevel(ScalaProjectSettings.COLLECTION_TYPE_HIGHLIGHTING_ALL)
   }
 

--- a/test/org/jetbrains/plugins/scala/base/TestScalaProjectSettings.scala
+++ b/test/org/jetbrains/plugins/scala/base/TestScalaProjectSettings.scala
@@ -1,0 +1,12 @@
+package org.jetbrains.plugins.scala.base
+
+import org.jetbrains.plugins.scala.settings.ScalaProjectSettings
+
+trait TestScalaProjectSettings {
+
+  self: ScalaLightPlatformCodeInsightTestCaseAdapter =>
+
+  def scalaProjectSettings: ScalaProjectSettings =
+    ScalaProjectSettings.getInstance(getProjectAdapter)
+
+}

--- a/test/org/jetbrains/plugins/scala/testingSupport/test/scalatest/ScalaTestTestFrameworkTest.scala
+++ b/test/org/jetbrains/plugins/scala/testingSupport/test/scalatest/ScalaTestTestFrameworkTest.scala
@@ -1,0 +1,19 @@
+package org.jetbrains.plugins.scala.testingSupport.test.scalatest
+
+import junit.framework.Assert
+import org.jetbrains.plugins.scala.base.{ScalaLightPlatformCodeInsightTestCaseAdapter, TestScalaProjectSettings}
+
+class ScalaTestTestFrameworkTest extends ScalaLightPlatformCodeInsightTestCaseAdapter with TestScalaProjectSettings {
+
+  val scalaTestFramework = new ScalaTestTestFramework
+
+  def testDefaultSuperClass(): Unit = {
+
+    scalaProjectSettings.setScalaTestDefaultSuperClass("org.scalatest.FlatSpec")
+    Assert.assertEquals("org.scalatest.FlatSpec", scalaTestFramework.getDefaultSuperClass)
+
+    scalaProjectSettings.setScalaTestDefaultSuperClass("org.scalatest.WordSPec")
+    Assert.assertEquals("org.scalatest.WordSPec", scalaTestFramework.getDefaultSuperClass)
+  }
+
+}


### PR DESCRIPTION
ScalaTest offers many options for base classes, so if you always use one which is not FunSuite, then you have to change it in the dialog every time you create a test. 
New text field is added to Scala Project Settings panel.