### PR TITLE
trim (`l` | `L`) in the integer literal before base caculation

### DIFF
--- a/src/org/jetbrains/plugins/scala/annotator/ScalaAnnotator.scala
+++ b/src/org/jetbrains/plugins/scala/annotator/ScalaAnnotator.scala
@@ -1179,6 +1179,7 @@ class ScalaAnnotator extends Annotator with FunctionAnnotator with ScopeAnnotato
     val child = literal.getFirstChild.getNode
     val text = literal.getText
     val endsWithL = child.getText.endsWith('l') || child.getText.endsWith('L')
+    val textWithoutL = if (endsWithL) text.substring(0, text.length - 1) else text
     val parent = literal.getParent
     val scalaVersion = literal.scalaLanguageLevel
     val isNegative = parent match {
@@ -1186,7 +1187,7 @@ class ScalaAnnotator extends Annotator with FunctionAnnotator with ScopeAnnotato
       case prefixExpr: ScPrefixExpr if prefixExpr.getChildren.size == 2 && prefixExpr.getFirstChild.getText == "-" => true
       case _ => false
     }
-    val (number, base) = text match {
+    val (number, base) = textWithoutL match {
       case t if t.startsWith("0x") || t.startsWith("0X") => (t.substring(2), 16)
       case t if t.startsWith("0") && t.length >= 2 => (t.substring(1), 8)
       case _ => (text, 10)
@@ -1245,8 +1246,7 @@ class ScalaAnnotator extends Annotator with FunctionAnnotator with ScopeAnnotato
         case _ =>
       }
     }
-    val textWithoutL = if (endsWithL) number.substring(0, number.length - 1) else number
-    val (_, status) = parseIntegerNumber(textWithoutL, isNegative)
+    val (_, status) = parseIntegerNumber(number, isNegative)
     if (status == 2) { // the Integer number is out of range even for Long
       val error = "Integer number is out of range even for type Long"
       val annotation = holder.createErrorAnnotation(literal, error)

--- a/src/org/jetbrains/plugins/scala/lang/psi/impl/base/ScLiteralImpl.scala
+++ b/src/org/jetbrains/plugins/scala/lang/psi/impl/base/ScLiteralImpl.scala
@@ -97,6 +97,7 @@ class ScLiteralImpl(node: ASTNode) extends ScalaPsiElementImpl(node) with ScLite
         Character.valueOf(chars.charAt(0))
       case ScalaTokenTypes.tINTEGER =>
         val endsWithL = child.getText.endsWith('l') || child.getText.endsWith('L')
+        text = if (endsWithL) text.substring(0, text.length - 1) else text
         val (number, base) = text match {
           case t if t.startsWith("0x") || t.startsWith("0X") => (t.substring(2), 16)
           case t if t.startsWith("0") && t.length >= 2 => (t.substring(0), 8)
@@ -105,8 +106,7 @@ class ScLiteralImpl(node: ASTNode) extends ScalaPsiElementImpl(node) with ScLite
         val limit = if (endsWithL) java.lang.Long.MAX_VALUE else java.lang.Integer.MAX_VALUE
         val divider = if (base == 10) 1 else 2
         var value = 0l
-        text = if (endsWithL) number.substring(0, number.length - 1) else number
-        for (d <- text.map(_.asDigit)) {
+        for (d <- number.map(_.asDigit)) {
           if (value < 0 ||
               limit / (base / divider) < value / divider ||
               limit - (d / divider) < value * (base / divider)


### PR DESCRIPTION
This is a hot fix as some one reports error on issue https://youtrack.jetbrains.com/issue/SCL-7874.
