### PR TITLE
HOCON include resolution

### DIFF
--- a/resources/META-INF/HOCON.xml
+++ b/resources/META-INF/HOCON.xml
@@ -3,18 +3,24 @@
     <fileTypeFactory implementation="org.jetbrains.plugins.hocon.lang.HoconFileTypeFactory"/>
     <lang.syntaxHighlighterFactory key="HOCON"
                                    implementationClass="org.jetbrains.plugins.hocon.highlight.HoconSyntaxHighlighterFactory"/>
-    <lang.parserDefinition language="HOCON" implementationClass="org.jetbrains.plugins.hocon.parser.HoconParserDefinition"/>
+    <lang.parserDefinition language="HOCON"
+                           implementationClass="org.jetbrains.plugins.hocon.parser.HoconParserDefinition"/>
     <lang.braceMatcher language="HOCON" implementationClass="org.jetbrains.plugins.hocon.misc.HoconBraceMatcher"/>
     <lang.foldingBuilder language="HOCON" implementationClass="org.jetbrains.plugins.hocon.misc.HoconFoldingBuilder"/>
     <quoteHandler fileType="HOCON" className="org.jetbrains.plugins.hocon.misc.HoconQuoteHandler"/>
-    <annotator language="HOCON" implementationClass="org.jetbrains.plugins.hocon.highlight.HoconSyntaxHighlightingAnnotator"/>
-    <annotator language="HOCON" implementationClass="org.jetbrains.plugins.hocon.parser.HoconErrorHighlightingAnnotator"/>
+    <annotator language="HOCON"
+               implementationClass="org.jetbrains.plugins.hocon.highlight.HoconSyntaxHighlightingAnnotator"/>
+    <annotator language="HOCON"
+               implementationClass="org.jetbrains.plugins.hocon.parser.HoconErrorHighlightingAnnotator"/>
+
     <additionalTextAttributes scheme="Default" file="colorSchemes/HoconDefault.xml"/>
     <additionalTextAttributes scheme="Darcula" file="colorSchemes/HoconDarcula.xml"/>
     <colorSettingsPage implementation="org.jetbrains.plugins.hocon.highlight.HoconColorSettingsPage"/>
     <codeStyleSettingsProvider implementation="org.jetbrains.plugins.hocon.codestyle.HoconCodeStyleSettingsProvider"/>
-    <langCodeStyleSettingsProvider implementation="org.jetbrains.plugins.hocon.codestyle.HoconLanguageCodeStyleSettingsProvider"/>
-    <lang.formatter language="HOCON" implementationClass="org.jetbrains.plugins.hocon.formatting.HoconFormattingModelBuilder"/>
+    <langCodeStyleSettingsProvider
+        implementation="org.jetbrains.plugins.hocon.codestyle.HoconLanguageCodeStyleSettingsProvider"/>
+    <lang.formatter language="HOCON"
+                    implementationClass="org.jetbrains.plugins.hocon.formatting.HoconFormattingModelBuilder"/>
     <lang.commenter language="HOCON" implementationClass="org.jetbrains.plugins.hocon.misc.HoconCommenter"/>
     <lang.elementManipulator forClass="org.jetbrains.plugins.hocon.psi.HString"
                              implementationClass="org.jetbrains.plugins.hocon.manipulators.HStringManipulator"/>
@@ -22,5 +28,9 @@
     <projectService serviceInterface="org.jetbrains.plugins.hocon.settings.HoconProjectSettings"
                     serviceImplementation="org.jetbrains.plugins.hocon.settings.HoconProjectSettings"/>
     <projectConfigurable instance="org.jetbrains.plugins.hocon.settings.HoconProjectSettingsConfigurable"/>
+
+    <localInspection language="HOCON"
+                     implementationClass="org.jetbrains.plugins.hocon.ref.HoconIncludeResolutionInspection"
+                     displayName="HOCON include resolution" groupName="HOCON" enabledByDefault="true" level="WARNING"/>
   </extensions>
 </idea-plugin>

--- a/src/org/jetbrains/plugins/hocon/CommonUtil.scala
+++ b/src/org/jetbrains/plugins/hocon/CommonUtil.scala
@@ -1,14 +1,16 @@
 package org.jetbrains.plugins.hocon
 
-import java.{lang => jl}
+import java.net.{MalformedURLException, URL}
+import java.{lang => jl, util => ju}
 
 import com.intellij.lang.ASTNode
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.tree.{IElementType, TokenSet}
 
+import scala.collection.GenTraversableOnce
 import scala.language.implicitConversions
 
-object Util {
+object CommonUtil {
   implicit def liftSingleToken(token: IElementType): TokenSet = TokenSet.create(token)
 
   implicit class TokenSetOps(val tokenSet: TokenSet) {
@@ -27,7 +29,7 @@ object Util {
     val extractor = this
   }
 
-  implicit def token2TokenSetOps(token: IElementType) = new TokenSetOps(token)
+  implicit def token2TokenSetOps(token: IElementType): TokenSetOps = new TokenSetOps(token)
 
   implicit class CharSequenceOps(val cs: CharSequence) extends AnyVal {
     def startsWith(str: String) =
@@ -56,6 +58,14 @@ object Util {
 
   implicit class any2opt[T](val t: T) extends AnyVal {
     def opt = Option(t)
+  }
+
+  implicit class collectionOps[A](val coll: GenTraversableOnce[A]) extends AnyVal {
+    def toJList[B >: A]: ju.List[B] = {
+      val result = new ju.ArrayList[B]
+      coll.foreach(result.add)
+      result
+    }
   }
 
   private val quotedCharPattern = "\\\\[\\\\\"/bfnrt]".r
@@ -87,4 +97,11 @@ object Util {
       com.intellij.openapi.util.TextRange.create(start, end)
   }
 
+  def isValidUrl(str: String) =
+    try {
+      new URL(str)
+      true
+    } catch {
+      case _: MalformedURLException => false
+    }
 }

--- a/src/org/jetbrains/plugins/hocon/HoconConstants.scala
+++ b/src/org/jetbrains/plugins/hocon/HoconConstants.scala
@@ -1,0 +1,20 @@
+package org.jetbrains.plugins.hocon
+
+import com.intellij.json.JsonFileType
+import com.intellij.lang.properties.PropertiesFileType
+import org.jetbrains.plugins.hocon.lang.HoconFileType
+
+object HoconConstants {
+  final val UrlQualifier = "url("
+  final val FileQualifier = "file("
+  final val ClasspathQualifier = "classpath("
+
+  final val IncludeQualifiers = Set(UrlQualifier, ClasspathQualifier, FileQualifier)
+  final val IntegerPattern = """-?(0|[1-9][0-9]*)""".r
+  final val DecimalPartPattern = """([0-9]+)((e|E)(\+|-)?[0-9]+)?""".r
+  final val ProperlyClosedQuotedString = ".*[^\\\\](\\\\\\\\)*\"".r
+
+  final val ConfExt = "." + HoconFileType.DefaultExtension
+  final val JsonExt = "." + JsonFileType.DEFAULT_EXTENSION
+  final val PropsExt = "." + PropertiesFileType.DEFAULT_EXTENSION
+}

--- a/src/org/jetbrains/plugins/hocon/formatting/HoconBlock.scala
+++ b/src/org/jetbrains/plugins/hocon/formatting/HoconBlock.scala
@@ -13,7 +13,7 @@ import scala.collection.JavaConverters._
 class HoconBlock(formatter: HoconFormatter, node: ASTNode, indent: Indent, wrap: Wrap, alignment: Alignment)
         extends AbstractBlock(node, wrap, alignment) {
 
-  import org.jetbrains.plugins.hocon.Util._
+  import org.jetbrains.plugins.hocon.CommonUtil._
 
   // HoconFormatter needs these to be able to return exactly the same instances of Wrap and Alignment for
   // children of this block

--- a/src/org/jetbrains/plugins/hocon/formatting/HoconFormatter.scala
+++ b/src/org/jetbrains/plugins/hocon/formatting/HoconFormatter.scala
@@ -9,7 +9,7 @@ import org.jetbrains.plugins.hocon.lang.HoconLanguage
 
 class HoconFormatter(settings: CodeStyleSettings) {
 
-  import org.jetbrains.plugins.hocon.Util._
+  import org.jetbrains.plugins.hocon.CommonUtil._
   import org.jetbrains.plugins.hocon.lexer.HoconTokenSets._
   import org.jetbrains.plugins.hocon.lexer.HoconTokenType._
   import org.jetbrains.plugins.hocon.parser.HoconElementSets._

--- a/src/org/jetbrains/plugins/hocon/highlight/HoconSyntaxHighlightingAnnotator.scala
+++ b/src/org/jetbrains/plugins/hocon/highlight/HoconSyntaxHighlightingAnnotator.scala
@@ -2,11 +2,12 @@ package org.jetbrains.plugins.hocon.highlight
 
 import com.intellij.lang.annotation.{AnnotationHolder, Annotator}
 import com.intellij.psi.PsiElement
+import org.jetbrains.plugins.hocon.HoconConstants
 import org.jetbrains.plugins.hocon.parser.HoconPsiParser
 
 class HoconSyntaxHighlightingAnnotator extends Annotator {
 
-  import org.jetbrains.plugins.hocon.Util._
+  import org.jetbrains.plugins.hocon.CommonUtil._
   import org.jetbrains.plugins.hocon.lexer.HoconTokenType._
   import org.jetbrains.plugins.hocon.parser.HoconElementSets._
   import org.jetbrains.plugins.hocon.parser.HoconElementType._
@@ -28,7 +29,7 @@ class HoconSyntaxHighlightingAnnotator extends Annotator {
         holder.createInfoAnnotation(element, null).setTextAttributes(HoconHighlighterColors.Include)
 
       case UnquotedChars if parentType == Included =>
-        if (HoconPsiParser.IncludeQualifiers.contains(element.getText)) {
+        if (HoconConstants.IncludeQualifiers.contains(element.getText)) {
           val TextRange(start, end) = element.getTextRange
           holder.createInfoAnnotation(TextRange(start, end - 1), null).setTextAttributes(HoconHighlighterColors.IncludeModifier)
           holder.createInfoAnnotation(TextRange(end - 1, end), null).setTextAttributes(HoconHighlighterColors.IncludeModifierParens)

--- a/src/org/jetbrains/plugins/hocon/lang/HoconFileType.scala
+++ b/src/org/jetbrains/plugins/hocon/lang/HoconFileType.scala
@@ -3,7 +3,7 @@ package org.jetbrains.plugins.hocon.lang
 import com.intellij.icons.AllIcons
 import com.intellij.openapi.fileTypes.LanguageFileType
 
-object HoconLanguageFileType extends LanguageFileType(HoconLanguage) {
+object HoconFileType extends LanguageFileType(HoconLanguage) {
   val DefaultExtension = "conf"
 
   def getIcon = AllIcons.FileTypes.Config

--- a/src/org/jetbrains/plugins/hocon/lang/HoconFileTypeFactory.scala
+++ b/src/org/jetbrains/plugins/hocon/lang/HoconFileTypeFactory.scala
@@ -4,5 +4,5 @@ import com.intellij.openapi.fileTypes.{FileTypeConsumer, FileTypeFactory}
 
 class HoconFileTypeFactory extends FileTypeFactory {
   def createFileTypes(consumer: FileTypeConsumer) =
-    consumer.consume(HoconLanguageFileType, HoconLanguageFileType.DefaultExtension)
+    consumer.consume(HoconFileType, HoconFileType.DefaultExtension)
 }

--- a/src/org/jetbrains/plugins/hocon/lexer/HoconLexer.scala
+++ b/src/org/jetbrains/plugins/hocon/lexer/HoconLexer.scala
@@ -24,7 +24,7 @@ object HoconLexer {
 
 class HoconLexer extends LexerBase {
 
-  import org.jetbrains.plugins.hocon.Util._
+  import org.jetbrains.plugins.hocon.CommonUtil._
   import org.jetbrains.plugins.hocon.lexer.HoconLexer._
   import org.jetbrains.plugins.hocon.lexer.HoconTokenType._
 

--- a/src/org/jetbrains/plugins/hocon/lexer/HoconTokenSets.scala
+++ b/src/org/jetbrains/plugins/hocon/lexer/HoconTokenSets.scala
@@ -6,7 +6,7 @@ import scala.language.implicitConversions
 
 object HoconTokenSets {
 
-  import org.jetbrains.plugins.hocon.Util._
+  import org.jetbrains.plugins.hocon.CommonUtil._
   import org.jetbrains.plugins.hocon.lexer.HoconTokenType._
 
   val Empty = TokenSet.EMPTY

--- a/src/org/jetbrains/plugins/hocon/misc/HoconBraceMatcher.scala
+++ b/src/org/jetbrains/plugins/hocon/misc/HoconBraceMatcher.scala
@@ -6,7 +6,7 @@ import com.intellij.psi.tree.IElementType
 
 class HoconBraceMatcher extends PairedBraceMatcher {
 
-  import org.jetbrains.plugins.hocon.Util._
+  import org.jetbrains.plugins.hocon.CommonUtil._
   import org.jetbrains.plugins.hocon.lexer.HoconTokenSets._
   import org.jetbrains.plugins.hocon.lexer.HoconTokenType._
 

--- a/src/org/jetbrains/plugins/hocon/parser/HoconElementSets.scala
+++ b/src/org/jetbrains/plugins/hocon/parser/HoconElementSets.scala
@@ -4,7 +4,7 @@ import com.intellij.psi.TokenType
 
 object HoconElementSets {
 
-  import org.jetbrains.plugins.hocon.Util._
+  import org.jetbrains.plugins.hocon.CommonUtil._
   import org.jetbrains.plugins.hocon.parser.HoconElementType._
 
   val Path = FieldPath | SubstitutionPath

--- a/src/org/jetbrains/plugins/hocon/parser/HoconErrorHighlightingAnnotator.scala
+++ b/src/org/jetbrains/plugins/hocon/parser/HoconErrorHighlightingAnnotator.scala
@@ -10,7 +10,7 @@ import scala.annotation.tailrec
 
 class HoconErrorHighlightingAnnotator extends Annotator {
 
-  import org.jetbrains.plugins.hocon.Util._
+  import org.jetbrains.plugins.hocon.CommonUtil._
   import org.jetbrains.plugins.hocon.lexer.HoconTokenType._
   import org.jetbrains.plugins.hocon.parser.HoconElementType._
 

--- a/src/org/jetbrains/plugins/hocon/parser/HoconPsiParser.scala
+++ b/src/org/jetbrains/plugins/hocon/parser/HoconPsiParser.scala
@@ -7,24 +7,16 @@ import com.intellij.lang.PsiBuilder.Marker
 import com.intellij.lang.WhitespacesAndCommentsBinder.TokenTextGetter
 import com.intellij.lang.{PsiBuilder, PsiParser, WhitespacesAndCommentsBinder, WhitespacesBinders}
 import com.intellij.psi.tree.IElementType
+import org.jetbrains.plugins.hocon.HoconConstants._
+import org.jetbrains.plugins.hocon.CommonUtil._
+import org.jetbrains.plugins.hocon.lexer.HoconTokenSets._
+import org.jetbrains.plugins.hocon.lexer.HoconTokenType._
+import org.jetbrains.plugins.hocon.parser.HoconElementType._
 
 import scala.annotation.tailrec
 import scala.util.matching.Regex
 
-object HoconPsiParser {
-  val IncludeQualifiers = Set("url(", "classpath(", "file(")
-  val IntegerPattern = """-?(0|[1-9][0-9]*)""".r
-  val DecimalPartPattern = """([0-9]+)((e|E)(\+|-)?[0-9]+)?""".r
-  val ProperlyClosedQuotedString = ".*[^\\\\](\\\\\\\\)*\"".r
-}
-
 class HoconPsiParser extends PsiParser {
-
-  import org.jetbrains.plugins.hocon.Util._
-  import org.jetbrains.plugins.hocon.lexer.HoconTokenSets._
-  import org.jetbrains.plugins.hocon.lexer.HoconTokenType._
-  import org.jetbrains.plugins.hocon.parser.HoconElementType._
-  import org.jetbrains.plugins.hocon.parser.HoconPsiParser._
 
   def parse(root: IElementType, builder: PsiBuilder) = {
     val file = builder.mark()
@@ -191,7 +183,7 @@ class HoconPsiParser extends PsiParser {
         val qualifier = builder.getTokenText
         advanceLexer()
         if (matches(QuotedString)) {
-          if (qualifier == "url(") {
+          if (qualifier == UrlQualifier) {
             try {
               new URL(unquote(builder.getTokenText))
               parseStringLiteral()

--- a/src/org/jetbrains/plugins/hocon/psi/HoconElementVisitor.scala
+++ b/src/org/jetbrains/plugins/hocon/psi/HoconElementVisitor.scala
@@ -1,0 +1,47 @@
+package org.jetbrains.plugins.hocon.psi
+
+import com.intellij.psi.PsiElementVisitor
+
+class HoconElementVisitor extends PsiElementVisitor {
+  def visitHoconFile(element: HoconPsiFile) = visitFile(element)
+
+  def visitHoconElement(element: HoconPsiElement) = visitElement(element)
+
+  def visitHValue(element: HValue) = visitHoconElement(element)
+
+  def visitHLiteral(element: HLiteral) = visitHValue(element)
+
+  def visitHNull(element: HNull) = visitHLiteral(element)
+
+  def visitHBoolean(element: HBoolean) = visitHLiteral(element)
+
+  def visitHNumber(element: HNumber) = visitHLiteral(element)
+
+  def visitHString(element: HString) = visitHLiteral(element)
+
+  def visitHObject(element: HObject) = visitHValue(element)
+
+  def visitHArray(element: HArray) = visitHValue(element)
+
+  def visitHSubstitution(element: HSubstitution) = visitHValue(element)
+
+  def visitHConcatenation(element: HConcatenation) = visitHValue(element)
+
+  def visitHObjectEntry(element: HObjectEntry) = visitHoconElement(element)
+
+  def visitHObjectField(element: HObjectField) = visitHObjectEntry(element)
+
+  def visitHInclude(element: HInclude) = visitHObjectEntry(element)
+
+  def visitHObjectEntries(element: HObjectEntries) = visitHoconElement(element)
+
+  def visitHBareObjectField(element: HBareObjectField) = visitHoconElement(element)
+
+  def visitHIncluded(element: HIncluded) = visitHoconElement(element)
+
+  def visitHKey(element: HKey) = visitHoconElement(element)
+
+  def visitHPath(element: HPath) = visitHoconElement(element)
+
+  def visitHUnquotedString(element: HUnquotedString) = visitHoconElement(element)
+}

--- a/src/org/jetbrains/plugins/hocon/psi/HoconPsiElement.scala
+++ b/src/org/jetbrains/plugins/hocon/psi/HoconPsiElement.scala
@@ -1,14 +1,32 @@
 package org.jetbrains.plugins.hocon.psi
 
+import java.{lang => jl}
+
 import com.intellij.extapi.psi.ASTWrapperPsiElement
 import com.intellij.lang.ASTNode
-import com.intellij.psi.{ContributedReferenceHost, PsiComment, PsiReferenceService}
+import com.intellij.openapi.util.text.StringUtil
+import com.intellij.psi._
+import com.intellij.psi.impl.source.resolve.reference.impl.providers.FileReference
+import org.jetbrains.plugins.hocon.CommonUtil._
+import org.jetbrains.plugins.hocon.HoconConstants
+import org.jetbrains.plugins.hocon.HoconConstants._
 import org.jetbrains.plugins.hocon.lexer.{HoconTokenSets, HoconTokenType}
-import org.jetbrains.plugins.hocon.parser.HoconPsiParser
+import org.jetbrains.plugins.hocon.parser.HoconElementType
+import org.jetbrains.plugins.hocon.ref.IncludedFileReferenceSet
 
 import scala.reflect.{ClassTag, classTag}
 
 sealed abstract class HoconPsiElement(ast: ASTNode) extends ASTWrapperPsiElement(ast) {
+  override def accept(visitor: PsiElementVisitor) = visitor match {
+    case hoconVisitor: HoconElementVisitor => accept(hoconVisitor)
+    case _ => super.accept(visitor)
+  }
+
+  def accept(visitor: HoconElementVisitor) = visitor.visitHoconElement(this)
+
+  def elementType =
+    getNode.getElementType
+
   def getChild[T <: HoconPsiElement : ClassTag]: T =
     findChildByClass(classTag[T].runtimeClass.asInstanceOf[Class[T]])
 
@@ -17,6 +35,12 @@ sealed abstract class HoconPsiElement(ast: ASTNode) extends ASTWrapperPsiElement
 
   def allChildren =
     Iterator.iterate(getFirstChild)(_.getNextSibling).takeWhile(_ != null)
+
+  def prevSiblings =
+    Iterator.iterate(getPrevSibling)(_.getPrevSibling).takeWhile(_ != null)
+
+  def nextSiblings =
+    Iterator.iterate(getNextSibling)(_.getNextSibling).takeWhile(_ != null)
 
   def nonWhitespaceChildren =
     allChildren.filterNot(ch => HoconTokenSets.Whitespace.contains(ch.getNode.getElementType))
@@ -29,7 +53,7 @@ sealed abstract class HoconPsiElement(ast: ASTNode) extends ASTWrapperPsiElement
 
 sealed trait HValue extends HoconPsiElement
 
-sealed trait HLiteral extends HValue
+sealed trait HLiteral extends HValue with PsiLiteral
 
 sealed trait HObjectEntry extends HoconPsiElement
 
@@ -39,6 +63,8 @@ final class HObjectEntries(ast: ASTNode) extends HoconPsiElement(ast) {
   def fields = findChildren[HObjectField]
 
   def includes = findChildren[HInclude]
+
+  override def accept(visitor: HoconElementVisitor) = visitor.visitHObjectEntries(this)
 }
 
 final class HObjectField(ast: ASTNode) extends HoconPsiElement(ast) with HObjectEntry {
@@ -53,55 +79,166 @@ final class HObjectField(ast: ASTNode) extends HoconPsiElement(ast) with HObject
   def value = bareField.value
 
   def separator = bareField.separator
+
+  override def accept(visitor: HoconElementVisitor) = visitor.visitHObjectField(this)
 }
 
 final class HBareObjectField(ast: ASTNode) extends HoconPsiElement(ast) {
-  def path = findChild[HPath]
+  def path = getChild[HPath]
 
   def value = findChild[HValue]
 
   def separator = Option(findChildByType(HoconTokenSets.PathValueSeparator))
           .map(_.getNode.getElementType.asInstanceOf[HoconTokenType])
+
+  override def accept(visitor: HoconElementVisitor) = visitor.visitHBareObjectField(this)
 }
 
-final class HInclude(ast: ASTNode) extends HoconPsiElement(ast) with HObjectEntry
+final class HInclude(ast: ASTNode) extends HoconPsiElement(ast) with HObjectEntry {
+  def included = getChild[HIncluded]
 
-final class HIncluded(ast: ASTNode) extends HoconPsiElement(ast)
+  override def accept(visitor: HoconElementVisitor) = visitor.visitHInclude(this)
+}
 
-final class HKey(ast: ASTNode) extends HoconPsiElement(ast)
+final class HIncluded(ast: ASTNode) extends HoconPsiElement(ast) {
+  def qualifier = getFirstChild.getNode.getElementType match {
+    case HoconTokenType.UnquotedChars =>
+      Some(getFirstChild.getText)
+    case _ => None
+  }
 
-final class HPath(ast: ASTNode) extends HoconPsiElement(ast)
+  def target =
+    findChild[HString].filter(_.stringType == HoconTokenType.QuotedString)
+
+  def fileReferenceSet = target.flatMap { hs =>
+    val strVal = hs.stringValue
+    def refSet(absolute: Boolean) =
+      new IncludedFileReferenceSet(strVal, hs, absolute)
+
+    // com.typesafe.config.impl.SimpleIncluder#includeWithoutFallback
+    qualifier match {
+      case Some(ClasspathQualifier) =>
+        Some(refSet(absolute = true))
+      case None if !isValidUrl(strVal) =>
+        Some(refSet(absolute = false))
+      case _ =>
+        None
+    }
+  }
+
+  override def accept(visitor: HoconElementVisitor) =
+    visitor.visitHIncluded(this)
+}
+
+final class HKey(ast: ASTNode) extends HoconPsiElement(ast) {
+  override def accept(visitor: HoconElementVisitor) = visitor.visitHKey(this)
+}
+
+final class HPath(ast: ASTNode) extends HoconPsiElement(ast) {
+  def prefix = findChild[HPath]
+
+  def key = findChild[HKey]
+
+  override def accept(visitor: HoconElementVisitor) = visitor.visitHPath(this)
+}
 
 final class HObject(ast: ASTNode) extends HoconPsiElement(ast) with HValue {
   def entries = getChild[HObjectEntries]
+
+  override def accept(visitor: HoconElementVisitor) = visitor.visitHObject(this)
 }
 
-final class HArray(ast: ASTNode) extends HoconPsiElement(ast) with HValue
+final class HArray(ast: ASTNode) extends HoconPsiElement(ast) with HValue {
+  override def accept(visitor: HoconElementVisitor) = visitor.visitHArray(this)
+}
 
-final class HSubstitution(ast: ASTNode) extends HoconPsiElement(ast) with HValue
+final class HSubstitution(ast: ASTNode) extends HoconPsiElement(ast) with HValue {
+  override def accept(visitor: HoconElementVisitor) = visitor.visitHSubstitution(this)
+}
 
-final class HConcatenation(ast: ASTNode) extends HoconPsiElement(ast) with HValue
+final class HConcatenation(ast: ASTNode) extends HoconPsiElement(ast) with HValue {
+  override def accept(visitor: HoconElementVisitor) = visitor.visitHConcatenation(this)
+}
 
-final class HNull(ast: ASTNode) extends HoconPsiElement(ast) with HLiteral
+final class HNull(ast: ASTNode) extends HoconPsiElement(ast) with HLiteral {
+  def getValue: Object = null
 
-final class HBoolean(ast: ASTNode) extends HoconPsiElement(ast) with HLiteral
+  override def accept(visitor: HoconElementVisitor) = visitor.visitHNull(this)
+}
 
-final class HNumber(ast: ASTNode) extends HoconPsiElement(ast) with HLiteral
+final class HBoolean(ast: ASTNode) extends HoconPsiElement(ast) with HLiteral {
+  def getValue: Object = jl.Boolean.valueOf(booleanValue)
 
-final class HUnquotedString(ast: ASTNode) extends HoconPsiElement(ast)
+  def booleanValue = getText.toBoolean
+
+  override def accept(visitor: HoconElementVisitor) = visitor.visitHBoolean(this)
+}
+
+final class HNumber(ast: ASTNode) extends HoconPsiElement(ast) with HLiteral {
+  def getValue: Object = numberValue
+
+  def numberValue: jl.Number =
+    if (getText.exists(HNumber.DecimalIndicators.contains))
+      jl.Double.parseDouble(getText)
+    else
+      jl.Long.parseLong(getText)
+
+  override def accept(visitor: HoconElementVisitor) =
+    visitor.visitHNumber(this)
+}
+
+object HNumber {
+  private final val DecimalIndicators = Set('.', 'e', 'E')
+}
+
+final class HUnquotedString(ast: ASTNode) extends HoconPsiElement(ast) {
+  override def accept(visitor: HoconElementVisitor) = visitor.visitHUnquotedString(this)
+}
 
 final class HString(ast: ASTNode) extends HoconPsiElement(ast) with HLiteral with ContributedReferenceHost {
   def stringType = getFirstChild.getNode.getElementType
 
+  def getValue: Object = stringValue
+
+  def unquote = stringType match {
+    case HoconTokenType.QuotedString =>
+      getText.substring(1, getText.length - (if (isClosed) 1 else 0))
+    case HoconTokenType.MultilineString =>
+      getText.substring(3, getText.length - (if (isClosed) 3 else 0))
+    case HoconElementType.UnquotedString =>
+      getText
+  }
+
+  def stringValue = stringType match {
+    case HoconTokenType.QuotedString =>
+      StringUtil.unescapeStringCharacters(unquote)
+    case _ =>
+      unquote
+  }
+
   def isClosed = stringType match {
     case HoconTokenType.QuotedString =>
-      HoconPsiParser.ProperlyClosedQuotedString.pattern.matcher(getText).matches
+      HoconConstants.ProperlyClosedQuotedString.pattern.matcher(getText).matches
     case HoconTokenType.MultilineString =>
       getText.endsWith("\"\"\"")
     case _ =>
       true
   }
 
+  def isIncludeTarget =
+    stringType == HoconTokenType.QuotedString &&
+            getParent.getNode.getElementType == HoconElementType.Included
+
+  def getFileReferences =
+    if (isIncludeTarget)
+      getParent.asInstanceOf[HIncluded].fileReferenceSet
+              .map(_.getAllReferences).getOrElse(FileReference.EMPTY)
+    else
+      FileReference.EMPTY
+
   override def getReferences =
     PsiReferenceService.getService.getContributedReferences(this)
+
+  override def accept(visitor: HoconElementVisitor) =
+    visitor.visitHString(this)
 }

--- a/src/org/jetbrains/plugins/hocon/psi/HoconPsiElementFactory.scala
+++ b/src/org/jetbrains/plugins/hocon/psi/HoconPsiElementFactory.scala
@@ -1,7 +1,7 @@
 package org.jetbrains.plugins.hocon.psi
 
 import com.intellij.psi.{PsiFileFactory, PsiManager}
-import org.jetbrains.plugins.hocon.lang.HoconLanguageFileType
+import org.jetbrains.plugins.hocon.lang.HoconFileType
 
 object HoconPsiElementFactory {
   private val Dummy = "dummy."
@@ -9,7 +9,7 @@ object HoconPsiElementFactory {
   def createString(contents: String, manager: PsiManager): HString = {
     val text = s"k = $contents"
     val dummyFile = PsiFileFactory.getInstance(manager.getProject)
-            .createFileFromText(Dummy + HoconLanguageFileType.DefaultExtension, HoconLanguageFileType, text)
+            .createFileFromText(Dummy + HoconFileType.DefaultExtension, HoconFileType, text)
     dummyFile.getFirstChild.getFirstChild.getFirstChild.getLastChild.asInstanceOf[HString]
   }
 

--- a/src/org/jetbrains/plugins/hocon/psi/HoconPsiFile.scala
+++ b/src/org/jetbrains/plugins/hocon/psi/HoconPsiFile.scala
@@ -3,15 +3,17 @@ package org.jetbrains.plugins.hocon.psi
 import com.intellij.openapi.fileTypes.FileType
 import com.intellij.psi.impl.source.PsiFileImpl
 import com.intellij.psi.{FileViewProvider, PsiElementVisitor}
-import org.jetbrains.plugins.hocon.lang.HoconLanguageFileType
+import org.jetbrains.plugins.hocon.lang.HoconFileType
 import org.jetbrains.plugins.hocon.parser.HoconElementType.HoconFileElementType
 
 class HoconPsiFile(provider: FileViewProvider) extends PsiFileImpl(HoconFileElementType, HoconFileElementType, provider) {
-  def accept(visitor: PsiElementVisitor): Unit =
-    visitor.visitFile(this)
+  def accept(visitor: PsiElementVisitor): Unit = visitor match {
+    case hoconVisitor: HoconElementVisitor => hoconVisitor.visitHoconFile(this)
+    case _ => visitor.visitFile(this)
+  }
 
   def getFileType: FileType =
-    HoconLanguageFileType
+    HoconFileType
 
   def toplevelEntries = getFirstChild match {
     case obj: HObject => obj.entries

--- a/src/org/jetbrains/plugins/hocon/ref/HoconIncludeResolutionInspection.scala
+++ b/src/org/jetbrains/plugins/hocon/ref/HoconIncludeResolutionInspection.scala
@@ -1,0 +1,17 @@
+package org.jetbrains.plugins.hocon.ref
+
+import com.intellij.codeInspection.{LocalInspectionTool, ProblemHighlightType, ProblemsHolder}
+import org.jetbrains.plugins.hocon.psi.{HString, HoconElementVisitor}
+
+class HoconIncludeResolutionInspection extends LocalInspectionTool {
+  override def buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean) =
+    new HoconElementVisitor {
+      override def visitHString(element: HString) =
+        element.getFileReferences.foreach { ref =>
+          if (!ref.isSoft && ref.multiResolve(false).isEmpty) {
+            holder.registerProblem(ref, ProblemsHolder.unresolvedReferenceMessage(ref),
+              ProblemHighlightType.LIKE_UNKNOWN_SYMBOL)
+          }
+        }
+    }
+}

--- a/src/org/jetbrains/plugins/hocon/ref/HoconReferenceContributor.scala
+++ b/src/org/jetbrains/plugins/hocon/ref/HoconReferenceContributor.scala
@@ -2,10 +2,12 @@ package org.jetbrains.plugins.hocon.ref
 
 import com.intellij.patterns.PlatformPatterns
 import com.intellij.psi.{PsiReferenceContributor, PsiReferenceRegistrar}
-import org.jetbrains.plugins.hocon.psi.HString
+import org.jetbrains.plugins.hocon.psi.{HIncluded, HString}
 
 class HoconReferenceContributor extends PsiReferenceContributor {
   def registerReferenceProviders(registrar: PsiReferenceRegistrar): Unit = {
-    registrar.registerReferenceProvider(PlatformPatterns.psiElement(classOf[HString]), new HStringJavaClassReferenceProvider)
+    val hStringPattern = PlatformPatterns.psiElement(classOf[HString])
+    registrar.registerReferenceProvider(hStringPattern, new HStringJavaClassReferenceProvider)
+    registrar.registerReferenceProvider(hStringPattern.withParent(classOf[HIncluded]), new IncludedFileReferenceProvider)
   }
 }

--- a/src/org/jetbrains/plugins/hocon/ref/IncludedFileReferenceProvider.scala
+++ b/src/org/jetbrains/plugins/hocon/ref/IncludedFileReferenceProvider.scala
@@ -1,0 +1,13 @@
+package org.jetbrains.plugins.hocon.ref
+
+import com.intellij.psi.{PsiElement, PsiReference, PsiReferenceProvider}
+import com.intellij.util.ProcessingContext
+import org.jetbrains.plugins.hocon.psi.HString
+
+class IncludedFileReferenceProvider extends PsiReferenceProvider {
+  def getReferencesByElement(element: PsiElement, context: ProcessingContext) = element match {
+    case hs: HString if hs.isIncludeTarget =>
+      hs.getFileReferences.asInstanceOf[Array[PsiReference]]
+    case _ => PsiReference.EMPTY_ARRAY
+  }
+}

--- a/src/org/jetbrains/plugins/hocon/ref/IncludedFileReferenceSet.scala
+++ b/src/org/jetbrains/plugins/hocon/ref/IncludedFileReferenceSet.scala
@@ -1,0 +1,124 @@
+package org.jetbrains.plugins.hocon.ref
+
+import java.{lang => jl, util => ju}
+
+import com.intellij.openapi.roots._
+import com.intellij.openapi.roots.impl.DirectoryIndex
+import com.intellij.openapi.util.{Condition, TextRange}
+import com.intellij.psi._
+import com.intellij.psi.impl.source.resolve.reference.impl.providers.{FileReference, FileReferenceSet}
+import org.jetbrains.plugins.hocon.CommonUtil._
+import org.jetbrains.plugins.hocon.HoconConstants._
+
+import scala.collection.JavaConverters._
+
+/**
+ * FileReferenceSet subclass that tries to simulate how Typesafe Config handles includes with its
+ * default includer implementation, <tt>com.typesafe.config.impl.SimpleIncluder</tt> -
+ * as much as this is possible without access to actual runtime.
+ * <p/>
+ * This implementation will only try to resolve includes with <tt>classpath(...)</tt> qualifier or no qualifier -
+ * that is, <tt>file(...)</tt> and <tt>url(...)</tt> are not supported since they can only be understood at runtime.
+ * Also, for heuristic include (no qualifier), it is assumed that including file was loaded from classpath resource
+ * and thus, included path will be interpreted as classpath resource relative to current file.
+ * <p/>
+ * Files to include will be searched for in classpath of including file's containing module or - when including file
+ * is in a library - joined classpath of all modules that directly depend on that library. Test sources and dependencies
+ * are searched only when including file is also a test source or lies in a test dependency.
+ * <p/>
+ * Just like Typesafe Config, this implementation will try to guess extension of included resource to be either
+ * <tt>.conf</tt>, <tt>.json</tt> or <tt>.properties</tt>. It is impossible to include a file with any other extension.
+ * This constraint is also reflected by appropriate completion filter.
+ */
+class IncludedFileReferenceSet(text: String, element: PsiElement, absolute: Boolean)
+        extends FileReferenceSet(text, element, 1, null, true) {
+
+  setEmptyPathAllowed(false)
+
+  override def isAbsolutePathReference: Boolean =
+    absolute || super.isAbsolutePathReference
+
+  override def couldBeConvertedTo(relative: Boolean): Boolean =
+    !(relative && absolute)
+
+  override def createFileReference(range: TextRange, index: Int, text: String): FileReference =
+    new IncludedFileReference(this, range, index, text)
+
+  override def getReferenceCompletionFilter: Condition[PsiFileSystemItem] =
+    new Condition[PsiFileSystemItem] {
+      def value(item: PsiFileSystemItem): Boolean = item.isDirectory ||
+              item.getName.endsWith(ConfExt) || item.getName.endsWith(JsonExt) || item.getName.endsWith(PropsExt)
+    }
+
+  override def computeDefaultContexts: ju.Collection[PsiFileSystemItem] = {
+    // code mostly based on similar bits in `FileReferenceSet` and `PsiFileReferenceHelper`
+
+    val empty = ju.Collections.emptyList[PsiFileSystemItem]
+    val cf = getContainingFile
+    if (cf == null) return empty
+
+    val containingFile = Option(cf.getContext).map(_.getContainingFile).getOrElse(cf)
+
+    val proj = containingFile.getProject
+    val vfile = containingFile.getOriginalFile.getVirtualFile
+    if (vfile == null) return empty
+
+    val parent = vfile.getParent
+    if (parent == null) return empty
+
+    val psiManager = PsiManager.getInstance(proj)
+
+    val pfi = ProjectRootManager.getInstance(proj).getFileIndex
+    val pkgName =
+      if (isAbsolutePathReference) ""
+      else pfi.getPackageNameByDirectory(parent)
+
+    if (pkgName == null) return empty
+
+    val scope = pfi.getOrderEntriesForFile(parent).iterator.asScala.map { oe =>
+      val withTests = pfi.isInTestSourceContent(parent) || (oe match {
+        case eoe: ExportableOrderEntry => eoe.getScope == DependencyScope.TEST
+        case _ => false
+      })
+      oe.getOwnerModule.getModuleWithDependenciesAndLibrariesScope(withTests)
+    }.reduce(_ union _)
+
+    // If there are any source roots with package prefix and that package is a subpackage of
+    // including file's package, they will be omitted because `getDirectoriesByPackageName` doesn't find them.
+    // I tried to fix this by manually searching for package-prefixed source dirs and representing them with
+    // `PackagePrefixFileSystemItem` instances, but implementation of `FileReference#innerResolveInContext`
+    // straight away negates my efforts by explicitly ignoring package prefixes - not sure why.
+    // TODO: possibly fix this in some other way?
+    DirectoryIndex.getInstance(proj).getDirectoriesByPackageName(pkgName, false).iterator.asScala
+            .filter(scope.contains).flatMap(dir => Option(psiManager.findDirectory(dir)))
+            .toJList
+  }
+
+}
+
+class IncludedFileReference(refSet: FileReferenceSet, range: TextRange, index: Int, text: String)
+        extends FileReference(refSet, range, index, text) {
+
+  private def lacksExtension(text: String) =
+    isLast && text.nonEmpty && text != "." && text != ".." && text != "/" &&
+            !text.endsWith(ConfExt) && !text.endsWith(JsonExt) && !text.endsWith(PropsExt)
+
+
+  override def innerResolveInContext(text: String, context: PsiFileSystemItem, result: ju.Collection[ResolveResult],
+                                     caseSensitive: Boolean) =
+    if (lacksExtension(text)) {
+      def resolveWithExt(ext: String) =
+        super.innerResolveInContext(text + ext, context, result, caseSensitive)
+
+      resolveWithExt(ConfExt)
+      resolveWithExt(JsonExt)
+      resolveWithExt(PropsExt)
+    } else
+      super.innerResolveInContext(text, context, result, caseSensitive)
+
+  override def getFileNameToCreate: String =
+    if (lacksExtension(getCanonicalText))
+      super.getFileNameToCreate + ConfExt
+    else
+      super.getFileNameToCreate
+}

--- a/test/org/jetbrains/plugins/hocon/formatting/HoconFormatterTest.scala
+++ b/test/org/jetbrains/plugins/hocon/formatting/HoconFormatterTest.scala
@@ -7,7 +7,7 @@ import com.intellij.openapi.command.CommandProcessor
 import com.intellij.openapi.util.JDOMUtil
 import com.intellij.openapi.util.io.FileUtil
 import com.intellij.psi.codeStyle.{CodeStyleManager, CodeStyleSettingsManager}
-import org.jetbrains.plugins.hocon.Util.TextRange
+import org.jetbrains.plugins.hocon.CommonUtil.TextRange
 import org.jetbrains.plugins.scala.testcases.ScalaFileSetTestCase
 import org.jetbrains.plugins.scala.util.TestUtils
 import org.junit.Assert


### PR DESCRIPTION
This PR implements resolution of HOCON `include` statements. Quoted strings inside includes now contain references to files found in sources and libraries. Also, there is an inspection for unresolved includes.

Details and assumptions:
- Only `classpath(...)` and generic includes are supported. Thus, `file(...)` and `url(...)` includes are not supported.
- Including file is assumed to have been loaded from classpath. Therefore, each generic include is interpreted as a relative path to other classpath resources (unless it's explicitly absolute - starts with a slash)
- `classpath(...)` includes are interpreted as absolute paths to classpath resources.
- If including file is in the sources of a module, included files are searched in entire classpath of this module (sources, dependencies and libraries).
- If including file is in a library, included files are searched in merged classpath of all modules that directly depend on that library.
- Test sources and test dependencies are searched only if including file is also a test source or lies inside a test dependency.
- If included file name doesn't have one of `.conf`, `.json` or `.properties` extensions, the file name will be appended with all of these extensions and each will be searched for. Therefore, there is no way to include file with any other extension. This is also reflected by an appropriate completion filter.

The scope where included files are searched for is potentially the most controversial issue. We have no way of knowing with what classpath the HOCON file will be loaded in runtime, so we don't know exactly where to search. The actual scope may be much wider.

Refactors and general improvements that come along with include resolution implementation:
- extended API of some HOCON PSI elements
- introduced a dedicated visitor class for HOCON PSI elements
- various string constants moved to common object
- cosmetic renames

Implementation of include resolution is based on code found in `FilePathReferenceProvider`, `FileReferenceSet`, `FileReference` and implementations of `FileReferenceHelper` - primarily the `PsiFileReferenceHelper`. Code of these components is reused as much as possible.

I haven't written any tests - to properly test that feature, I'd have to setup a multi-module test project with actual (physical) sources and libraries. I was unable to find out how to do it. Please point me to some examples if possible.
