### PR TITLE
Integer check fix

### DIFF
--- a/src/org/jetbrains/plugins/scala/annotator/ScalaAnnotator.scala
+++ b/src/org/jetbrains/plugins/scala/annotator/ScalaAnnotator.scala
@@ -1190,7 +1190,7 @@ class ScalaAnnotator extends Annotator with FunctionAnnotator with ScopeAnnotato
     val (number, base) = textWithoutL match {
       case t if t.startsWith("0x") || t.startsWith("0X") => (t.substring(2), 16)
       case t if t.startsWith("0") && t.length >= 2 => (t.substring(1), 8)
-      case _ => (text, 10)
+      case t => (t, 10)
     }
 
     // parse integer literal. the return is (Option(value), statusCode)
@@ -1206,20 +1206,20 @@ class ScalaAnnotator extends Annotator with FunctionAnnotator with ScopeAnnotato
       val limit = java.lang.Long.MAX_VALUE
       val intLimit = java.lang.Integer.MAX_VALUE
       var i = 0
-      val len = text.length
-      while (i < len) {
-        val d = text.charAt(i).asDigit
+      for (d <- number.map(_.asDigit)) {
         if (value > intLimit ||
             intLimit / (base / divider) < value ||
             intLimit - (d / divider) < value * (base / divider) &&
+            // This checks for -2147483648, value is 214748364, base is 10, d is 8. This check returns false.
+            // base 8 and 16 won't have this check because the divider is 2        .
             !(isNegative && intLimit == value * base - 1 + d)) {
           statusCode = 1
         }
         if (value < 0 ||
             limit / (base / divider) < value ||
             limit - (d / divider) < value * (base / divider) &&
+            // This checks for Long.MinValue, same as the the previous Int.MinValue check.
             !(isNegative && limit == value * base - 1 + d)) {
-          statusCode = 2
           return (None, 2)
         }
         value = value * base + d

--- a/test/org/jetbrains/plugins/scala/annotator/IntegerLiteralCheckTest.scala
+++ b/test/org/jetbrains/plugins/scala/annotator/IntegerLiteralCheckTest.scala
@@ -17,12 +17,11 @@ class IntegerLiteralCheckTest extends SimpleTestCase {
   final val Header = ""
 
   def randomIntValues(num: Int): List[Int] = {
-    Int.MaxValue :: Int.MinValue :: List.fill(num)(Random.nextInt)
+    List.fill(num)(Random.nextInt)
   }
 
   def randomLongValues(num: Int): List[Long] = {
-    val randomList = Stream.continually(Random.nextLong).filter(_.toHexString.length > 8).take(num).toList
-    Long.MaxValue :: Long.MinValue :: randomList
+    Stream.continually(Random.nextLong).filter(_.toHexString.length > 8).take(num).toList
   }
 
   // how should I bound T to Int and Long only?
@@ -38,17 +37,17 @@ class IntegerLiteralCheckTest extends SimpleTestCase {
 
   def appendL(s: String): List[String] = List(s + "l", s + "L")
 
-  val intValues = List(0, -0, 1, -1, 1234, -1234)
+  val intValues = List(0, -0, 1, -1, 1234, -1234, Int.MinValue, Int.MaxValue)
   val longValues = List(1l + Int.MaxValue, 12345l + Int.MaxValue, -1l +  Int.MinValue, -1234l + Int.MinValue, Long.MinValue, Long.MaxValue)
   val numOfGenInteger = 10
 
   def testFine() {
-    val intStrings = ((intValues ++ randomIntValues(numOfGenInteger)).flatMap(expandIntegerLiteral).flatMap(prependSign)).distinct
+    val intStrings = (intValues ++ randomIntValues(numOfGenInteger)).flatMap(expandIntegerLiteral).flatMap(prependSign).distinct
     for (s <- intStrings) {
       assertNothing(messages(s"val a = $s"))
     }
     val longStrings = (intStrings flatMap appendL) ++
-                      ((longValues ++ randomLongValues(numOfGenInteger)).flatMap(expandIntegerLiteral).flatMap(prependSign).flatMap(appendL)).distinct
+                      (longValues ++ randomLongValues(numOfGenInteger)).flatMap(expandIntegerLiteral).flatMap(prependSign).flatMap(appendL).distinct
     for (s <- longStrings) {
       assertNothing(messages(s"val a = $s"))
     }


### PR DESCRIPTION
Add comment for Int.MinValue or Long.MinValue check.
@Alefas, As I commented in the https://github.com/JetBrains/intellij-scala/commit/0201e5cdd25d5efaf6b23832370ec2a30720a19b#commitcomment-9441224. This is the comment that I want to add. And, I hope you can run IntegerLiteralCheckTest test before merge this code into master.

Also, the test numbers you added in the IntegerLiteralCheckTest.scala may not be necessary, because I prepend Int.MaxValue, Int.MinValue to randomIntValues, Long.MaxValue, Long.MinValue to randomLongValues (which may not be a good idea). I'd like to change the test file. what would you think?