### PR TITLE
SCL-8593 fix + test

### DIFF
--- a/src/org/jetbrains/plugins/hocon/HoconConstants.scala
+++ b/src/org/jetbrains/plugins/hocon/HoconConstants.scala
@@ -13,6 +13,7 @@ object HoconConstants {
   final val IntegerPattern = """-?(0|[1-9][0-9]*)""".r
   final val DecimalPartPattern = """([0-9]+)((e|E)(\+|-)?[0-9]+)?""".r
   final val ProperlyClosedQuotedString = ".*[^\\\\](\\\\\\\\)*\"".r
+  final val MultilineStringEnd = "\"{3,}".r
 
   final val ConfExt = "." + HoconFileType.DefaultExtension
   final val JsonExt = "." + JsonFileType.DEFAULT_EXTENSION

--- a/testdata/hocon/lexer/data/SCL8593.test
+++ b/testdata/hocon/lexer/data/SCL8593.test
@@ -1,0 +1,34 @@
+x.fun="CREATE THIS "${cass.key}"."""${cas.t}""" "(
+sym_id ascii,
+ts timestamp,
+val decimal,
+prev_val decimal,
+PRIMARY KEY (sym_id, ts)
+) WITH CLUSTERING ORDER BY ( ts DESC )"
+-----
+UNQUOTED_CHARS {x}
+PERIOD {.}
+UNQUOTED_CHARS {fun}
+EQUALS {=}
+QUOTED_STRING {"CREATE THIS "}
+DOLLAR {$}
+SUB_LBRACE {{}
+UNQUOTED_CHARS {cass}
+PERIOD {.}
+UNQUOTED_CHARS {key}
+SUB_RBRACE {}}
+QUOTED_STRING {"."}
+QUOTED_STRING {""}
+DOLLAR {$}
+SUB_LBRACE {{}
+UNQUOTED_CHARS {cas}
+PERIOD {.}
+UNQUOTED_CHARS {t}
+SUB_RBRACE {}}
+MULTILINE_STRING {""" "(
+sym_id ascii,
+ts timestamp,
+val decimal,
+prev_val decimal,
+PRIMARY KEY (sym_id, ts)
+) WITH CLUSTERING ORDER BY ( ts DESC )"}


### PR DESCRIPTION
HOCON lexer was using an unfortunate stack-blowing regex for multiline string matching. Now it uses a manual lexing rule.
