### PR TITLE
fix NPE in ModuleExt

### DIFF
--- a/src/org/jetbrains/sbt/project/data/ScalaSdkDataService.scala
+++ b/src/org/jetbrains/sbt/project/data/ScalaSdkDataService.scala
@@ -27,6 +27,9 @@ class ScalaSdkDataService(platformFacade: PlatformFacade, helper: ProjectStructu
       helper.findIdeModule(moduleData.getExternalName, project)
     }
 
+    if (module == null)
+      return
+
     module.configureScalaCompilerSettingsFrom("SBT", sdkData.compilerOptions)
 
     val compilerVersion = sdkData.scalaVersion


### PR DESCRIPTION
helper.findIdeModule can return null and late in implicit class happens NPE

Behavior:

when I am trying import intellij-scala in IntelliJ Idea EAP and get error:

```text
[  26557]  ERROR - llij.ide.plugins.PluginManager - null
java.lang.NullPointerException
	at org.jetbrains.plugins.scala.project.package$ModuleExt.compilerConfiguration(package.scala:116)
	at org.jetbrains.plugins.scala.project.package$ModuleExt.configureScalaCompilerSettingsFrom(package.scala:113)
	at org.jetbrains.sbt.project.data.ScalaSdkDataService.org$jetbrains$sbt$project$data$ScalaSdkDataService$$doImport(ScalaSdkDataService.scala:30)
	at org.jetbrains.sbt.project.data.ScalaSdkDataService$$anonfun$doImportData$1.apply(ScalaSdkDataService.scala:19)
	at org.jetbrains.sbt.project.data.ScalaSdkDataService$$anonfun$doImportData$1.apply(ScalaSdkDataService.scala:19)
```

this happens because helper.findIdeModule can return null, same early I have a lot warn message like:
```text
ModuleDependencyDataService - Can't import module dependencies [ModuleDependencyData: dependency=module ':compiler_settings:'|scope=Compile|exported=true|owner=module ':scala-jps-plugin:']. Reason: target module (ModuleData: module ':scala-jps-plugin:') is not found at the ide and can't be imported
```


