### PR TITLE
Fix for SCL-7465: Infix expressions can have type args

### DIFF
--- a/src/org/jetbrains/plugins/scala/codeInsight/intention/expression/ConvertFromInfixExpressionIntention.scala
+++ b/src/org/jetbrains/plugins/scala/codeInsight/intention/expression/ConvertFromInfixExpressionIntention.scala
@@ -40,7 +40,11 @@ class ConvertFromInfixExpressionIntention extends PsiElementBaseIntentionAction 
     val diff = editor.getCaretModel.getOffset - infixExpr.operation.nameId.getTextRange.getStartOffset
 
     val methodCallExpr = ScalaPsiElementFactory.createEquivMethodCall(infixExpr)
-    val size = methodCallExpr.getInvokedExpr.asInstanceOf[ScReferenceExpression].nameId.getTextRange.getStartOffset -
+    val referenceExpr = methodCallExpr.getInvokedExpr match {
+      case ref: ScReferenceExpression => ref
+      case call: ScGenericCall => call.referencedExpr.asInstanceOf[ScReferenceExpression]
+    }
+    val size = referenceExpr.nameId.getTextRange.getStartOffset -
        methodCallExpr.getTextRange.getStartOffset
 
     inWriteAction {

--- a/src/org/jetbrains/plugins/scala/lang/parser/parsing/expressions/InfixExpr.scala
+++ b/src/org/jetbrains/plugins/scala/lang/parser/parsing/expressions/InfixExpr.scala
@@ -7,6 +7,7 @@ package expressions
 import com.intellij.lang.PsiBuilder
 import org.jetbrains.plugins.scala.lang.lexer.ScalaTokenTypes
 import org.jetbrains.plugins.scala.lang.parser.parsing.builder.ScalaPsiBuilder
+import org.jetbrains.plugins.scala.lang.parser.parsing.types.TypeArgs
 
 
 /**
@@ -16,7 +17,7 @@ import org.jetbrains.plugins.scala.lang.parser.parsing.builder.ScalaPsiBuilder
 
 /*
  * InfixExpr ::= PrefixExpr
- *             | InfixExpr id [nl] InfixExpr
+ *             | InfixExpr id [TypeArgs] [nl] InfixExpr
  */
 
 object InfixExpr {
@@ -64,6 +65,7 @@ object InfixExpr {
       val setMarker = builder.mark
       val opMarker = builder.mark
       builder.advanceLexer() //Ate id
+      TypeArgs.parse(builder, isPattern = false)
       opMarker.done(ScalaElementTypes.REFERENCE_EXPRESSION)
       if (builder.twoNewlinesBeforeCurrentToken) {
         setMarker.rollbackTo()

--- a/src/org/jetbrains/plugins/scala/lang/parser/parsing/expressions/InfixExpr.scala
+++ b/src/org/jetbrains/plugins/scala/lang/parser/parsing/expressions/InfixExpr.scala
@@ -65,8 +65,8 @@ object InfixExpr {
       val setMarker = builder.mark
       val opMarker = builder.mark
       builder.advanceLexer() //Ate id
-      TypeArgs.parse(builder, isPattern = false)
       opMarker.done(ScalaElementTypes.REFERENCE_EXPRESSION)
+      TypeArgs.parse(builder, isPattern = false)
       if (builder.twoNewlinesBeforeCurrentToken) {
         setMarker.rollbackTo()
         count = 0

--- a/src/org/jetbrains/plugins/scala/lang/psi/api/expr/ScInfixExpr.scala
+++ b/src/org/jetbrains/plugins/scala/lang/psi/api/expr/ScInfixExpr.scala
@@ -6,6 +6,7 @@ package expr
 
 import com.intellij.psi.PsiElement
 import org.jetbrains.plugins.scala.lang.parser.util.ParserUtils
+import org.jetbrains.plugins.scala.lang.psi.api.base.types.ScTypeArgs
 
 /**
 * @author Alexander Podkhalyuzin
@@ -23,6 +24,12 @@ trait ScInfixExpr extends ScExpression with ScSugarCallExpr {
     }
   }
 
+  def typeArgs: Option[ScTypeArgs] = {
+    findChildrenByClassScala(classOf[ScTypeArgs]) match {
+      case Array(tpArg: ScTypeArgs) => Some(tpArg)
+      case _ => None
+    }
+  }
 
   def rOp: ScExpression = {
     val exprs: Array[ScExpression] = findChildrenByClassScala(classOf[ScExpression])

--- a/test/org/jetbrains/plugins/scala/codeInsight/intentions/expression/ConvertFromInfixExpressionIntentionTest.scala
+++ b/test/org/jetbrains/plugins/scala/codeInsight/intentions/expression/ConvertFromInfixExpressionIntentionTest.scala
@@ -96,4 +96,24 @@ class ConvertFromInfixExpressionIntentionTest extends ScalaIntentionTestBase {
     doTest(text, resultText)
   }
 
+  def testConvertFromInfixExpression12(): Unit = {
+    val text =
+      """
+        |case class M[A](a: A) {
+        |  def map[B](f: A => B): M[B] = M(f(a))
+        |}
+        |
+        |M(1) <caret>map[String] (_.toString)
+      """.stripMargin
+    val resultText =
+      """
+        |case class M[A](a: A) {
+        |  def map[B](f: A => B): M[B] = M(f(a))
+        |}
+        |
+        |M(1).<caret>map[String](_.toString)
+      """.stripMargin
+    doTest(text, resultText)
+  }
+
 }

--- a/test/org/jetbrains/plugins/scala/codeInsight/intentions/expression/ConvertToInfixExpressionIntentionTest.scala
+++ b/test/org/jetbrains/plugins/scala/codeInsight/intentions/expression/ConvertToInfixExpressionIntentionTest.scala
@@ -96,4 +96,25 @@ class ConvertToInfixExpressionIntentionTest extends ScalaIntentionTestBase {
     doTest(text, resultText)
   }
 
+  def testConvertToInfix12() = {
+    val text =
+      """
+        |case class M[A](a: A) {
+        |  def map[B](f: A => B): M[B] = M(f(a))
+        |}
+        |
+        |M(1).<caret>map[String](_.toString)
+      """.stripMargin
+    val resultText =
+      """
+        |case class M[A](a: A) {
+        |  def map[B](f: A => B): M[B] = M(f(a))
+        |}
+        |
+        |M(1) <caret>map[String] (_.toString)
+      """.stripMargin
+
+    doTest(text, resultText)
+  }
+
 }

--- a/testdata/parser/data/expressions/infix/InfixTypeArgs.test
+++ b/testdata/parser/data/expressions/infix/InfixTypeArgs.test
@@ -15,14 +15,14 @@ ScalaFile
               PsiElement(()('(')
               PsiElement())(')')
     PsiWhiteSpace(' ')
-    ReferenceExpression: map[String]
+    ReferenceExpression: map
       PsiElement(identifier)('map')
-      TypeArgumentsList
-        PsiElement([)('[')
-        SimpleTypeElement: String
-          CodeReferenceElement: String
-            PsiElement(identifier)('String')
-        PsiElement(])(']')
+    TypeArgumentsList
+      PsiElement([)('[')
+      SimpleTypeElement: String
+        CodeReferenceElement: String
+          PsiElement(identifier)('String')
+      PsiElement(])(']')
     PsiWhiteSpace(' ')
     ReferenceExpression: _.toString
       UnderscoreSection

--- a/testdata/parser/data/expressions/infix/InfixTypeArgs.test
+++ b/testdata/parser/data/expressions/infix/InfixTypeArgs.test
@@ -1,0 +1,31 @@
+new M() map[String] _.toString
+-----
+ScalaFile
+  InfixExpression
+    NewTemplateDefinition
+      PsiElement(new)('new')
+      PsiWhiteSpace(' ')
+      ExtendsBlock
+        ClassParents
+          Constructor
+            SimpleTypeElement: M
+              CodeReferenceElement: M
+                PsiElement(identifier)('M')
+            ArgumentList
+              PsiElement(()('(')
+              PsiElement())(')')
+    PsiWhiteSpace(' ')
+    ReferenceExpression: map[String]
+      PsiElement(identifier)('map')
+      TypeArgumentsList
+        PsiElement([)('[')
+        SimpleTypeElement: String
+          CodeReferenceElement: String
+            PsiElement(identifier)('String')
+        PsiElement(])(']')
+    PsiWhiteSpace(' ')
+    ReferenceExpression: _.toString
+      UnderscoreSection
+        PsiElement(_)('_')
+      PsiElement(.)('.')
+      PsiElement(identifier)('toString')


### PR DESCRIPTION
Minor change in parser, so that infix expression can have type arguments. 
Fixed [SCL-7465](https://youtrack.jetbrains.com/issue/SCL-7465)
