### PR TITLE
final functions in traits can be overriden in java  #SCL-5824 Fixed

### DIFF
--- a/src/org/jetbrains/plugins/scala/lang/psi/light/ScFunctionWrapper.scala
+++ b/src/org/jetbrains/plugins/scala/lang/psi/light/ScFunctionWrapper.scala
@@ -6,7 +6,7 @@ import org.jetbrains.plugins.scala.lang.psi.ScalaPsiUtil
 import org.jetbrains.plugins.scala.lang.psi.api.base.{ScMethodLike, ScPrimaryConstructor}
 import org.jetbrains.plugins.scala.lang.psi.api.statements.ScFunction
 import org.jetbrains.plugins.scala.lang.psi.api.statements.params.ScTypeParam
-import org.jetbrains.plugins.scala.lang.psi.api.toplevel.typedef.{ScObject, ScTypeDefinition}
+import org.jetbrains.plugins.scala.lang.psi.api.toplevel.typedef.{ScObject, ScTrait, ScTypeDefinition}
 import org.jetbrains.plugins.scala.lang.psi.types._
 import org.jetbrains.plugins.scala.lang.psi.types.result.{Success, TypeResult, TypingContext}
 
@@ -113,6 +113,7 @@ class ScFunctionWrapper(val function: ScFunction, isStatic: Boolean, isInterface
   override def hasModifierProperty(name: String): Boolean = {
     name match {
       case "abstract" if isInterface => true
+      case "final" if containingClass.isInstanceOf[ScTrait] => false //fix for SCL-5824
       case _ => super.hasModifierProperty(name)
     }
   }

--- a/test/org/jetbrains/plugins/scala/javaHighlighting/JavaHighlightingTest.scala
+++ b/test/org/jetbrains/plugins/scala/javaHighlighting/JavaHighlightingTest.scala
@@ -40,6 +40,27 @@ class JavaHighlightingTest extends ScalaFixtureTestCase {
     }
   }
 
+  def testOverrideFinal(): Unit = {
+    val scala = ""
+    val java =
+      """
+        |import scala.Function1;
+        |import scala.concurrent.ExecutionContext;
+        |
+        |public abstract class Future<T> implements scala.concurrent.Future<T> {
+        |
+        |    @Override
+        |    public scala.concurrent.Future<T> withFilter(Function1<T, Object> pred, ExecutionContext executor) {
+        |        return null;
+        |    }
+        |}
+      """.stripMargin
+
+    assertMatches(messagesFromJavaCode(scala, java, "Future")) {
+      case Nil =>
+    }
+  }
+
   def messagesFromJavaCode(scalaFileText: String, javaFileText: String, javaClassName: String): List[Message] = {
     myFixture.addFileToProject("dummy.scala", scalaFileText)
     val myFile: PsiFile = myFixture.addFileToProject(javaClassName + JavaFileType.DOT_DEFAULT_EXTENSION, javaFileText)


### PR DESCRIPTION
Fix for [SCL-5824](https://youtrack.jetbrains.com/issue/SCL-5824)
Allow override of final methods in Java if they are in traits.
This should be allowed because Scala traits are compiled down to interfaces and implementation is in a separate class
