### PR TITLE
Fix : ScalaNameSuggestionProvider incorrectly removes previous suggestions

### DIFF
--- a/src/org/jetbrains/plugins/scala/lang/refactoring/namesSuggester/ScalaNameSuggestionProvider.scala
+++ b/src/org/jetbrains/plugins/scala/lang/refactoring/namesSuggester/ScalaNameSuggestionProvider.scala
@@ -23,7 +23,6 @@ class ScalaNameSuggestionProvider extends NameSuggestionProvider {
   def completeName(element: PsiElement, nameSuggestionContext: PsiElement, prefix: String): util.Collection[LookupElement] = null
 
   def getSuggestedNames(element: PsiElement, nameSuggestionContext: PsiElement, result: util.Set[String]): SuggestedNameInfo = {
-    result.clear()
     val names = element match {
       case clazz: ScTemplateDefinition => Seq[String](clazz.name)
       case typed: ScTypedDefinition => typed.name +: NameSuggester.suggestNamesByType(typed.getType(TypingContext.empty).getOrAny).toSeq


### PR DESCRIPTION
A very small fix, but it will re-enable a little IntelliJ renaming goodness :)

Hope this helps.
Guillaume
