### PR TITLE
Nested stateful monads inspection was added

### DIFF
--- a/resources/META-INF/scala-plugin-common.xml
+++ b/resources/META-INF/scala-plugin-common.xml
@@ -825,6 +825,10 @@
                          displayName="Convert expression to Single Abstract Method (SAM)" groupPath="Scala" groupName="General"
                          shortName="ConvertExpressionToSAM" level="WARNING"
                          enabledByDefault="true" language="Scala"/>
+        <localInspection implementationClass="org.jetbrains.plugins.scala.codeInspection.monads.NestedStatefulMonadsInspection"
+                         displayName="Nested stateful monads" groupPath="Scala" groupName="General"
+                         shortName="NestedStatefulMonads" level="WARNING"
+                         enabledByDefault="true" language="Scala"/>
         <!--<localInspection implementationClass="org.jetbrains.plugins.scala.codeInspection.allErrorsInspection.AnnotatorBasedErrorInspection"
                         displayName="All Errors Tool" groupPath="Scala" groupName="General"
                         shortName="ScalaAllErrors" level="WARNING"

--- a/resources/inspectionDescriptions/NestedStatefulMonads.html
+++ b/resources/inspectionDescriptions/NestedStatefulMonads.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+This inspection reports nested stateful monads which may lead to architectural errors.
+</body>
+</html>

--- a/src/org/jetbrains/plugins/scala/codeInspection/monads/NestedStatefulMonadsInspection.scala
+++ b/src/org/jetbrains/plugins/scala/codeInspection/monads/NestedStatefulMonadsInspection.scala
@@ -1,0 +1,29 @@
+package org.jetbrains.plugins.scala.codeInspection.monads
+
+import com.intellij.codeInspection.ProblemsHolder
+import org.jetbrains.plugins.scala.codeInspection.AbstractInspection
+import org.jetbrains.plugins.scala.codeInspection.monads.NestedStatefulMonadsInspection._
+import org.jetbrains.plugins.scala.codeInspection.monads.StatefulMonads._
+import org.jetbrains.plugins.scala.lang.psi.api.expr.ScMethodCall
+import org.jetbrains.plugins.scala.lang.psi.types.{Any, ScParameterizedType}
+
+/**
+ * @author Sergey Tolmachev (tolsi.ru@gmail.com)
+ * @since 29.09.15
+ */
+object NestedStatefulMonadsInspection {
+  private[monads] final val Annotation = "Nested stateful monads"
+}
+
+final class NestedStatefulMonadsInspection extends AbstractInspection(Annotation) {
+  override def actionFor(holder: ProblemsHolder) = {
+    case call: ScMethodCall =>
+      val project = call.getProject
+      call.getType().getOrAny match {
+        case outer @ ScParameterizedType(_, typeArgs)
+          if isStatefulMonadType(outer, project) && typeArgs.exists(isStatefulMonadType(_, project)) =>
+          holder.registerProblem(call, Annotation)
+        case _ =>
+      }
+  }
+}

--- a/src/org/jetbrains/plugins/scala/codeInspection/monads/StatefulMonads.scala
+++ b/src/org/jetbrains/plugins/scala/codeInspection/monads/StatefulMonads.scala
@@ -1,0 +1,21 @@
+package org.jetbrains.plugins.scala.codeInspection.monads
+
+import com.intellij.openapi.project.Project
+import org.jetbrains.plugins.scala.codeInspection.InspectionsUtil
+import org.jetbrains.plugins.scala.lang.psi.types.ScType
+
+import scala.concurrent.Future
+import scala.util.Try
+
+/**
+ * @author Sergey Tolmachev (tolsi.ru@gmail.com)
+ * @since 29.09.15
+ */
+object StatefulMonads {
+  private[monads] final lazy val StatefulMonadsTypes: Set[Class[_]] = Set(classOf[Future[_]], classOf[Try[_]])
+  private[monads] final lazy val StatefulMonadsTypesNames = StatefulMonadsTypes.map(_.getCanonicalName)
+
+  private[monads] def isStatefulMonadType(t: ScType, projection: Project): Boolean = {
+    StatefulMonadsTypesNames.exists(typeName => InspectionsUtil.conformsToTypeFromClass(t, typeName, projection))
+  }
+}

--- a/test/org/jetbrains/plugins/scala/codeInspection/monads/NestedStatefulMonadsInspectionTest.scala
+++ b/test/org/jetbrains/plugins/scala/codeInspection/monads/NestedStatefulMonadsInspectionTest.scala
@@ -1,0 +1,105 @@
+package org.jetbrains.plugins.scala.codeInspection.monads
+
+import com.intellij.codeInspection.LocalInspectionTool
+import org.jetbrains.plugins.scala.codeInspection.ScalaLightInspectionFixtureTestAdapter
+
+/**
+ * @author Sergey Tolmachev (tolsi.ru@gmail.com)
+ * @since 29.09.15
+ */
+class NestedStatefulMonadsInspectionTest extends ScalaLightInspectionFixtureTestAdapter {
+  val annotation = NestedStatefulMonadsInspection.Annotation
+  protected def classOfInspection: Class[_ <: LocalInspectionTool] = classOf[NestedStatefulMonadsInspection]
+
+  def test_1(): Unit = {
+    val text =
+      """import scala.util.Try
+        |Try {}"""
+    checkTextHasNoErrors(text)
+  }
+
+  def test_2(): Unit = {
+    val text =
+      """import scala.concurrent.Future
+        |Future {}"""
+    checkTextHasNoErrors(text)
+  }
+
+  def test_3(): Unit = {
+    val text =
+      s"""import scala.util.Try
+        |${START}Try { Try {} }${END}"""
+    check(text)
+  }
+
+  def test_4(): Unit = {
+    val text =
+      s"""import scala.concurrent.Future
+        |${START}Future { Future {} }${END}"""
+    check(text)
+  }
+
+  def test_5(): Unit = {
+    val text = "Array.fill(5)(Array.fill(5)(0))"
+    checkTextHasNoErrors(text)
+  }
+
+  def test_6(): Unit = {
+    val text =
+      s"""import scala.concurrent.Future
+          |val a = Future { }
+          |${START}Future { a }${END}"""
+    check(text)
+  }
+
+  def test_7(): Unit = {
+    val text =
+      s"""import scala.util._
+          |${START}Try { Success() }${END}"""
+    check(text)
+  }
+
+  def test_8(): Unit = {
+    val text =
+      s"""import scala.util._
+          |import scala.concurrent.Future
+          |${START}Try { Future.successful() }${END}"""
+    check(text)
+  }
+
+  def test_9(): Unit = {
+    val text =
+      s"""import scala.util._
+        |${START}Success(Success(1))${END}"""
+    check(text)
+  }
+
+  def test_10(): Unit = {
+    val text =
+      s"""import scala.util._
+          |import scala.concurrent.Future
+          |${START}Future { Success() }${END}"""
+    check(text)
+  }
+
+  def test_11(): Unit = {
+    val text =
+      """import scala.util._
+        |Array(Failure(1))"""
+    checkTextHasNoErrors(text)
+  }
+
+  def test_12(): Unit = {
+    val text =
+      """import scala.util._
+        |Success(Array(1))"""
+    checkTextHasNoErrors(text)
+  }
+
+  def test_13(): Unit = {
+    val text =
+      s"""import scala.util._
+        |Array(${START}Success(Failure(1))${END})"""
+    check(text)
+  }
+}


### PR DESCRIPTION
I found a useful opportunity to see in IDE that you made a mistake on the nested monads which carry state.

But I have doubts about the implementation of, in particular, verify that the code block returns the type of storing the state of the monads, I have not found a way to do it, but to check the string type name. How can I do it a better way?

ps I also want to make inspection checked that monads containing state code processed explicitly (Try using a pattern-matching or isSuccess or etc; Future with onResult or onSuccess and etc; may be Option's), if they are not passed to other methods and do not return from the method, but it is difficult to me have a deal with the representation of the code in the form of a psi tree and existing opportunities of processing this tree. In any case it will be the individual pull request. I'll be glad to get a reference to any material on this topic.
