### PR TITLE
Fix : ScalaNameSuggestionProvider incorrectly removes previous suggestions from other NameSuggestionProvider

### DIFF
--- a/src/org/jetbrains/plugins/scala/lang/refactoring/namesSuggester/ScalaNameSuggestionProvider.scala
+++ b/src/org/jetbrains/plugins/scala/lang/refactoring/namesSuggester/ScalaNameSuggestionProvider.scala
@@ -23,7 +23,6 @@ class ScalaNameSuggestionProvider extends NameSuggestionProvider {
   def completeName(element: PsiElement, nameSuggestionContext: PsiElement, prefix: String): util.Collection[LookupElement] = null
 
   def getSuggestedNames(element: PsiElement, nameSuggestionContext: PsiElement, result: util.Set[String]): SuggestedNameInfo = {
-    result.clear()
     val names = element match {
       case clazz: ScTemplateDefinition => Seq[String](clazz.name)
       case typed: ScTypedDefinition => typed.name +: NameSuggester.suggestNamesByType(typed.getType(TypingContext.empty).getOrAny).toSeq


### PR DESCRIPTION
Hello,

This PR is a simple cherry-pick for **idea15.x** branch of PR https://github.com/JetBrains/intellij-scala/pull/185 which was targeted to **idea14.1.eap** branch.

Hope this helps,
Guillaume
