### PR TITLE
SAM Autotupling inspection Fix

### DIFF
--- a/src/org/jetbrains/plugins/scala/actions/ShowTypeInfoAction.scala
+++ b/src/org/jetbrains/plugins/scala/actions/ShowTypeInfoAction.scala
@@ -11,7 +11,6 @@ import org.jetbrains.plugins.scala.extensions._
 import org.jetbrains.plugins.scala.lang.lexer.ScalaTokenTypes
 import org.jetbrains.plugins.scala.lang.psi.api.base.patterns.ScBindingPattern
 import org.jetbrains.plugins.scala.lang.psi.api.expr.ScExpression
-import org.jetbrains.plugins.scala.lang.psi.types.result.TypingContext
 import org.jetbrains.plugins.scala.lang.psi.types.{ScSubstitutor, ScType}
 import org.jetbrains.plugins.scala.lang.refactoring.util.ScalaRefactoringUtil
 
@@ -51,7 +50,7 @@ class ShowTypeInfoAction extends AnAction(ScalaBundle.message("type.info")) {
           case (expr @ ExpressionType(tpe), _) =>
             val tpeText = tpe.presentableText
             val withoutAliases = Some(withoutAliasesText(tpe))
-            val tpeWithoutImplicits = expr.getTypeWithoutImplicits(TypingContext.empty).toOption
+            val tpeWithoutImplicits = expr.getTypeWithoutImplicits().toOption
             val tpeWithoutImplicitsText = tpeWithoutImplicits.map(_.presentableText)
             val expectedTypeText = expr.expectedType().map(_.presentableText)
             val nonSingletonTypeText = ScType.extractDesignatorSingletonType(tpe).map(_.presentableText)

--- a/src/org/jetbrains/plugins/scala/lang/completion/ScalaGlobalMembersCompletionContributor.scala
+++ b/src/org/jetbrains/plugins/scala/lang/completion/ScalaGlobalMembersCompletionContributor.scala
@@ -24,7 +24,6 @@ import org.jetbrains.plugins.scala.lang.psi.api.toplevel.typedef.{ScClass, ScMem
 import org.jetbrains.plugins.scala.lang.psi.implicits.ScImplicitlyConvertible
 import org.jetbrains.plugins.scala.lang.psi.stubs.index.ScalaIndexKeys
 import org.jetbrains.plugins.scala.lang.psi.types.ScType
-import org.jetbrains.plugins.scala.lang.psi.types.result.TypingContext
 import org.jetbrains.plugins.scala.lang.resolve.processor.CompletionProcessor
 import org.jetbrains.plugins.scala.lang.resolve.{ResolveUtils, ScalaResolveResult, StdKinds}
 
@@ -56,7 +55,7 @@ class ScalaGlobalMembersCompletionContributor extends CompletionContributor {
                   return
               }
           }
-          val typeWithoutImplicits = qualifier.getTypeWithoutImplicits(TypingContext.empty)
+          val typeWithoutImplicits = qualifier.getTypeWithoutImplicits()
           if (typeWithoutImplicits.isEmpty) return
           val tp = typeWithoutImplicits.get
           completeImplicits(ref, result, parameters.getOriginalFile, tp)

--- a/src/org/jetbrains/plugins/scala/lang/psi/ScalaPsiUtil.scala
+++ b/src/org/jetbrains/plugins/scala/lang/psi/ScalaPsiUtil.scala
@@ -253,7 +253,7 @@ object ScalaPsiUtil {
     Option[ImplicitResolveResult] = {
     //TODO! remove this after find a way to improve implicits according to compiler.
     val isHardCoded = refName == "+" &&
-      e.getTypeWithoutImplicits(TypingContext.empty).map(_.isInstanceOf[ValType]).getOrElse(false)
+      e.getTypeWithoutImplicits().map(_.isInstanceOf[ValType]).getOrElse(false)
     val kinds = processor.kinds
     var implicitMap: Seq[ImplicitResolveResult] = Seq.empty
     def checkImplicits(secondPart: Boolean, noApplicability: Boolean, withoutImplicitsForArgs: Boolean = noImplicitsForArgs) {
@@ -368,7 +368,7 @@ object ScalaPsiUtil {
 
     //TODO! remove this after find a way to improve implicits according to compiler.
     val isHardCoded = refName == "+" &&
-      e.getTypeWithoutImplicits(TypingContext.empty).map(_.isInstanceOf[ValType]).getOrElse(false)
+      e.getTypeWithoutImplicits().map(_.isInstanceOf[ValType]).getOrElse(false)
     val kinds = processor.kinds
     var implicitMap: Seq[ScalaResolveResult] = Seq.empty
     def checkImplicits(secondPart: Boolean, noApplicability: Boolean, withoutImplicitsForArgs: Boolean = noImplicitsForArgs) {

--- a/src/org/jetbrains/plugins/scala/lang/psi/api/expr/ScExpression.scala
+++ b/src/org/jetbrains/plugins/scala/lang/psi/api/expr/ScExpression.scala
@@ -52,9 +52,9 @@ trait ScExpression extends ScBlockStatement with PsiAnnotationMemberValue with I
     else {
       val expected: ScType = expectedOption.getOrElse(expectedType(fromUnderscore).orNull)
       if (expected == null) {
-        ExpressionTypeResult(getTypeWithoutImplicits(TypingContext.empty, ignoreBaseTypes, fromUnderscore), Set.empty, None)
+        ExpressionTypeResult(getTypeWithoutImplicits(ignoreBaseTypes, fromUnderscore), Set.empty, None)
       } else {
-        val tr = getTypeWithoutImplicits(TypingContext.empty, ignoreBaseTypes, fromUnderscore)
+        val tr = getTypeWithoutImplicits(ignoreBaseTypes, fromUnderscore)
         def defaultResult: ExpressionTypeResult = ExpressionTypeResult(tr, Set.empty, None)
         if (!checkImplicits) defaultResult //do not try implicit conversions for shape check
         else {
@@ -123,9 +123,7 @@ trait ScExpression extends ScBlockStatement with PsiAnnotationMemberValue with I
     }
   }
 
-  def getTypeWithoutImplicits(ctx: TypingContext, //todo: remove TypingContext?
-                              ignoreBaseTypes: Boolean = false,
-                              fromUnderscore: Boolean = false): TypeResult[ScType] = {
+  def getTypeWithoutImplicits(ignoreBaseTypes: Boolean = false, fromUnderscore: Boolean = false): TypeResult[ScType] = {
     @CachedMappedWithRecursionGuard(this, CachesUtil.TYPE_WITHOUT_IMPLICITS,
       Failure("Recursive getTypeWithoutImplicits", Some(this)), PsiModificationTracker.MODIFICATION_COUNT)
     def inner(ignoreBaseTypes: Boolean, fromUnderscore: Boolean): TypeResult[ScType] = {
@@ -344,7 +342,7 @@ trait ScExpression extends ScBlockStatement with PsiAnnotationMemberValue with I
     ProgressManager.checkCanceled()
 
     if (ScUnderScoreSectionUtil.underscores(this).nonEmpty) {
-      getTypeWithoutImplicits(TypingContext.empty, fromUnderscore = true) //to update implicitParametersFromUnder
+      getTypeWithoutImplicits(fromUnderscore = true) //to update implicitParametersFromUnder
       implicitParametersFromUnder
     } else {
       getType(TypingContext.empty) //to update implicitParameters field

--- a/src/org/jetbrains/plugins/scala/lang/psi/impl/base/ScLiteralImpl.scala
+++ b/src/org/jetbrains/plugins/scala/lang/psi/impl/base/ScLiteralImpl.scala
@@ -212,10 +212,10 @@ class ScLiteralImpl(node: ASTNode) extends ScalaPsiElementImpl(node) with ScLite
     typeWithoutImplicits = tp
   }
 
-  override def getTypeWithoutImplicits(ctx: TypingContext, ignoreBaseTypes: Boolean, fromUnderscore: Boolean): TypeResult[ScType] = {
+  override def getTypeWithoutImplicits(ignoreBaseTypes: Boolean, fromUnderscore: Boolean): TypeResult[ScType] = {
     val tp = typeWithoutImplicits
     if (tp != None) return Success(tp.get, None)
-    super.getTypeWithoutImplicits(ctx, ignoreBaseTypes, fromUnderscore)
+    super.getTypeWithoutImplicits(ignoreBaseTypes, fromUnderscore)
   }
   
   /*

--- a/src/org/jetbrains/plugins/scala/lang/psi/implicits/ImplicitCollector.scala
+++ b/src/org/jetbrains/plugins/scala/lang/psi/implicits/ImplicitCollector.scala
@@ -37,7 +37,7 @@ object ImplicitCollector {
   val cache = new ConcurrentHashMap[(PsiElement, ScType), Seq[ScalaResolveResult]]()
 
   def exprType(expr: ScExpression, fromUnder: Boolean): Option[ScType] = {
-    expr.getTypeWithoutImplicits(TypingContext.empty, fromUnderscore = fromUnder).toOption.map {
+    expr.getTypeWithoutImplicits(fromUnderscore = fromUnder).toOption.map {
       case tp =>
         ScType.extractDesignatorSingletonType(tp) match {
           case Some(res) => res

--- a/src/org/jetbrains/plugins/scala/lang/psi/implicits/ScImplicitlyConvertible.scala
+++ b/src/org/jetbrains/plugins/scala/lang/psi/implicits/ScImplicitlyConvertible.scala
@@ -46,7 +46,7 @@ class ScImplicitlyConvertible(place: PsiElement, placeType: Boolean => Option[Sc
       // def foo(x: Map[String, Int]) {}
       // def foo(x: String) {}
       // foo(Map(y -> 1)) //Error is here
-      expr.getTypeWithoutImplicits(TypingContext.empty, fromUnderscore = fromUnder).toOption.map {
+      expr.getTypeWithoutImplicits(fromUnderscore = fromUnder).toOption.map {
         case tp =>
           ScType.extractDesignatorSingletonType(tp) match {
             case Some(res) => res

--- a/src/org/jetbrains/plugins/scala/lang/refactoring/namesSuggester/NameSuggester.scala
+++ b/src/org/jetbrains/plugins/scala/lang/refactoring/namesSuggester/NameSuggester.scala
@@ -40,7 +40,7 @@ object NameSuggester {
     val types = new ArrayBuffer[ScType]()
     val typez = expr.getType(TypingContext.empty).getOrElse(null)
     if (typez != null && typez != Unit) types += typez
-    expr.getTypeWithoutImplicits(TypingContext.empty).foreach(types += _)
+    expr.getTypeWithoutImplicits().foreach(types += _)
     expr.getTypeIgnoreBaseType(TypingContext.empty).foreach(types += _)
     if (typez != null && typez == Unit) types += typez
 

--- a/src/org/jetbrains/plugins/scala/lang/refactoring/util/ScalaRefactoringUtil.scala
+++ b/src/org/jetbrains/plugins/scala/lang/refactoring/util/ScalaRefactoringUtil.scala
@@ -101,7 +101,7 @@ object ScalaRefactoringUtil {
   def addPossibleTypes(scType: ScType, expr: ScExpression): Array[ScType] = {
     val types = new ArrayBuffer[ScType]
     if (scType != null) types += scType
-    expr.getTypeWithoutImplicits(TypingContext.empty).foreach(types += _)
+    expr.getTypeWithoutImplicits().foreach(types += _)
     expr.getTypeIgnoreBaseType(TypingContext.empty).foreach(types += _)
     expr.expectedType().foreach(types += _)
     if (types.isEmpty) types += psi.types.Any


### PR DESCRIPTION
This PR closes [SCL-9069](https://youtrack.jetbrains.com/issue/SCL-9069).

The problem: Method Calls with SAMs are highlighted

The cause: SAM is not calculated during shape resolve

The solutions: 
- Check for SAM during shape resolve as well (this is what I implemented now)
  - The downside is that it might be more expensive (but not really because (almost) everything is cached)
  - The other downside is that it makes already complicated code more complicated
- Do a quick hack in AutoTupling inspection not to check SAMs
  - This is ugly but it may work (I don't think we had any other problems because of SAM not being calculated during shape resolve)
