### PR TITLE
show canonical text when presentable text is the same

### DIFF
--- a/src/org/jetbrains/plugins/scala/annotator/ApplicationAnnotator.scala
+++ b/src/org/jetbrains/plugins/scala/annotator/ApplicationAnnotator.scala
@@ -116,7 +116,7 @@ trait ApplicationAnnotator {
                   case ElementApplicabilityProblem(element, actual, expected) =>
                     val (actualType, expectedType) = ScTypePresentation.different(actual, expected)
                     holder.createErrorAnnotation(element, ScalaBundle.message("type.mismatch.found.required",
-                      actual.presentableText, expected.presentableText))
+                      actualType, expectedType))
                   case a =>
                     holder.createErrorAnnotation(call.argsElement, "Not applicable to " + signatureOf(f))
                 }


### PR DESCRIPTION
There was a small bug in this commit: https://github.com/JetBrains/intellij-scala/commit/e3e9bf8ae674105497634d06278f31e2a969677e

The calculation of ScTypePresentation was made, but actualType and expectedType were never used. 

The error would appear in the following case:

```
  def foo(b: java.math.BigDecimal*) = ???
  foo(new java.math.BigDecimal(1), BigDecimal(1))
```
