### PR TITLE
Mechanism for analyzing caches + new run configuration

### DIFF
--- a/.idea/runConfigurations/IDEA__Analyze_Caches__no_ProcessCancelledException_.xml
+++ b/.idea/runConfigurations/IDEA__Analyze_Caches__no_ProcessCancelledException_.xml
@@ -1,0 +1,49 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="IDEA (Analyze Caches, no ProcessCancelledException)" type="Application" factoryName="Application">
+    <extension name="coverage" enabled="false" merge="false" sample_coverage="true" runner="idea" />
+    <option name="MAIN_CLASS_NAME" value="com.intellij.idea.Main" />
+    <option name="VM_PARAMETERS" value="-Xmx800m -XX:ReservedCodeCacheSize=64m -XX:MaxPermSize=350m -XX:+HeapDumpOnOutOfMemoryError -ea -Didea.is.internal=true -Didea.debug.mode=true -Didea.system.path=$USER_HOME$/.IdeaData/IDEA-15/scala/system -Didea.config.path=$USER_HOME$/.IdeaData/IDEA-15/scala/config -Dapple.laf.useScreenMenuBar=true -Dplugin.path=$PROJECT_DIR$/out/plugin/Scala -Didea.ProcessCanceledException=disabled -Didea.platform.prefix=Idea -javaagent:$USER_HOME$/.ivy2/cache/com.github.jbellis/jamm/jars/jamm-0.3.1.jar" />
+    <option name="PROGRAM_PARAMETERS" value="" />
+    <option name="WORKING_DIRECTORY" value="file://$PROJECT_DIR$" />
+    <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="false" />
+    <option name="ALTERNATIVE_JRE_PATH" value="" />
+    <option name="ENABLE_SWING_INSPECTOR" value="false" />
+    <option name="ENV_VARIABLES" />
+    <option name="PASS_PARENT_ENVS" value="true" />
+    <module name="ideaRunner" />
+    <envs />
+    <RunnerSettings RunnerId="Debug">
+      <option name="DEBUG_PORT" value="" />
+      <option name="TRANSPORT" value="0" />
+      <option name="LOCAL" value="true" />
+    </RunnerSettings>
+    <RunnerSettings RunnerId="JavaRebel">
+      <option name="bootstrapPath" />
+      <option name="jrebelArgs" value="" />
+      <option name="loggingEnabled" value="false" />
+      <option name="useBootstrapDefaults" value="true" />
+    </RunnerSettings>
+    <RunnerSettings RunnerId="JavaRebel Debug">
+      <option name="bootstrapPath" />
+      <option name="debugPort" value="" />
+      <option name="jrebelArgs" value="" />
+      <option name="loggingEnabled" value="false" />
+      <option name="transport" value="0" />
+      <option name="useBootstrapDefaults" value="true" />
+      <option name="DEBUG_PORT" value="" />
+      <option name="TRANSPORT" value="0" />
+      <option name="LOCAL" value="true" />
+    </RunnerSettings>
+    <RunnerSettings RunnerId="Profile ">
+      <option name="myExternalizedOptions" value="&#13;&#10;additional-options2=onexit\=snapshot&#13;&#10;" />
+    </RunnerSettings>
+    <RunnerSettings RunnerId="Run" />
+    <ConfigurationWrapper RunnerId="Debug" />
+    <ConfigurationWrapper RunnerId="Run" />
+    <method>
+      <option name="BuildArtifacts" enabled="true">
+        <artifact name="ScalaPlugins" />
+      </option>
+    </method>
+  </configuration>
+</component>

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 import Common._
-import sbt.Keys.{`package` => pack}
 import com.dancingrobot84.sbtidea.Tasks.{updateIdea => updateIdeaTask}
+import sbt.Keys.{`package` => pack}
 
 // Global build settings
 
@@ -25,7 +25,6 @@ addCommandAlias("packagePlugin", "pluginPackager/package")
 addCommandAlias("packagePluginZip", "pluginCompressor/package")
 
 // Main projects
-
 lazy val scalaCommunity: Project =
   newProject("scalaCommunity", file("."))
   .dependsOn(compilerSettings, scalap, runners % "test->test;compile->compile", macroAnnotations)
@@ -35,6 +34,7 @@ lazy val scalaCommunity: Project =
     ideExcludedDirectories := Seq(baseDirectory.value / "testdata" / "projects"),
     javacOptions in Global ++= Seq("-source", "1.6", "-target", "1.6"),
     scalacOptions in Global += "-target:jvm-1.6",
+    scalacOptions in Global += "-Xmacro-settings:analyze-caches",
     libraryDependencies ++= DependencyGroups.scalaCommunity,
     unmanagedJars in Compile +=  file(System.getProperty("java.home")).getParentFile / "lib" / "tools.jar",
     unmanagedJars in Compile ++= unmanagedJarsFrom(sdkDirectory.value, "nailgun"),

--- a/macroAnnotations/src/org/jetbrains/plugins/scala/macroAnnotations/CachedMacro.scala
+++ b/macroAnnotations/src/org/jetbrains/plugins/scala/macroAnnotations/CachedMacro.scala
@@ -10,9 +10,15 @@ import scala.reflect.macros.whitebox
  */
 object CachedMacro {
   val debug: Boolean = false
+  //to analyze caches pass in the following compiler flag: "-Xmacro-settings:analyze-caches"
+  val ANALYZE_CACHES: String = "analyze-caches"
+
 
   def cachedImpl(c: whitebox.Context)(annottees: c.Tree*): c.Expr[Any] = {
     import c.universe._
+
+    //fully qualified names
+    val cacheStatisticsFQN = q"_root_.org.jetbrains.plugins.scala.statistics.CacheStatistics"
 
     def abort(message: String) = c.abort(c.enclosingPosition, message)
 
@@ -37,27 +43,45 @@ object CachedMacro {
       }
     }
 
+    //annotation parameters
+    val (synchronized, modCount, manager) = parameters
 
-    //todo: caching two overloaded functions
     annottees.toList match {
       case DefDef(mods, name, tpParams, paramss, retTp, rhs) :: Nil =>
         if (retTp.isEmpty) {
           abort("You must specify return type")
         }
-
-        val (synchronized, modCount, manager) = parameters
-        val flatParams = paramss.flatten
-        val paramNames = flatParams.map(_.name)
+        //generated names
         val cacheVarName = c.freshName(name)
         val modCountVarName = c.freshName(name)
         val mapName = c.freshName(name)
-        val hasParameters: Boolean = flatParams.nonEmpty
         val cachedFunName = TermName(c.freshName("cachedFun"))
+        val cacheStatsName = TermName(c.freshName(name + "cacheStats"))
+        val keyId = c.freshName(name.toString + "cacheKey")
+        val analyzeCaches = c.settings.contains(ANALYZE_CACHES)
 
+        //DefDef parameters
+        val flatParams = paramss.flatten
+        val paramNames = flatParams.map(_.name)
+        val hasParameters: Boolean = flatParams.nonEmpty
+
+        val analyzeCachesField =
+          if(analyzeCaches) {
+            val cacheDecl = q"private val $cacheStatsName = $cacheStatisticsFQN($keyId, ${name.toString})"
+            if (hasParameters) { //need to put map in cacheStats, so its size can be measured
+              q"""
+                $cacheDecl
+
+                $cacheStatsName.addCacheObject($mapName)
+              """
+            } else cacheDecl
+          } else EmptyTree
         val fields = if (hasParameters) {
           q"""
             private val $mapName = _root_.com.intellij.util.containers.ContainerUtil.
                 newConcurrentMap[(..${flatParams.map(_.tpt)}), ($retTp, _root_.scala.Long)]()
+
+            ..$analyzeCachesField
           """
         } else {
           q"""
@@ -65,6 +89,8 @@ object CachedMacro {
             private var $cacheVarName: _root_.scala.Option[$retTp] = _root_.scala.None
             new _root_.scala.volatile()
             private var $modCountVarName: _root_.scala.Long = 0L
+
+            ..$analyzeCachesField
           """
         }
 
@@ -76,24 +102,48 @@ object CachedMacro {
           """
         def putValuesIntoMap: c.universe.Tree = q"$mapName.put((..$paramNames), ($cacheVarName.get, $modCountVarName))"
 
+        val analyzeCachesBeforeCalculation =
+          if (analyzeCaches) {
+            q"""
+              if ($cacheVarName.isDefined) $cacheStatsName.removeCacheObject($cacheVarName.get)
+              val startTime = System.nanoTime()
+            """
+          } else EmptyTree
+
+        val analyzeCachesAfterCalculation =
+          if (analyzeCaches) {
+            q"""
+              val stopTime = System.nanoTime()
+              $cacheStatsName.reportTimeToCalculate(stopTime - startTime)
+              $cacheStatsName.addCacheObject($cacheVarName)
+            """
+          } else EmptyTree
+
         val functionContents = q"""
+            ${if (analyzeCaches) q"$cacheStatsName.aboutToEnterCachedArea()" else EmptyTree}
             val modCount = $manager.getModificationTracker.${TermName(modCount.toString)}
             ..${if (hasParameters) getValuesFromMap else EmptyTree}
-            if ($cacheVarName.isDefined && $modCountVarName == modCount) $cacheVarName.get
-            else {
-              $cacheVarName = _root_.scala.Some($cachedFunName())
+            if ($cacheVarName.isEmpty || $modCountVarName != modCount) {
+              ..$analyzeCachesBeforeCalculation
+              val cacheFunResult = $cachedFunName()
+              ..$analyzeCachesAfterCalculation
+              $cacheVarName = _root_.scala.Some(cacheFunResult)
               $modCountVarName = modCount
               ..${if (hasParameters) putValuesIntoMap else EmptyTree}
-              $cacheVarName.get
             }
+            $cacheVarName.get
           """
+        val updatedRhs = q"""
+          def $cachedFunName(): $retTp = {
+            ${if (analyzeCaches) q"$cacheStatsName.recalculatingCache()" else EmptyTree}
+            $rhs
+          }
+          ..${ if (synchronized) q"synchronized { $functionContents }" else functionContents }
+        """
+        val updatedDef = DefDef(mods, name, tpParams, paramss, retTp, updatedRhs)
         val res = q"""
           ..$fields
-          $mods def $name[..$tpParams](...$paramss): $retTp = {
-            def $cachedFunName(): $retTp = $rhs
-
-            ..${ if (synchronized) q"synchronized { $functionContents }" else functionContents }
-          }
+          $updatedDef
           """
         println(res)
         c.Expr(res)
@@ -103,7 +153,28 @@ object CachedMacro {
 
   def cachedMappedWithRecursionGuardImpl(c: whitebox.Context)(annottees: c.Tree*): c.Expr[Any] = {
     import c.universe._
+
+    //fully qualified names
+    val cachesUtilFQN = q"_root_.org.jetbrains.plugins.scala.caches.CachesUtil"
+    val mappedKeyTypeFQN = tq"_root_.org.jetbrains.plugins.scala.caches.CachesUtil.MappedKey"
+    val methodFQN = q"$cachesUtilFQN.getMappedWithRecursionPreventingWithRollback"
+    val cacheStatisticsFQN = q"_root_.org.jetbrains.plugins.scala.statistics.CacheStatistics"
+    val dom = tq"com.intellij.psi.PsiElement"
+
+    //generated names
+    val cachedFunName = TermName(c.freshName("cachedFun"))
+    val dataName = TermName(c.freshName("data"))
+    val dataTypeName = TypeName(c.freshName("Data"))
+
+    def parameters: (Tree, Tree, Tree) = c.prefix.tree match {
+      case q"new CachedMappedWithRecursionGuard(..$params)" if params.length == 3 => (params(0), params(1), params(2))
+      case _ => abort("Wrong annotation parameters!")
+    }
+
     def abort(s: String) = c.abort(c.enclosingPosition, s)
+
+    //annotation parameters
+    val (element, defaultValue, dependencyItem) = parameters
 
     annottees.toList match {
       case DefDef(mods, name, tpParams, paramss, retTp, rhs) :: Nil =>
@@ -111,54 +182,65 @@ object CachedMacro {
           abort("You must specify return type")
         }
 
-        val (annotationParameters: List[Tree], dom) = c.prefix.tree match {
-          case q"new CachedMappedWithRecursionGuard(..$params)" if params.length == 3 => (params, tq"com.intellij.psi.PsiElement")
-          case _ => abort("Wrong annotation parameters!")
-        }
+        //some more generated names
+        val keyId = c.freshName(name.toString + "cacheKey")
+        val key = TermName(c.freshName(name.toString + "Key"))
+        val cacheStatsName = TermName(c.freshName(name + "cacheStats"))
+
+        val analyzeCaches = c.settings.contains(ANALYZE_CACHES)
+        //function parameters
         val flatParams = paramss.flatten
         val parameterTypes = flatParams.map(_.tpt)
         val parameterNames: List[c.universe.TermName] = flatParams.map(_.name)
-        val cachesUtilFQN = q"_root_.org.jetbrains.plugins.scala.caches.CachesUtil"
-        val cachedFunName = TermName(c.freshName("cachedFun"))
-        val dataName = TermName(c.freshName("data"))
-        val dataTypeName = TypeName(c.freshName("Data"))
         val parameterDefinitions: List[c.universe.Tree] = flatParams match {
           case param :: Nil => List(ValDef(NoMods, param.name, param.tpt, q"$dataName"))
           case _ => flatParams.zipWithIndex.map {
-            case (param, i) =>
-              ValDef(NoMods, param.name, param.tpt, q"$dataName.${TermName("_" + (i + 1))}")
+            case (param, i) => ValDef(NoMods, param.name, param.tpt, q"$dataName.${TermName("_" + (i + 1))}")
           }
         }
-        val methodFQN = q"$cachesUtilFQN.getMappedWithRecursionPreventingWithRollback"
-        val keyId = c.freshName(name.toString + "cacheKey")
-        val key = TermName(c.freshName(name.toString + "Key"))
-        val mappedKeyTypeFQN = tq"_root_.org.jetbrains.plugins.scala.caches.CachesUtil.MappedKey"
+
+        val rightHandSide =
+          if (analyzeCaches) {
+            val innerCachedFunName = TermName(c.freshName())
+            //have to put it in a separate function because otherwise it falls with NonLocalReturn
+            q"""
+              def $innerCachedFunName(): $retTp = $rhs
+
+              $cacheStatsName.recalculatingCache()
+              val startTime = System.nanoTime()
+              val res = $innerCachedFunName()
+              val stopTime = System.nanoTime()
+              $cacheStatsName.reportTimeToCalculate(stopTime - startTime)
+              $cacheStatsName.addCacheObject(res)
+              res
+            """
+          } else rhs
 
         val builder = q"""
           def $cachedFunName(${TermName(c.freshName())}: _root_.scala.Any, $dataName: $dataTypeName): $retTp = {
             ..$parameterDefinitions
-            $rhs
+
+            $rightHandSide
           }
           """
-        val element = annotationParameters.head
-        val defaultValue = annotationParameters(1)
-        val dependencyItem = annotationParameters(2)
 
         val updatedRhs = q"""
+          ${if (analyzeCaches) q"$cacheStatsName.aboutToEnterCachedArea()" else EmptyTree}
           type $dataTypeName = (..$parameterTypes)
           val $dataName = (..$parameterNames)
 
           $builder
 
           $methodFQN[$dom, $dataTypeName, $retTp]($element, $dataName, $key, $cachedFunName, $defaultValue, $dependencyItem)
-          """
+        """
 
         val updatedDef = DefDef(mods, name, tpParams, paramss, retTp, updatedRhs)
         val res = q"""
           private val $key = $cachesUtilFQN.getOrCreateKey[$mappedKeyTypeFQN[(..$parameterTypes), $retTp]]($keyId)
+          ${if (analyzeCaches) q"private val $cacheStatsName = $cacheStatisticsFQN($keyId, ${name.toString})" else EmptyTree}
 
           ..$updatedDef
-          """
+        """
         println(res)
         c.Expr(res)
       case _ => abort("You can only annotate one function!")
@@ -169,44 +251,73 @@ object CachedMacro {
     import c.universe._
     def abort(s: String) = c.abort(c.enclosingPosition, s)
 
+    def parameters: (Tree, Tree, Tree, Tree, Boolean) = c.prefix.tree match {
+      case q"new CachedWithRecursionGuard[$t](..$params)" if params.length == 3 =>
+        (params.head, params(1), params(2), t, false) //false is for default parameter
+      case q"new CachedWithRecursionGuard[$t](..$params)" if params.length == 4 =>
+        val optional = params.last match {
+          case q"useOptionalProvider = $v" => c.eval[Boolean](c.Expr(v))
+          case q"$v" => c.eval[Boolean](c.Expr(v))
+        }
+        (params.head, params(1), params(2), t, optional)
+      case _ => abort("Wrong annotation parameters!")
+    }
+
+    //fully qualified names
+    val cachesUtilFQN = q"_root_.org.jetbrains.plugins.scala.caches.CachesUtil"
+    val cachedValueFQN = tq"_root_.com.intellij.psi.util.CachedValue"
+    val keyFQN = tq"_root_.com.intellij.openapi.util.Key"
+    val cacheStatisticsFQN = q"_root_.org.jetbrains.plugins.scala.statistics.CacheStatistics"
+
+    val (element, defaultValue, dependencyItem, providerType, useOptionalProvider) = parameters
+
     annottees.toList match {
       case DefDef(mods, name, tpParams, params, retTp, rhs) :: Nil =>
         if (retTp.isEmpty) {
           abort("You must specify return type")
         }
 
-        val cachesUtilFQN = q"_root_.org.jetbrains.plugins.scala.caches.CachesUtil"
-
-        val (annotationParameters: List[Tree], providerType, useOptionalProvider: Boolean) = c.prefix.tree match {
-          case q"new CachedWithRecursionGuard[$t](..$params)" if params.length == 3 => (params, t, false) //default parameter
-          case q"new CachedWithRecursionGuard[$t](..$params)" if params.length == 4 =>
-            val optional = params.last match {
-              case q"useOptionalProvider = $v" => c.eval[Boolean](c.Expr(v))
-              case q"$v" => c.eval[Boolean](c.Expr(v))
-            }
-            (params, t, optional)
-          case _ => abort("Wrong annotation parameters!")
-        }
-        val element = annotationParameters.head
-        val defaultValue = annotationParameters(1)
-        val dependencyItem = annotationParameters(2)
+        //generated names
         val cachedFunName = TermName(c.freshName("cachedFun"))
         val keyId = c.freshName(name.toString + "cacheKey")
-        val key = TermName(c.freshName(name.toString + "Key"))
+        val keyVarName = TermName(c.freshName(name.toString + "Key"))
+        val cacheStatsName = TermName(c.freshName("cacheStats"))
+        val analyzeCaches = c.settings.contains(ANALYZE_CACHES)
+
         val provider =
           if (useOptionalProvider) TypeName("MyOptionalProvider")
           else TypeName("MyProvider")
-        val fun = q"def $cachedFunName(): $retTp = $rhs"
+
+
+
+        val cachedFunRHS =
+          if (analyzeCaches) {
+            val innerCachedFunName = TermName(c.freshName())
+            //have to put it in a separate function because otherwise it falls with NonLocalReturn
+            q"""
+              def $innerCachedFunName(): $retTp = $rhs
+
+              $cacheStatsName.recalculatingCache()
+              val startTime = System.nanoTime()
+              val res = $innerCachedFunName()
+              val stopTime = System.nanoTime()
+              $cacheStatsName.reportTimeToCalculate(stopTime - startTime)
+              $cacheStatsName.addCacheObject(res)
+              res
+            """
+          } else rhs
+        val fun = q"def $cachedFunName(): $retTp = $cachedFunRHS"
         val builder = q"new $cachesUtilFQN.$provider[$providerType, $retTp]($element, _ => $cachedFunName())($dependencyItem)"
-        val cachedValueFQN = tq"_root_.com.intellij.psi.util.CachedValue"
-        val keyFQN = tq"_root_.com.intellij.openapi.util.Key"
+
         val updatedRhs = q"""
+          ${if (analyzeCaches) q"$cacheStatsName.aboutToEnterCachedArea()" else EmptyTree}
           $fun
-          $cachesUtilFQN.getWithRecursionPreventingWithRollback[$providerType, $retTp]($element, $key, $builder, $defaultValue)
+          $cachesUtilFQN.getWithRecursionPreventingWithRollback[$providerType, $retTp]($element, $keyVarName, $builder, $defaultValue)
           """
         val updatedDef = DefDef(mods, name, tpParams, params, retTp, updatedRhs)
         val res = q"""
-          private val $key = $cachesUtilFQN.getOrCreateKey[$keyFQN[$cachedValueFQN[$retTp]]]($keyId)
+          private val $keyVarName = $cachesUtilFQN.getOrCreateKey[$keyFQN[$cachedValueFQN[$retTp]]]($keyId)
+          ${if (analyzeCaches) q"private val $cacheStatsName = $cacheStatisticsFQN($keyId, ${name.toString})" else EmptyTree}
 
           ..$updatedDef
           """
@@ -220,41 +331,72 @@ object CachedMacro {
     import c.universe._
     def abort(s: String) = c.abort(c.enclosingPosition, s)
 
+    def parameters: (Tree, Tree, Boolean) = c.prefix.tree match {
+      case q"new CachedInsidePsiElement(..$params)" if params.length == 2 => (params.head, params(1), false)
+      case q"new CachedInsidePsiElement(..$params)" if params.length == 3 =>
+        val optional = params.last match {
+          case q"useOptionalProvider = $v" => c.eval[Boolean](c.Expr(v))
+          case q"$v" => c.eval[Boolean](c.Expr(v))
+        }
+        (params.head, params(1), optional)
+      case _ => abort("Wrong annotation parameters!")
+    }
+
+    //fully qualified names
+    val cachesUtilFQN = q"_root_.org.jetbrains.plugins.scala.caches.CachesUtil"
+    val cachedValueFQN = tq"_root_.com.intellij.psi.util.CachedValue"
+    val keyFQN = tq"_root_.com.intellij.openapi.util.Key"
+    val cacheStatisticsFQN = q"_root_.org.jetbrains.plugins.scala.statistics.CacheStatistics"
+
+    //annotation parameters
+    val (elem, dependencyItem, useOptionalProvider) = parameters
+
     annottees.toList match {
       case DefDef(mods, name, tpParams, paramss, retTp, rhs) :: Nil =>
         if (retTp.isEmpty) {
           abort("You must specify return type")
         }
-        val (annotationParameters: List[Tree], useOptionalProvider: Boolean) = c.prefix.tree match {
-          case q"new CachedInsidePsiElement(..$params)" if params.length == 2 => (params, false)
-          case q"new CachedInsidePsiElement(..$params)" if params.length == 3 =>
-            val optional = params.last match {
-              case q"useOptionalProvider = $v" => c.eval[Boolean](c.Expr(v))
-              case q"$v" => c.eval[Boolean](c.Expr(v))
-            }
-            (params, optional)
-          case _ => abort("Wrong annotation parameters!")
-        }
-        val cachesUtilFQN = q"_root_.org.jetbrains.plugins.scala.caches.CachesUtil"
-        val elem = annotationParameters.head
-        val dependencyItem = annotationParameters(1)
+
+        //generated names
         val cachedFunName = TermName(c.freshName("cachedFun"))
         val keyId = c.freshName(name.toString + "cacheKey")
         val key = TermName(c.freshName(name.toString + "Key"))
-        val cachedValueFQN = tq"_root_.com.intellij.psi.util.CachedValue"
-        val keyFQN = tq"_root_.com.intellij.openapi.util.Key"
+        val cacheStatsName = TermName(c.freshName("cacheStats"))
+
+        val analyzeCaches = c.settings.contains(ANALYZE_CACHES)
+        println(s"analyzeCaches: $analyzeCaches")
+        println(s"compiler flags: ${c.settings}")
+
         val provider =
           if (useOptionalProvider) TypeName("MyOptionalProvider")
           else TypeName("MyProvider")
-        
-        val updatedRhs = q"""
-          def $cachedFunName(): $retTp = $rhs
 
+        val cachedFunRHS =
+          if (analyzeCaches) {
+            val innerCachedFunName = TermName(c.freshName())
+            //have to put it in a separate function because otherwise it falls with NonLocalReturn
+            q"""
+              def $innerCachedFunName(): $retTp = $rhs
+
+              $cacheStatsName.recalculatingCache()
+              val startTime = System.nanoTime()
+              val res = $innerCachedFunName()
+              val stopTime = System.nanoTime()
+              $cacheStatsName.reportTimeToCalculate(stopTime - startTime)
+              $cacheStatsName.addCacheObject(res)
+              res
+            """
+          } else rhs
+        val updatedRhs = q"""
+          def $cachedFunName(): $retTp = $cachedFunRHS
+
+          ${if (analyzeCaches) q"$cacheStatsName.aboutToEnterCachedArea()" else EmptyTree}
           $cachesUtilFQN.get($elem, $key, new $cachesUtilFQN.$provider[Any, $retTp]($elem, _ => $cachedFunName())($dependencyItem))
           """
         val updatedDef = DefDef(mods, name, tpParams, paramss, retTp, updatedRhs)
         val res = q"""
           private val $key = $cachesUtilFQN.getOrCreateKey[$keyFQN[$cachedValueFQN[$retTp]]]($keyId)
+          ${if (analyzeCaches) q"private val $cacheStatsName = $cacheStatisticsFQN($keyId, ${name.toString})" else EmptyTree}
 
           ..$updatedDef
           """

--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -19,6 +19,7 @@ object Dependencies {
   val sbtStructureExtractor013 = "org.jetbrains" % "sbt-structure-extractor-0-13" % sbtStructureVersion
   val sbtLaunch = "org.scala-sbt" % "sbt-launch" % "0.13.8"
 
+  val jamm = "com.github.jbellis" % "jamm" % "0.3.1"
   val scalaLibrary = "org.scala-lang" % "scala-library" % scalaVersion
   val scalaReflect = "org.scala-lang" % "scala-reflect" % scalaVersion
   val scalaCompiler = "org.scala-lang" % "scala-compiler" % scalaVersion
@@ -132,7 +133,8 @@ object DependencyGroups {
     scalaParserCombinators,
     sbtStructureCore,
     evoInflector,
-    scalatestFindersPatched
+    scalatestFindersPatched,
+    jamm
   ) ++ mavenIndexer ++ scalastyle
 
   val scalap = Seq(

--- a/src/org/jetbrains/plugins/scala/components/TypeAwareHighlightingApplicationState.scala
+++ b/src/org/jetbrains/plugins/scala/components/TypeAwareHighlightingApplicationState.scala
@@ -3,6 +3,7 @@ package components
 
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.components._
+import org.jetbrains.plugins.scala.statistics.CacheStatistics
 
 /**
  * User: Dmitry Naydanov
@@ -35,7 +36,9 @@ class TypeAwareHighlightingApplicationState extends ApplicationComponent with
 
   def initComponent() {}
 
-  def disposeComponent() {}
+  def disposeComponent(): Unit = {
+    CacheStatistics.printStats()
+  }
 }
 
 object TypeAwareHighlightingApplicationState {

--- a/src/org/jetbrains/plugins/scala/statistics/CacheStatistics.scala
+++ b/src/org/jetbrains/plugins/scala/statistics/CacheStatistics.scala
@@ -1,0 +1,121 @@
+package org.jetbrains.plugins.scala.statistics
+
+import com.intellij.util.containers.ContainerUtil
+import org.github.jamm.MemoryMeter
+import org.jetbrains.plugins.scala.statistics.CacheStatistics.memoryMeter
+
+import scala.collection.mutable
+import scala.ref.WeakReference
+
+/**
+*  Author: Svyatoslav Ilinskiy
+*  Date: 10/9/15.
+*/
+class CacheStatistics private(id: String, name: String) {
+  @volatile
+  var cachedAreaEntrances: Long = 0
+  @volatile
+  var cachesRecalculated: Long = 0
+  val objectsToKeepTrackOf = ContainerUtil.newConcurrentSet[WeakReference[AnyRef]]
+  val calculationTimes = ContainerUtil.newConcurrentSet[Long]()
+
+  //we could ask time of entrance to measure time locality
+  //also, we could find out whether multiple threads are calculating this cache at the same time
+  def aboutToEnterCachedArea(): Unit = {
+    cachedAreaEntrances += 1
+  }
+
+  def recalculatingCache(): Unit = {
+    cachesRecalculated += 1
+  }
+
+  def reportTimeToCalculate(time: Long): Unit = {
+
+    calculationTimes.add(time)
+  }
+
+  def hits: Long = cachedAreaEntrances - cachesRecalculated
+
+  def misses: Long = cachesRecalculated
+
+  def addCacheObject(obj: Any): Unit = obj match {
+    case ref: AnyRef => objectsToKeepTrackOf.add(new WeakReference[AnyRef](ref))
+    case _ => //it's a primitive, its size is so tiny, so let's ignore it for now
+  }
+
+  def removeCacheObject(obj: Any): Boolean = {
+    import scala.collection.JavaConversions._
+    var res = false
+    objectsToKeepTrackOf.foreach {
+      case WeakReference(el) if el.equals(obj) => res = objectsToKeepTrackOf.remove(el)
+      case WeakReference(el) =>
+      case t => objectsToKeepTrackOf.remove(t) //weak refernce has expired
+    }
+    res
+  }
+
+  def objectsToKeepTrackOfNormalReferences: mutable.Set[Any] = {
+    import scala.collection.JavaConversions._
+    objectsToKeepTrackOf.collect {
+      case WeakReference(ref) => ref
+    }
+  }
+
+  //this method may take a while time to run
+  def spaceTakenByCache: Long = {
+    try {
+      objectsToKeepTrackOfNormalReferences.map(memoryMeter.measureDeep).sum
+    } catch {
+      case e@(_: AssertionError | _: IllegalStateException) =>
+        println(e.getMessage) //message is probably: Instrumentation is not set; Jamm must be set as -javaagent
+        print("Not counting size of cache")
+        -1
+    }
+
+  }
+
+  override def toString: String = {
+    import scala.collection.JavaConversions._
+    val calcTimes: Set[Long] = calculationTimes.toSet //efficient because not conccurent
+
+    val averageTimes =
+      if (calcTimes.nonEmpty) {
+        s"average time to calculate: ${calcTimes.sum.toDouble / calcTimes.size}, maxTime: ${calcTimes.max}, minTime: ${calcTimes.min}"
+      } else ""
+
+    s"""
+       |****************************
+       |$name
+       |hits: $hits, misses: $misses
+       |*approximate* spaceTaken: $spaceTakenByCache
+       |$averageTimes
+       |****************************
+     """.stripMargin
+  }
+}
+
+object CacheStatistics {
+  import scala.collection.JavaConversions._
+
+  val memoryMeter = new MemoryMeter()
+
+  //`caches` is empty if compiler flag "-Xmacro-settings:analyze-caches" is empty
+  private val caches = ContainerUtil.newConcurrentMap[String, CacheStatistics]()
+
+  def printStats(): Unit = {
+    caches.values().foreach(c => println(c.toString))
+  }
+
+  def apply(id: String, name: String) = Option(caches.get(id)) match {
+    case Some(res) => res
+    case _ => synchronized {
+      Option(caches.get(id)) match {
+        case Some(res) => res
+        case _ =>
+          val res = new CacheStatistics(id, name)
+          caches.put(id, res)
+          res
+      }
+    }
+  }
+}

--- a/src/org/jetbrains/plugins/scala/statistics/CacheStatistics.scala
+++ b/src/org/jetbrains/plugins/scala/statistics/CacheStatistics.scala
@@ -1,5 +1,7 @@
 package org.jetbrains.plugins.scala.statistics
 
+import java.util.concurrent.ConcurrentHashMap
+
 import com.intellij.util.containers.ContainerUtil
 import org.github.jamm.MemoryMeter
 import org.jetbrains.plugins.scala.statistics.CacheStatistics.memoryMeter
@@ -95,15 +97,14 @@ class CacheStatistics private(id: String, name: String) {
 }
 
 object CacheStatistics {
-  import scala.collection.JavaConversions._
+  import scala.collection.JavaConverters._
 
   val memoryMeter = new MemoryMeter()
 
-  //`caches` is empty if compiler flag "-Xmacro-settings:analyze-caches" is empty
-  private val caches = ContainerUtil.newConcurrentMap[String, CacheStatistics]()
+  private val caches = new ConcurrentHashMap[String, CacheStatistics]()
 
   def printStats(): Unit = {
-    caches.values().foreach(c => println(c.toString))
+    caches.values().asScala.foreach (c => println(c.toString))
   }
 
   def apply(id: String, name: String) = Option(caches.get(id)) match {


### PR DESCRIPTION
This PR allows us to analyze use of caches that use Cached\* annotations

If the compiler flag `-Xmacro-settings:analyze-caches` is not set, absolutely nothing will change.

If it is set, however, (as it is in this PR), after you rebuild the whole project, and run IDEA, all accesses to caches will be recorded. After you close the application, it  will print the stats for each cache to the console.

NOTE: THIS PR SHOULD NOT BE MERGED YET. The reason is that scalacOptions flag is currently set in build.sbt and we don't want to analyze caches in production. 
