### PR TITLE
Scala -> Java: Constructor parameters can be public fields

### DIFF
--- a/src/org/jetbrains/plugins/scala/lang/psi/impl/toplevel/typedef/ScClassImpl.scala
+++ b/src/org/jetbrains/plugins/scala/lang/psi/impl/toplevel/typedef/ScClassImpl.scala
@@ -9,6 +9,7 @@ import com.intellij.lang.ASTNode
 import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.project.DumbService
 import com.intellij.psi._
+import com.intellij.psi.impl.light.LightField
 import com.intellij.psi.stubs.StubElement
 import com.intellij.psi.tree.IElementType
 import com.intellij.psi.util.PsiTreeUtil
@@ -23,7 +24,8 @@ import org.jetbrains.plugins.scala.lang.psi.api.toplevel.typedef._
 import org.jetbrains.plugins.scala.lang.psi.api.toplevel.{ScTypeParametersOwner, ScTypedDefinition}
 import org.jetbrains.plugins.scala.lang.psi.impl.toplevel.typedef.TypeDefinitionMembers.SignatureNodes
 import org.jetbrains.plugins.scala.lang.psi.stubs.ScTemplateDefinitionStub
-import org.jetbrains.plugins.scala.lang.psi.types.{PhysicalSignature, ScSubstitutor}
+import org.jetbrains.plugins.scala.lang.psi.types.result.{Success, TypingContext}
+import org.jetbrains.plugins.scala.lang.psi.types.{PhysicalSignature, ScSubstitutor, ScType, ScTypeParameterType}
 import org.jetbrains.plugins.scala.lang.resolve.processor.BaseProcessor
 import org.jetbrains.plugins.scala.macroAnnotations.{Cached, ModCount}
 
@@ -264,6 +266,25 @@ class ScClassImpl private (stub: StubElement[ScTemplateDefinition], nodeType: IE
         case None => None
       }
     } else None
+  }
+
+  override def getFields: Array[PsiField] = {
+    val fields = constructor match {
+      case Some(constr) => constr.parameters.map { param =>
+        param.getType(TypingContext.empty) match {
+          case Success(tp: ScTypeParameterType, _) if tp.param.findAnnotation("scala.specialized") != null =>
+            val factory: PsiElementFactory = PsiElementFactory.SERVICE.getInstance(getProject)
+            val psiTypeText: String = ScType.toPsi(tp, getProject, getResolveScope).getCanonicalText
+            val text = s"public final $psiTypeText ${param.name};"
+            val elem = new LightField(getManager, factory.createFieldFromText(text, this), this)
+            elem.setNavigationElement(param)
+            Option(elem)
+          case _ => None
+        }
+      }
+      case _ => Seq.empty
+    }
+    super.getFields ++ fields.flatten
   }
 
   override def getTypeParameterList: PsiTypeParameterList = typeParametersClause.orNull

--- a/test/org/jetbrains/plugins/scala/javaHighlighting/JavaHighlightingTest.scala
+++ b/test/org/jetbrains/plugins/scala/javaHighlighting/JavaHighlightingTest.scala
@@ -363,6 +363,19 @@ class JavaHighlightingTest extends ScalaFixtureTestCase {
     assertNoErrors(messagesFromJavaCode(scalaCode, javaCode, "SCL8866B"))
   }
 
+  def testSpecializedFields(): Unit = {
+    val scalaCode = "class SpecClass[@specialized(Int) T](val t: T, val s: String)"
+    val javaCode =
+      """
+        |public class Pair extends SpecClass<Integer> {
+        |    public Pair(SpecClass<Integer> i) {
+        |        super(i.t, "");
+        |    }
+        |}
+      """.stripMargin
+    assertNoErrors(messagesFromJavaCode(scalaCode, javaCode, "Pair"))
+  }
+
   def messagesFromJavaCode(scalaFileText: String, javaFileText: String, javaClassName: String): List[Message] = {
     myFixture.addFileToProject("dummy.scala", scalaFileText)
     val myFile: PsiFile = myFixture.addFileToProject(javaClassName + JavaFileType.DOT_DEFAULT_EXTENSION, javaFileText)


### PR DESCRIPTION
Constructor parameters can be public fields (if their type is specialized generic type)
