### PR TITLE
Fix compatible problem with other NameMapper

### DIFF
--- a/src/org/jetbrains/plugins/scala/debugger/ScalaJVMNameMapper.scala
+++ b/src/org/jetbrains/plugins/scala/debugger/ScalaJVMNameMapper.scala
@@ -19,7 +19,7 @@ class ScalaJVMNameMapper extends NameMapper {
           case obj: ScObject => obj.qualifiedName + "$"
           case tr: ScTrait => tr.qualifiedName
           case templDef: ScTemplateDefinition => templDef.qualifiedName
-          case psiClass => psiClass.getQualifiedName
+          case psiClass => null
         }
       }
     })


### PR DESCRIPTION
IDEA's com.intellij.debugger.impl.DebuggerManagerImpl#getVMClassQualifiedName will iterate all registered NameMapper and return the first not null result from NameMapper.

When install Scala plugin with another plugin which also register a NameMapper to DebugManager, Scala's ScalaJVMNameMapper will return a not null value when the class is not a Scala object. This cause the follow NameMappers dit not got any chance to execute.

Return a null when it is not a Scala object will fix this bug.
