### PR TITLE
Fix broken tests: java's ConcurrentHashMap does not override hashcode

### DIFF
--- a/src/org/jetbrains/plugins/scala/lang/psi/impl/ScalaPsiManager.scala
+++ b/src/org/jetbrains/plugins/scala/lang/psi/impl/ScalaPsiManager.scala
@@ -42,9 +42,9 @@ import scala.collection.{Seq, mutable}
 
 class ScalaPsiManager(project: Project) extends ProjectComponent {
 
-  private val clearCacheOnChange = new util.HashSet[ConcurrentHashMap[_ <: Any, _ <: Any]]()
-  private val clearCacheOnLowMemory = new util.HashSet[ConcurrentHashMap[_ <: Any, _ <: Any]]()
-  private val clearCacheOnOutOfBlockChange = new util.HashSet[ConcurrentHashMap[_ <: Any, _ <: Any]]()
+  private val clearCacheOnChange = new util.ArrayList[ConcurrentHashMap[_ <: Any, _ <: Any]]()
+  private val clearCacheOnLowMemory = new util.ArrayList[ConcurrentHashMap[_ <: Any, _ <: Any]]()
+  private val clearCacheOnOutOfBlockChange = new util.ArrayList[ConcurrentHashMap[_ <: Any, _ <: Any]]()
 
   def getParameterlessSignatures(tp: ScCompoundType, compoundTypeThisType: Option[ScType]): PMap = {
     if (ScalaProjectSettings.getInstance(project).isDontCacheCompoundTypes) ParameterlessNodes.build(tp, compoundTypeThisType)


### PR DESCRIPTION
I learned the hard way that you should always check if an element
overrides hashcode before putting it into a HashSet.
java.util.concurrent.ConcurrentHashMap does not override hashcode,
unlike com.intellij.util.containers.ConcurrentHashMap
Because the latter is deprecated, I decided to use the standard
library one and this is where it got me.
