### PR TITLE
Big performance improvement: Invalidate caches less often

### DIFF
--- a/src/org/jetbrains/plugins/scala/caches/CachesUtil.scala
+++ b/src/org/jetbrains/plugins/scala/caches/CachesUtil.scala
@@ -14,6 +14,7 @@ import org.jetbrains.plugins.scala.lang.psi.api.ScalaFile
 import org.jetbrains.plugins.scala.lang.psi.api.statements.ScFunction
 import org.jetbrains.plugins.scala.lang.psi.api.toplevel.typedef.ScTypeDefinition
 import org.jetbrains.plugins.scala.lang.psi.impl.ScPackageImpl
+import org.jetbrains.plugins.scala.lang.psi.impl.expr.ScBlockExprImpl
 import org.jetbrains.plugins.scala.lang.psi.types.ScType
 
 import scala.util.control.ControlThrowable
@@ -260,8 +261,8 @@ object CachesUtil {
     result
   }
 
-  def getDependentItem(element: PsiElement,
-                       dep_item: Object = PsiModificationTracker.OUT_OF_CODE_BLOCK_MODIFICATION_COUNT): Option[Object] = {
+  //def getDependentItem(element: PsiElement)(dep_item: Object = PsiModificationTracker.OUT_OF_CODE_BLOCK_MODIFICATION_COUNT): Option[Object] = {
+  def getDependentItem(element: PsiElement)(dep_item: Object = enclosingBlockExprModTrackerOrOutOfCodeBlockModTracker(element)): Option[Object] = {
     element.getContainingFile match {
       case file: ScalaFile if file.isCompiled =>
         if (!ProjectRootManager.getInstance(element.getProject).getFileIndex.isInContent(file.getVirtualFile)) {
@@ -275,6 +276,13 @@ object CachesUtil {
         Some(ProjectRootManager.getInstance(element.getProject))
       case cls: ClsFileImpl => Some(ProjectRootManager.getInstance(element.getProject))
       case _ => Some(dep_item)
+    }
+  }
+
+  def enclosingBlockExprModTrackerOrOutOfCodeBlockModTracker(elem: PsiElement): Object = {
+    Option(PsiTreeUtil.getParentOfType(elem, classOf[ScBlockExprImpl])) match {
+      case Some(block) if block.shouldChangeModificationCount(elem) => block.getModificationTracker
+      case _ => PsiModificationTracker.OUT_OF_CODE_BLOCK_MODIFICATION_COUNT
     }
   }
 

--- a/src/org/jetbrains/plugins/scala/lang/psi/api/base/ScInterpolated.scala
+++ b/src/org/jetbrains/plugins/scala/lang/psi/api/base/ScInterpolated.scala
@@ -1,15 +1,15 @@
 package org.jetbrains.plugins.scala
 package lang.psi.api.base
 
-import com.intellij.psi.util.PsiModificationTracker
+import com.intellij.psi.util.{PsiTreeUtil, PsiModificationTracker}
 import com.intellij.psi.{PsiElement, PsiReference}
 import org.jetbrains.plugins.scala.lang.lexer.ScalaTokenTypes
-import org.jetbrains.plugins.scala.lang.psi.ScalaPsiElement
+import org.jetbrains.plugins.scala.lang.psi.{ScalaPsiUtil, ScalaPsiElement}
 import org.jetbrains.plugins.scala.lang.psi.api.base.patterns.ScInterpolationPattern
 import org.jetbrains.plugins.scala.lang.psi.api.expr.{ScBlockExpr, ScExpression, ScReferenceExpression}
 import org.jetbrains.plugins.scala.lang.psi.impl.ScalaPsiElementFactory
 import org.jetbrains.plugins.scala.lang.psi.impl.expr.{ScInterpolatedPrefixReference, ScInterpolatedStringPartReference}
-import org.jetbrains.plugins.scala.macroAnnotations.CachedInsidePsiElement
+import org.jetbrains.plugins.scala.macroAnnotations.{ModCount, CachedInsidePsiElement}
 
 import scala.collection.mutable.ListBuffer
 
@@ -34,7 +34,7 @@ trait ScInterpolated extends ScalaPsiElement {
     res.toArray
   }
 
-  @CachedInsidePsiElement(this, PsiModificationTracker.MODIFICATION_COUNT)
+  @CachedInsidePsiElement(this, ModCount.getBlockModificationCount)
   def getStringContextExpression: Option[ScExpression] = {
     val quote = if (isMultiLineString) "\"\"\"" else "\""
     val parts = getStringParts(this).mkString(quote, s"$quote, $quote", quote) //making list of string literals

--- a/src/org/jetbrains/plugins/scala/lang/psi/api/base/ScMethodLike.scala
+++ b/src/org/jetbrains/plugins/scala/lang/psi/api/base/ScMethodLike.scala
@@ -6,11 +6,13 @@ package base
 
 import com.intellij.psi.PsiMethod
 import com.intellij.psi.util.PsiModificationTracker
+import com.intellij.psi.util.PsiModificationTracker.OUT_OF_CODE_BLOCK_MODIFICATION_COUNT
+import org.jetbrains.plugins.scala.lang.psi.api.expr.ScBlockExpr
 import org.jetbrains.plugins.scala.lang.psi.api.statements.params.{ScParameter, ScParameterClause, ScParameters, ScTypeParamClause}
 import org.jetbrains.plugins.scala.lang.psi.api.toplevel.typedef.{ScMember, ScTypeDefinition}
 import org.jetbrains.plugins.scala.lang.psi.impl.ScalaPsiElementFactory
 import org.jetbrains.plugins.scala.lang.psi.types.ScType
-import org.jetbrains.plugins.scala.macroAnnotations.CachedInsidePsiElement
+import org.jetbrains.plugins.scala.macroAnnotations.{ModCount, CachedInsidePsiElement}
 
 /**
  * A member that can be converted to a ScMethodType, ie a method or a constructor.
@@ -27,7 +29,7 @@ trait ScMethodLike extends ScMember with PsiMethod {
    * in that context it will have different meaning. See SCL-3095.
    * @return generated type parameters only for constructors
    */
-  @CachedInsidePsiElement(this, PsiModificationTracker.MODIFICATION_COUNT)
+  @CachedInsidePsiElement(this, ModCount.getBlockModificationCount)
   def getConstructorTypeParameters: Option[ScTypeParamClause] = {
     this match {
       case method: PsiMethod if method.isConstructor =>

--- a/src/org/jetbrains/plugins/scala/lang/psi/api/base/ScPrimaryConstructor.scala
+++ b/src/org/jetbrains/plugins/scala/lang/psi/api/base/ScPrimaryConstructor.scala
@@ -5,6 +5,8 @@ package api
 package base
 
 import com.intellij.psi.util.PsiModificationTracker
+import com.intellij.psi.util.PsiModificationTracker.{OUT_OF_CODE_BLOCK_MODIFICATION_COUNT, MODIFICATION_COUNT}
+import org.jetbrains.plugins.scala.lang.psi.api.expr.ScBlockExpr
 import org.jetbrains.plugins.scala.lang.psi.api.statements.ScAnnotationsHolder
 import org.jetbrains.plugins.scala.lang.psi.api.statements.params._
 import org.jetbrains.plugins.scala.lang.psi.api.toplevel.ScTypeParametersOwner
@@ -49,7 +51,7 @@ trait ScPrimaryConstructor extends ScMember with ScMethodLike with ScAnnotations
    *
    * In addition, view and context bounds generate an additional implicit parameter section.
    */
-  @CachedInsidePsiElement(this, PsiModificationTracker.MODIFICATION_COUNT)
+  @CachedInsidePsiElement(this, ModCount.getBlockModificationCount)
   def effectiveParameterClauses: Seq[ScParameterClause] = {
     def emptyParameterList: ScParameterClause =
       ScalaPsiElementFactory.createEmptyClassParamClauseWithContext(getManager, parameterList)
@@ -111,7 +113,7 @@ trait ScPrimaryConstructor extends ScMember with ScMethodLike with ScAnnotations
     }
   }
 
-  @Cached(synchronized = false, ModCount.getOutOfCodeBlockModificationCount, getManager)
+  @Cached(synchronized = false, ModCount.getOutOfCodeBlockModificationCount, this)
   def getFunctionWrappers: Seq[ScPrimaryConstructorWrapper] = {
     val buffer = new ArrayBuffer[ScPrimaryConstructorWrapper]()
     buffer += new ScPrimaryConstructorWrapper(this)

--- a/src/org/jetbrains/plugins/scala/lang/psi/api/base/patterns/ScPattern.scala
+++ b/src/org/jetbrains/plugins/scala/lang/psi/api/base/patterns/ScPattern.scala
@@ -7,6 +7,7 @@ package patterns
 
 import com.intellij.psi._
 import com.intellij.psi.util.PsiModificationTracker
+import com.intellij.psi.util.PsiModificationTracker._
 import org.jetbrains.plugins.scala.extensions._
 import org.jetbrains.plugins.scala.lang.psi.api.base.types.ScTypeVariableTypeElement
 import org.jetbrains.plugins.scala.lang.psi.api.expr._
@@ -21,7 +22,7 @@ import org.jetbrains.plugins.scala.lang.psi.types._
 import org.jetbrains.plugins.scala.lang.psi.types.result.{Failure, Success, TypeResult, TypingContext}
 import org.jetbrains.plugins.scala.lang.resolve._
 import org.jetbrains.plugins.scala.lang.resolve.processor.{CompletionProcessor, ExpandedExtractorResolveProcessor}
-import org.jetbrains.plugins.scala.macroAnnotations.CachedInsidePsiElement
+import org.jetbrains.plugins.scala.macroAnnotations.{ModCount, CachedInsidePsiElement}
 import org.jetbrains.plugins.scala.project.ScalaLanguageLevel.Scala_2_11
 import org.jetbrains.plugins.scala.project._
 
@@ -220,7 +221,7 @@ trait ScPattern extends ScalaPsiElement {
     }
   }
 
-  @CachedInsidePsiElement(this, PsiModificationTracker.MODIFICATION_COUNT)
+  @CachedInsidePsiElement(this, ModCount.getBlockModificationCount)
   def expectedType: Option[ScType] = getContext match {
     case list : ScPatternList => list.getContext match {
       case _var : ScVariable => Some(_var.getType(TypingContext.empty) match {

--- a/src/org/jetbrains/plugins/scala/lang/psi/api/base/types/ScTypeElement.scala
+++ b/src/org/jetbrains/plugins/scala/lang/psi/api/base/types/ScTypeElement.scala
@@ -5,18 +5,18 @@ package api
 package base
 package types
 
-import com.intellij.psi.util.PsiModificationTracker
 import org.jetbrains.plugins.scala.lang.psi.api.statements.params.ScTypeParam
 import org.jetbrains.plugins.scala.lang.psi.types._
 import org.jetbrains.plugins.scala.lang.psi.types.result.{Failure, TypeResult, TypingContext, TypingContextOwner}
-import org.jetbrains.plugins.scala.macroAnnotations.CachedWithRecursionGuard
+import org.jetbrains.plugins.scala.macroAnnotations.{CachedWithRecursionGuard, ModCount}
 
 /**
 * @author Alexander Podkhalyuzin
 */
 
 trait ScTypeElement extends ScalaPsiElement with TypingContextOwner {
-  @CachedWithRecursionGuard[ScTypeElement](this, Failure("Recursive type of type element", Some(this)), PsiModificationTracker.MODIFICATION_COUNT)
+  @CachedWithRecursionGuard[ScTypeElement](this, Failure("Recursive type of type element", Some(this)),
+    ModCount.getBlockModificationCount)
   def getType(ctx: TypingContext): TypeResult[ScType] = innerType(ctx)
 
   override def toString: String = super.toString

--- a/src/org/jetbrains/plugins/scala/lang/psi/api/statements/ScFunction.scala
+++ b/src/org/jetbrains/plugins/scala/lang/psi/api/statements/ScFunction.scala
@@ -16,7 +16,7 @@ import com.intellij.psi.PsiReferenceList.Role
 import com.intellij.psi._
 import com.intellij.psi.impl.source.HierarchicalMethodSignatureImpl
 import com.intellij.psi.tree.TokenSet
-import com.intellij.psi.util.{MethodSignatureBackedByPsiMethod, PsiModificationTracker}
+import com.intellij.psi.util.MethodSignatureBackedByPsiMethod
 import org.jetbrains.plugins.scala.extensions._
 import org.jetbrains.plugins.scala.icons.Icons
 import org.jetbrains.plugins.scala.lang.lexer.ScalaTokenTypes
@@ -308,7 +308,7 @@ trait ScFunction extends ScalaPsiElement with ScMember with ScTypeParametersOwne
 
   def paramTypes: Seq[ScType] = parameters.map {_.getType(TypingContext.empty).getOrNothing}
 
-  @CachedInsidePsiElement(this, PsiModificationTracker.MODIFICATION_COUNT)
+  @CachedInsidePsiElement(this, ModCount.getBlockModificationCount)
   def effectiveParameterClauses: Seq[ScParameterClause] = paramClauses.clauses ++ syntheticParamClause
 
   private def syntheticParamClause: Option[ScParameterClause] = {
@@ -410,7 +410,7 @@ trait ScFunction extends ScalaPsiElement with ScMember with ScTypeParametersOwne
   /**
    * @return Empty array, if containing class is null.
    */
-  @Cached(synchronized = false, ModCount.getOutOfCodeBlockModificationCount, getManager)
+  @Cached(synchronized = false, ModCount.getOutOfCodeBlockModificationCount, this)
   def getFunctionWrappers(isStatic: Boolean, isInterface: Boolean, cClass: Option[PsiClass] = None): Seq[ScFunctionWrapper] = {
     val buffer = new ArrayBuffer[ScFunctionWrapper]
     if (cClass.isDefined || containingClass != null) {
@@ -444,7 +444,7 @@ trait ScFunction extends ScalaPsiElement with ScMember with ScTypeParametersOwne
     getReturnTypeImpl
   }
 
-  @CachedInsidePsiElement(this, PsiModificationTracker.MODIFICATION_COUNT)
+  @CachedInsidePsiElement(this, ModCount.getBlockModificationCount)
   private def getReturnTypeImpl: PsiType = {
     val tp = getType(TypingContext.empty).getOrAny
     tp match {
@@ -661,7 +661,7 @@ trait ScFunction extends ScalaPsiElement with ScMember with ScTypeParametersOwne
     }
   }
 
-  @Cached(synchronized = false, ModCount.getModificationCount, getManager)
+  @Cached(synchronized = false, ModCount.getModificationCount, this)
   def collectReverseParamTypesNoImplicits: Option[Seq[Seq[ScType]]] = {
     var i = paramClauses.clauses.length - 1
     val res: ArrayBuffer[Seq[ScType]] = ArrayBuffer.empty

--- a/src/org/jetbrains/plugins/scala/lang/psi/api/statements/ScFunctionDefinition.scala
+++ b/src/org/jetbrains/plugins/scala/lang/psi/api/statements/ScFunctionDefinition.scala
@@ -93,7 +93,7 @@ trait ScFunctionDefinition extends ScFunction with ScControlFlowOwner {
 
   def isSecondaryConstructor: Boolean = name == "this"
 
-  @Cached(synchronized = false, ModCount.getOutOfCodeBlockModificationCount, getManager)
+  @Cached(synchronized = false, ModCount.getOutOfCodeBlockModificationCount, this)
   def getStaticTraitFunctionWrapper(cClass: PsiClassWrapper): StaticTraitScFunctionWrapper = {
     new StaticTraitScFunctionWrapper(this, cClass)
   }

--- a/src/org/jetbrains/plugins/scala/lang/psi/api/statements/ScTypeAliasDefinition.scala
+++ b/src/org/jetbrains/plugins/scala/lang/psi/api/statements/ScTypeAliasDefinition.scala
@@ -4,7 +4,6 @@ package psi
 package api
 package statements
 
-import com.intellij.psi.util.PsiModificationTracker
 import com.intellij.psi.{PsiClass, PsiElement}
 import org.jetbrains.plugins.scala.lang.psi.api.base.types.ScTypeElement
 import org.jetbrains.plugins.scala.lang.psi.api.statements.params.ScTypeParam
@@ -13,7 +12,7 @@ import org.jetbrains.plugins.scala.lang.psi.api.toplevel.typedef.{ScClass, ScObj
 import org.jetbrains.plugins.scala.lang.psi.stubs.ScTypeAliasStub
 import org.jetbrains.plugins.scala.lang.psi.types.result.{Failure, TypeResult, TypingContext}
 import org.jetbrains.plugins.scala.lang.psi.types.{Equivalence, ScParameterizedType, ScType, ScTypeParameterType}
-import org.jetbrains.plugins.scala.macroAnnotations.CachedInsidePsiElement
+import org.jetbrains.plugins.scala.macroAnnotations.{CachedInsidePsiElement, ModCount}
 
 /**
 * @author Alexander Podkhalyuzin
@@ -38,7 +37,7 @@ trait ScTypeAliasDefinition extends ScTypeAlias {
     }
   }
 
-  @CachedInsidePsiElement(this, PsiModificationTracker.MODIFICATION_COUNT)
+  @CachedInsidePsiElement(this, ModCount.getBlockModificationCount)
   def aliasedType: TypeResult[ScType] = aliasedType(TypingContext.empty)
 
   def lowerBound: TypeResult[ScType] = aliasedType(TypingContext.empty)

--- a/src/org/jetbrains/plugins/scala/lang/psi/api/statements/params/ScParameter.scala
+++ b/src/org/jetbrains/plugins/scala/lang/psi/api/statements/params/ScParameter.scala
@@ -162,7 +162,7 @@ trait ScParameter extends ScTypedDefinition with ScModifierListOwner with
 
   def getTypeNoResolve: PsiType = PsiType.VOID
 
-  @Cached(synchronized = false, ModCount.getModificationCount, getManager)
+  @Cached(synchronized = false, ModCount.getModificationCount, this)
   def isDefaultParam: Boolean = calcIsDefaultParam(this, HashSet.empty)
 
 

--- a/src/org/jetbrains/plugins/scala/lang/psi/api/toplevel/ScTypedDefinition.scala
+++ b/src/org/jetbrains/plugins/scala/lang/psi/api/toplevel/ScTypedDefinition.scala
@@ -30,7 +30,7 @@ trait ScTypedDefinition extends ScNamedElement with TypingContextOwner {
     case (tpe, index) => new Parameter("", None, tpe, false, false, false, index)
   }.toArray
 
-  @Cached(synchronized = false, modificationCount = ModCount.getOutOfCodeBlockModificationCount, getManager)
+  @Cached(synchronized = false, modificationCount = ModCount.getOutOfCodeBlockModificationCount, this)
   def getUnderEqualsMethod: PsiMethod = {
     val hasModifierProperty: String => Boolean = nameContext match {
       case v: ScModifierListOwner => v.hasModifierProperty
@@ -40,7 +40,7 @@ trait ScTypedDefinition extends ScNamedElement with TypingContextOwner {
     new FakePsiMethod(this, name + "_=", typeArr2paramArr(Array[ScType](tType)), types.Unit, hasModifierProperty)
   }
 
-  @Cached(synchronized = false, modificationCount = ModCount.getOutOfCodeBlockModificationCount, getManager)
+  @Cached(synchronized = false, modificationCount = ModCount.getOutOfCodeBlockModificationCount, this)
   def getGetBeanMethod: PsiMethod = {
     val hasModifierProperty: String => Boolean = nameContext match {
       case v: ScModifierListOwner => v.hasModifierProperty
@@ -50,7 +50,7 @@ trait ScTypedDefinition extends ScNamedElement with TypingContextOwner {
       this.getType(TypingContext.empty).getOrAny, hasModifierProperty)
   }
 
-  @Cached(synchronized = false, modificationCount = ModCount.getOutOfCodeBlockModificationCount, getManager)
+  @Cached(synchronized = false, modificationCount = ModCount.getOutOfCodeBlockModificationCount, this)
   def getSetBeanMethod: PsiMethod = {
     val hasModifierProperty: String => Boolean = nameContext match {
       case v: ScModifierListOwner => v.hasModifierProperty
@@ -60,7 +60,7 @@ trait ScTypedDefinition extends ScNamedElement with TypingContextOwner {
     new FakePsiMethod(this, "set" + name.capitalize, typeArr2paramArr(Array[ScType](tType)), types.Unit, hasModifierProperty)
   }
 
-  @Cached(synchronized = false, modificationCount = ModCount.getOutOfCodeBlockModificationCount, getManager)
+  @Cached(synchronized = false, modificationCount = ModCount.getOutOfCodeBlockModificationCount, this)
   def getIsBeanMethod: PsiMethod = {
     val hasModifierProperty: String => Boolean = nameContext match {
       case v: ScModifierListOwner => v.hasModifierProperty
@@ -70,7 +70,7 @@ trait ScTypedDefinition extends ScNamedElement with TypingContextOwner {
       this.getType(TypingContext.empty).getOrAny, hasModifierProperty)
   }
 
-  @Cached(synchronized = false, modificationCount = ModCount.getOutOfCodeBlockModificationCount, getManager)
+  @Cached(synchronized = false, modificationCount = ModCount.getOutOfCodeBlockModificationCount, this)
   def getBeanMethods: Seq[PsiMethod] = {
     def valueSeq(v: ScAnnotationsHolder with ScModifierListOwner): Seq[PsiMethod] = {
       val beanProperty = ScalaPsiUtil.isBeanProperty(v)
@@ -101,13 +101,13 @@ trait ScTypedDefinition extends ScNamedElement with TypingContextOwner {
 
   import org.jetbrains.plugins.scala.lang.psi.light.PsiTypedDefinitionWrapper.DefinitionRole._
 
-  @Cached(synchronized = false, modificationCount = ModCount.getOutOfCodeBlockModificationCount, getManager)
+  @Cached(synchronized = false, modificationCount = ModCount.getOutOfCodeBlockModificationCount, this)
   def getTypedDefinitionWrapper(isStatic: Boolean, isInterface: Boolean, role: DefinitionRole,
                                 cClass: Option[PsiClass] = None): PsiTypedDefinitionWrapper = {
     new PsiTypedDefinitionWrapper(this, isStatic, isInterface, role, cClass)
   }
 
-  @Cached(synchronized = false, modificationCount = ModCount.getOutOfCodeBlockModificationCount, getManager)
+  @Cached(synchronized = false, modificationCount = ModCount.getOutOfCodeBlockModificationCount, this)
   def getStaticTypedDefinitionWrapper(role: DefinitionRole, cClass: PsiClassWrapper): StaticPsiTypedDefinitionWrapper = {
     new StaticPsiTypedDefinitionWrapper(this, role, cClass)
   }

--- a/src/org/jetbrains/plugins/scala/lang/psi/api/toplevel/typedef/ScTemplateDefinition.scala
+++ b/src/org/jetbrains/plugins/scala/lang/psi/api/toplevel/typedef/ScTemplateDefinition.scala
@@ -17,10 +17,12 @@ import com.intellij.psi.impl.{PsiClassImplUtil, PsiSuperMethodImplUtil}
 import com.intellij.psi.scope.PsiScopeProcessor
 import com.intellij.psi.scope.processor.MethodsProcessor
 import com.intellij.psi.search.GlobalSearchScope
+import com.intellij.psi.util.PsiModificationTracker._
 import com.intellij.psi.util.{PsiModificationTracker, PsiTreeUtil, PsiUtil}
 import org.jetbrains.plugins.scala.extensions._
 import org.jetbrains.plugins.scala.lang.parser.ScalaElementTypes
 import org.jetbrains.plugins.scala.lang.psi.api.base.types.ScSelfTypeElement
+import org.jetbrains.plugins.scala.lang.psi.api.expr.ScBlockExpr
 import org.jetbrains.plugins.scala.lang.psi.api.statements._
 import org.jetbrains.plugins.scala.lang.psi.api.toplevel.templates.ScExtendsBlock
 import org.jetbrains.plugins.scala.lang.psi.impl.ScalaPsiElementFactory
@@ -29,7 +31,7 @@ import org.jetbrains.plugins.scala.lang.psi.light.ScFunctionWrapper
 import org.jetbrains.plugins.scala.lang.psi.types._
 import org.jetbrains.plugins.scala.lang.psi.types.result.{TypeResult, TypingContext}
 import org.jetbrains.plugins.scala.lang.resolve.processor.BaseProcessor
-import org.jetbrains.plugins.scala.macroAnnotations.CachedInsidePsiElement
+import org.jetbrains.plugins.scala.macroAnnotations.{ModCount, CachedInsidePsiElement}
 
 /**
  * @author ven
@@ -138,7 +140,7 @@ trait ScTemplateDefinition extends ScNamedElement with PsiClass {
   def functions: Seq[ScFunction] = extendsBlock.functions
   def aliases: Seq[ScTypeAlias] = extendsBlock.aliases
 
-  @CachedInsidePsiElement(this, PsiModificationTracker.OUT_OF_CODE_BLOCK_MODIFICATION_COUNT)
+  @CachedInsidePsiElement(this, ModCount.getBlockModificationCount)
   def syntheticMethodsWithOverride: Seq[PsiMethod] = syntheticMethodsWithOverrideImpl
 
   /**
@@ -148,14 +150,14 @@ trait ScTemplateDefinition extends ScNamedElement with PsiClass {
 
   def allSynthetics: Seq[PsiMethod] = syntheticMethodsNoOverride ++ syntheticMethodsWithOverride
 
-  @CachedInsidePsiElement(this, PsiModificationTracker.OUT_OF_CODE_BLOCK_MODIFICATION_COUNT)
+  @CachedInsidePsiElement(this, ModCount.getBlockModificationCount)
   def syntheticMethodsNoOverride: Seq[PsiMethod] = syntheticMethodsNoOverrideImpl
 
   protected def syntheticMethodsNoOverrideImpl: Seq[PsiMethod] = Seq.empty
 
   def typeDefinitions: Seq[ScTypeDefinition] = extendsBlock.typeDefinitions
 
-  @CachedInsidePsiElement(this, PsiModificationTracker.OUT_OF_CODE_BLOCK_MODIFICATION_COUNT)
+  @CachedInsidePsiElement(this, ModCount.getBlockModificationCount)
   def syntheticTypeDefinitions: Seq[ScTypeDefinition] = syntheticTypeDefinitionsImpl
 
   def syntheticTypeDefinitionsImpl: Seq[ScTypeDefinition] = Seq.empty

--- a/src/org/jetbrains/plugins/scala/lang/psi/api/toplevel/typedef/ScTypeDefinition.scala
+++ b/src/org/jetbrains/plugins/scala/lang/psi/api/toplevel/typedef/ScTypeDefinition.scala
@@ -84,7 +84,7 @@ trait ScTypeDefinition extends ScTemplateDefinition with ScMember
     calcFakeCompanionModule()
   }
 
-  @Cached(synchronized = true, modificationCount = ModCount.getModificationCount, getManager)
+  @Cached(synchronized = true, modificationCount = ModCount.getModificationCount, this)
   def calcFakeCompanionModule(): Option[ScObject] = {
     val accessModifier = getModifierList.accessModifier.fold("")(_.modifierFormattedText + " ")
     val objText = this match {

--- a/src/org/jetbrains/plugins/scala/lang/psi/impl/base/types/ScFunctionalTypeElementImpl.scala
+++ b/src/org/jetbrains/plugins/scala/lang/psi/impl/base/types/ScFunctionalTypeElementImpl.scala
@@ -20,7 +20,7 @@ import org.jetbrains.plugins.scala.macroAnnotations.{Cached, ModCount}
 class ScFunctionalTypeElementImpl(node: ASTNode) extends ScalaPsiElementImpl(node) with ScFunctionalTypeElement {
   override def toString: String = "FunctionalType: " + getText
 
-  @Cached(synchronized = true, ModCount.getModificationCount, getManager)
+  @Cached(synchronized = true, ModCount.getModificationCount, this)
   def desugarizedInfixType: Option[ScParameterizedTypeElement] = {
     val paramTypes = paramTypeElement match {
       case tup: ScTupleTypeElement => tup.components

--- a/src/org/jetbrains/plugins/scala/lang/psi/impl/base/types/ScInfixTypeElementImpl.scala
+++ b/src/org/jetbrains/plugins/scala/lang/psi/impl/base/types/ScInfixTypeElementImpl.scala
@@ -25,7 +25,7 @@ class ScInfixTypeElementImpl(node: ASTNode) extends ScalaPsiElementImpl(node) wi
     case _ => None
   }
 
-  @Cached(synchronized = true, ModCount.getModificationCount, getManager)
+  @Cached(synchronized = true, ModCount.getModificationCount, this)
   def desugarizedInfixType: Option[ScParameterizedTypeElement] = {
     val newTypeText = s"${ref.getText}[${lOp.getText}, ${rOp.map(_.getText).getOrElse("Nothing")}}]"
     val newTypeElement = ScalaPsiElementFactory.createTypeElementFromText(newTypeText, getContext, this)

--- a/src/org/jetbrains/plugins/scala/lang/psi/impl/base/types/ScParameterizedTypeElementImpl.scala
+++ b/src/org/jetbrains/plugins/scala/lang/psi/impl/base/types/ScParameterizedTypeElementImpl.scala
@@ -43,7 +43,7 @@ class ScParameterizedTypeElementImpl(node: ASTNode) extends ScalaPsiElementImpl(
   private var desugarizedType: Option[ScTypeElement] = null
 
   //computes desugarized type either for existential type or one of kind projector types
-  @Cached(synchronized = true, ModCount.getModificationCount, getManager)
+  @Cached(synchronized = true, ModCount.getModificationCount, this)
   def computeDesugarizedType: Option[ScTypeElement] = {
     val inlineSyntaxIds = Set("?", "+?", "-?")
 

--- a/src/org/jetbrains/plugins/scala/lang/psi/impl/base/types/ScSimpleTypeElementImpl.scala
+++ b/src/org/jetbrains/plugins/scala/lang/psi/impl/base/types/ScSimpleTypeElementImpl.scala
@@ -8,13 +8,14 @@ package types
 import com.intellij.lang.ASTNode
 import com.intellij.openapi.progress.ProgressManager
 import com.intellij.psi._
+import com.intellij.psi.util.PsiModificationTracker._
 import com.intellij.psi.util.{PsiModificationTracker, PsiTreeUtil}
 import org.jetbrains.plugins.scala.extensions._
 import org.jetbrains.plugins.scala.lang.lexer.ScalaTokenTypes
 import org.jetbrains.plugins.scala.lang.psi.ScalaPsiUtil.SafeCheckException
 import org.jetbrains.plugins.scala.lang.psi.api.base._
 import org.jetbrains.plugins.scala.lang.psi.api.base.types._
-import org.jetbrains.plugins.scala.lang.psi.api.expr.{ScSuperReference, ScThisReference, ScUnderScoreSectionUtil}
+import org.jetbrains.plugins.scala.lang.psi.api.expr.{ScBlockExpr, ScSuperReference, ScThisReference, ScUnderScoreSectionUtil}
 import org.jetbrains.plugins.scala.lang.psi.api.statements._
 import org.jetbrains.plugins.scala.lang.psi.api.statements.params.ScTypeParam
 import org.jetbrains.plugins.scala.lang.psi.api.toplevel.ScTypeParametersOwner
@@ -27,7 +28,7 @@ import org.jetbrains.plugins.scala.lang.psi.types._
 import org.jetbrains.plugins.scala.lang.psi.types.nonvalue.{Parameter, ScMethodType, ScTypePolymorphicType, TypeParameter}
 import org.jetbrains.plugins.scala.lang.psi.types.result.{Failure, Success, TypeResult, TypingContext}
 import org.jetbrains.plugins.scala.lang.resolve.ScalaResolveResult
-import org.jetbrains.plugins.scala.macroAnnotations.CachedWithRecursionGuard
+import org.jetbrains.plugins.scala.macroAnnotations.{ModCount, CachedWithRecursionGuard}
 
 import scala.collection.immutable.HashMap
 
@@ -58,8 +59,9 @@ class ScSimpleTypeElementImpl(node: ASTNode) extends ScalaPsiElementImpl(node) w
   override def getTypeNoConstructor(ctx: TypingContext): TypeResult[ScType] = innerNonValueType(ctx, inferValueType = true, noConstructor = true)
 
   @CachedWithRecursionGuard[ScSimpleTypeElement](this, Failure("Recursive non value type of type element", Some(this)),
-    PsiModificationTracker.MODIFICATION_COUNT)
+    ModCount.getBlockModificationCount)
   override def getNonValueType(ctx: TypingContext): TypeResult[ScType] = innerNonValueType(ctx, inferValueType = false)
+
 
   private def innerNonValueType(ctx: TypingContext, inferValueType: Boolean, noConstructor: Boolean = false): TypeResult[ScType] = {
     ProgressManager.checkCanceled()

--- a/src/org/jetbrains/plugins/scala/lang/psi/impl/base/types/ScTupleTypeElementImpl.scala
+++ b/src/org/jetbrains/plugins/scala/lang/psi/impl/base/types/ScTupleTypeElementImpl.scala
@@ -20,7 +20,7 @@ import org.jetbrains.plugins.scala.macroAnnotations.{Cached, ModCount}
 class ScTupleTypeElementImpl(node: ASTNode) extends ScalaPsiElementImpl(node) with ScTupleTypeElement {
   override def toString: String = "TupleType: " + getText
 
-  @Cached(synchronized = true, ModCount.getModificationCount, getManager)
+  @Cached(synchronized = true, ModCount.getModificationCount, this)
   def desugarizedInfixType: Option[ScParameterizedTypeElement] = {
     val n = components.length
     val newTypeText = s"_root_.scala.Tuple$n[${components.map(_.getText).mkString(", ")}]"

--- a/src/org/jetbrains/plugins/scala/lang/psi/impl/expr/ScAssignStmtImpl.scala
+++ b/src/org/jetbrains/plugins/scala/lang/psi/impl/expr/ScAssignStmtImpl.scala
@@ -46,13 +46,13 @@ class ScAssignStmtImpl(node: ASTNode) extends ScalaPsiElementImpl(node) with ScA
     }
   }
 
-  @Cached(synchronized = false, ModCount.getModificationCount, getManager)
+  @Cached(synchronized = false, ModCount.getModificationCount, this)
   def resolveAssignment: Option[ScalaResolveResult] = resolveAssignmentInner(shapeResolve = false)
 
-  @Cached(synchronized = false, ModCount.getModificationCount, getManager)
+  @Cached(synchronized = false, ModCount.getModificationCount, this)
   def shapeResolveAssignment: Option[ScalaResolveResult] = resolveAssignmentInner(shapeResolve = true)
 
-  @Cached(synchronized = false, ModCount.getModificationCount, getManager)
+  @Cached(synchronized = false, ModCount.getModificationCount, this)
   def mirrorMethodCall: Option[ScMethodCall] = {
     getLExpression match {
       case ref: ScReferenceExpression =>

--- a/src/org/jetbrains/plugins/scala/lang/psi/impl/expr/ScForStatementImpl.scala
+++ b/src/org/jetbrains/plugins/scala/lang/psi/impl/expr/ScForStatementImpl.scala
@@ -200,7 +200,7 @@ class ScForStatementImpl(node: ASTNode) extends ScalaPsiElementImpl(node) with S
     Some(exprText.toString())
   }
 
-  @Cached(synchronized = true, ModCount.getModificationCount, getManager)
+  @Cached(synchronized = true, ModCount.getModificationCount, this)
   def getDesugarizedExpr: Option[ScExpression] = {
     val res = getDesugarizedExprText(forDisplay = false) match {
       case Some(text) =>

--- a/src/org/jetbrains/plugins/scala/lang/psi/impl/toplevel/templates/ScExtendsBlockImpl.scala
+++ b/src/org/jetbrains/plugins/scala/lang/psi/impl/toplevel/templates/ScExtendsBlockImpl.scala
@@ -10,7 +10,6 @@ import com.intellij.lang.ASTNode
 import com.intellij.psi.PsiClass
 import com.intellij.psi.stubs.StubElement
 import com.intellij.psi.tree.IElementType
-import com.intellij.psi.util.PsiModificationTracker
 import org.jetbrains.plugins.scala.extensions._
 import org.jetbrains.plugins.scala.lang.lexer.ScalaTokenTypes
 import org.jetbrains.plugins.scala.lang.parser.ScalaElementTypes
@@ -23,7 +22,7 @@ import org.jetbrains.plugins.scala.lang.psi.impl.toplevel.synthetic.ScSyntheticC
 import org.jetbrains.plugins.scala.lang.psi.stubs.ScExtendsBlockStub
 import org.jetbrains.plugins.scala.lang.psi.types.result.{Success, TypingContext}
 import org.jetbrains.plugins.scala.lang.psi.types.{ScCompoundType, ScDesignatorType, _}
-import org.jetbrains.plugins.scala.macroAnnotations.CachedInsidePsiElement
+import org.jetbrains.plugins.scala.macroAnnotations.{CachedInsidePsiElement, ModCount}
 
 import scala.annotation.tailrec
 import scala.collection.Seq
@@ -76,7 +75,7 @@ class ScExtendsBlockImpl private (stub: StubElement[ScExtendsBlock], nodeType: I
     res
   }
 
-  @CachedInsidePsiElement(this, PsiModificationTracker.MODIFICATION_COUNT)
+  @CachedInsidePsiElement(this, ModCount.getBlockModificationCount)
   def superTypes: List[ScType] = {
     val buffer = new ListBuffer[ScType]
     def addType(t: ScType) {
@@ -181,7 +180,7 @@ class ScExtendsBlockImpl private (stub: StubElement[ScExtendsBlock], nodeType: I
     }
   }
 
-  @CachedInsidePsiElement(this, PsiModificationTracker.MODIFICATION_COUNT)
+  @CachedInsidePsiElement(this, ModCount.getBlockModificationCount)
   def supers: Seq[PsiClass] = {
     val buffer = new ListBuffer[PsiClass]
     def addClass(t: PsiClass) {

--- a/src/org/jetbrains/plugins/scala/lang/psi/impl/toplevel/typedef/MixinNodes.scala
+++ b/src/org/jetbrains/plugins/scala/lang/psi/impl/toplevel/typedef/MixinNodes.scala
@@ -455,7 +455,7 @@ abstract class MixinNodes {
 
 object MixinNodes {
   def linearization(clazz: PsiClass): Seq[ScType] = {
-    @CachedWithRecursionGuard[PsiClass](clazz, Seq.empty, CachesUtil.getDependentItem(clazz), useOptionalProvider = true)
+    @CachedWithRecursionGuard[PsiClass](clazz, Seq.empty, CachesUtil.getDependentItem(clazz)(), useOptionalProvider = true)
     def inner(): Seq[ScType] = {
       clazz match {
         case obj: ScObject if obj.isPackageObject && obj.qualifiedName == "scala" =>

--- a/src/org/jetbrains/plugins/scala/lang/psi/impl/toplevel/typedef/ScClassImpl.scala
+++ b/src/org/jetbrains/plugins/scala/lang/psi/impl/toplevel/typedef/ScClassImpl.scala
@@ -251,7 +251,7 @@ class ScClassImpl private (stub: StubElement[ScTemplateDefinition], nodeType: IE
       " = throw new Error(\"\")"
   }
 
-  @Cached(synchronized = false, ModCount.getOutOfCodeBlockModificationCount, getManager)
+  @Cached(synchronized = false, ModCount.getOutOfCodeBlockModificationCount, this)
   def getSyntheticImplicitMethod: Option[ScFunction] = {
     if (hasModifierProperty("implicit")) {
       constructor match {

--- a/src/org/jetbrains/plugins/scala/lang/psi/impl/toplevel/typedef/ScObjectImpl.scala
+++ b/src/org/jetbrains/plugins/scala/lang/psi/impl/toplevel/typedef/ScObjectImpl.scala
@@ -177,7 +177,7 @@ class ScObjectImpl protected (stub: StubElement[ScTemplateDefinition], nodeType:
     }
   }
 
-  @Cached(synchronized = false, ModCount.getOutOfCodeBlockModificationCount, getManager)
+  @Cached(synchronized = false, ModCount.getOutOfCodeBlockModificationCount, this)
   private def getModuleField: Option[PsiField] = {
     if (getQualifiedName.split('.').exists(JavaLexer.isKeyword(_, PsiUtil.getLanguageLevel(this)))) None
     else {
@@ -230,7 +230,7 @@ class ScObjectImpl protected (stub: StubElement[ScTemplateDefinition], nodeType:
   @volatile
   private var emptyObjectConstructorModCount: Long = 0L
 
-  @Cached(synchronized = false, ModCount.getOutOfCodeBlockModificationCount, getManager)
+  @Cached(synchronized = false, ModCount.getOutOfCodeBlockModificationCount, this)
   override def getConstructors: Array[PsiMethod] = Array(new EmptyPrivateConstructor(this))
 
   override def isPhysical: Boolean = {

--- a/src/org/jetbrains/plugins/scala/lang/psi/impl/toplevel/typedef/ScTypeDefinitionImpl.scala
+++ b/src/org/jetbrains/plugins/scala/lang/psi/impl/toplevel/typedef/ScTypeDefinitionImpl.scala
@@ -188,7 +188,7 @@ extends ScalaStubBasedElementImpl(stub, nodeType, node) with ScTypeDefinition wi
     else javaQualName()
   }
 
-  @Cached(synchronized = false, ModCount.getOutOfCodeBlockModificationCount, getManager)
+  @Cached(synchronized = false, ModCount.getOutOfCodeBlockModificationCount, this)
   private def javaQualName(): String = {
     var res = qualifiedName(".", encodeName = true).split('.').map { s =>
       if (s.startsWith("`") && s.endsWith("`") && s.length > 2) s.drop(1).dropRight(1)
@@ -209,7 +209,7 @@ extends ScalaStubBasedElementImpl(stub, nodeType, node) with ScTypeDefinition wi
     else qualName()
   }
 
-  @Cached(synchronized = false, ModCount.getOutOfCodeBlockModificationCount, getManager)
+  @Cached(synchronized = false, ModCount.getOutOfCodeBlockModificationCount, this)
   private def qualName(): String = qualifiedName(".")
 
   override def getExtendsListTypes: Array[PsiClassType] = innerExtendsListTypes

--- a/src/org/jetbrains/plugins/scala/lang/psi/impl/toplevel/typedef/TypeDefinitionMembers.scala
+++ b/src/org/jetbrains/plugins/scala/lang/psi/impl/toplevel/typedef/TypeDefinitionMembers.scala
@@ -497,7 +497,7 @@ object TypeDefinitionMembers {
   import org.jetbrains.plugins.scala.lang.psi.impl.toplevel.typedef.TypeDefinitionMembers.TypeNodes.{Map => TMap}
 
   def getParameterlessSignatures(clazz: PsiClass): PMap = {
-    @CachedInsidePsiElement(clazz, CachesUtil.getDependentItem(clazz), useOptionalProvider = true)
+    @CachedInsidePsiElement(clazz, CachesUtil.getDependentItem(clazz)(), useOptionalProvider = true)
     def inner(): PMap = ParameterlessNodes.build(clazz)
 
     clazz match {
@@ -513,7 +513,7 @@ object TypeDefinitionMembers {
   }
 
   def getTypes(clazz: PsiClass): TMap = {
-    @CachedInsidePsiElement(clazz, CachesUtil.getDependentItem(clazz), useOptionalProvider = true)
+    @CachedInsidePsiElement(clazz, CachesUtil.getDependentItem(clazz)(), useOptionalProvider = true)
     def inner(): TMap =TypeNodes.build(clazz)
 
     clazz match {
@@ -529,7 +529,7 @@ object TypeDefinitionMembers {
   }
 
   def getSignatures(clazz: PsiClass, place: Option[PsiElement] = None): SMap = {
-    @CachedInsidePsiElement(clazz, CachesUtil.getDependentItem(clazz), useOptionalProvider = true)
+    @CachedInsidePsiElement(clazz, CachesUtil.getDependentItem(clazz)(), useOptionalProvider = true)
     def buildNodesClass(): SMap = SignatureNodes.build(clazz)
 
     clazz match {
@@ -552,7 +552,7 @@ object TypeDefinitionMembers {
                 c match {
                   case o: ScObject =>
                     if (allowedNames.contains(o.name)) {
-                      @CachedInsidePsiElement(o, CachesUtil.getDependentItem(o), useOptionalProvider = true)
+                      @CachedInsidePsiElement(o, CachesUtil.getDependentItem(o)(), useOptionalProvider = true)
                       def buildNodesObject(): SMap = SignatureNodes.build(o)
 
                       val add = buildNodesObject()
@@ -560,7 +560,7 @@ object TypeDefinitionMembers {
                     }
                   case c: ScClass =>
                     if (allowedNames.contains(c.name)) {
-                      @CachedInsidePsiElement(c, CachesUtil.getDependentItem(c), useOptionalProvider = true)
+                      @CachedInsidePsiElement(c, CachesUtil.getDependentItem(c)(), useOptionalProvider = true)
                       def buildNodesClass2(): SMap = SignatureNodes.build(c)
 
                       val add = buildNodesClass2()

--- a/src/org/jetbrains/plugins/scala/lang/psi/implicits/ScImplicitlyConvertible.scala
+++ b/src/org/jetbrains/plugins/scala/lang/psi/implicits/ScImplicitlyConvertible.scala
@@ -7,7 +7,7 @@ import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.util.Key
 import com.intellij.psi._
-import com.intellij.psi.util.{CachedValue, PsiModificationTracker, PsiTreeUtil}
+import com.intellij.psi.util.{CachedValue, PsiTreeUtil}
 import org.jetbrains.plugins.scala.extensions._
 import org.jetbrains.plugins.scala.lang.psi.api.InferUtil
 import org.jetbrains.plugins.scala.lang.psi.api.base.patterns.ScBindingPattern
@@ -25,7 +25,7 @@ import org.jetbrains.plugins.scala.lang.psi.types.nonvalue.Parameter
 import org.jetbrains.plugins.scala.lang.psi.types.result.TypingContext
 import org.jetbrains.plugins.scala.lang.resolve.processor.{BaseProcessor, ImplicitProcessor}
 import org.jetbrains.plugins.scala.lang.resolve.{ResolveUtils, ScalaResolveResult, StdKinds}
-import org.jetbrains.plugins.scala.macroAnnotations.CachedMappedWithRecursionGuard
+import org.jetbrains.plugins.scala.macroAnnotations.{CachedMappedWithRecursionGuard, ModCount}
 import org.jetbrains.plugins.scala.project.ScalaLanguageLevel.Scala_2_10
 import org.jetbrains.plugins.scala.project._
 
@@ -78,14 +78,14 @@ class ScImplicitlyConvertible(place: PsiElement, placeType: Boolean => Option[Sc
     buffer.toSeq
   }
 
-  @CachedMappedWithRecursionGuard(place, Seq.empty, PsiModificationTracker.MODIFICATION_COUNT)
+  @CachedMappedWithRecursionGuard(place, Seq.empty, ModCount.getBlockModificationCount)
   def implicitMapFirstPart(exp: Option[ScType] = None,
                   fromUnder: Boolean = false,
                   exprType: Option[ScType] = None): Seq[ImplicitResolveResult] = {
     buildImplicitMap(exp, fromUnder, isFromCompanion = false, Seq.empty, exprType)
   }
 
-  @CachedMappedWithRecursionGuard(place, Seq.empty, PsiModificationTracker.MODIFICATION_COUNT)
+  @CachedMappedWithRecursionGuard(place, Seq.empty, ModCount.getBlockModificationCount)
   def implicitMapSecondPart(exp: Option[ScType] = None,
                             fromUnder: Boolean = false,
                             args: Seq[ScType] = Seq.empty,
@@ -154,7 +154,7 @@ class ScImplicitlyConvertible(place: PsiElement, placeType: Boolean => Option[Sc
     result.toSeq
   }
 
-  @CachedMappedWithRecursionGuard(place, ArrayBuffer.empty, PsiModificationTracker.MODIFICATION_COUNT)
+  @CachedMappedWithRecursionGuard(place, ArrayBuffer.empty, ModCount.getBlockModificationCount)
   private def buildSimpleImplicitMap(fromUnder: Boolean, exprType: Option[ScType] = None): ArrayBuffer[ImplicitMapResult] = {
     ScalaPsiUtil.debug(s"Simple implicit map: $exprType", LOG)
 

--- a/src/org/jetbrains/plugins/scala/lang/psi/light/PsiClassWrapper.scala
+++ b/src/org/jetbrains/plugins/scala/lang/psi/light/PsiClassWrapper.scala
@@ -120,7 +120,8 @@ class PsiClassWrapper(val definition: ScTemplateDefinition,
     }
   }
 
-  @Cached(synchronized = false, ModCount.getOutOfCodeBlockModificationCount, getManager)
+  //todo: should use blockmodcount here???
+  @Cached(synchronized = false, ModCount.getOutOfCodeBlockModificationCount, this)
   private def getEmptyConstructor: PsiMethod = new EmptyPrivateConstructor(this)
 
   def getConstructors: Array[PsiMethod] = {

--- a/src/org/jetbrains/plugins/scala/lang/psi/types/Compatibility.scala
+++ b/src/org/jetbrains/plugins/scala/lang/psi/types/Compatibility.scala
@@ -24,7 +24,7 @@ import org.jetbrains.plugins.scala.lang.psi.implicits.ScImplicitlyConvertible.Im
 import org.jetbrains.plugins.scala.lang.psi.types.nonvalue.Parameter
 import org.jetbrains.plugins.scala.lang.psi.types.result._
 import org.jetbrains.plugins.scala.lang.resolve.processor.MostSpecificUtil
-import org.jetbrains.plugins.scala.macroAnnotations.CachedMappedWithRecursionGuard
+import org.jetbrains.plugins.scala.macroAnnotations.{ModCount, CachedMappedWithRecursionGuard}
 
 import scala.collection.{Set, Seq}
 import scala.collection.mutable.ArrayBuffer
@@ -51,7 +51,7 @@ object Compatibility {
     }
 
 
-    @CachedMappedWithRecursionGuard(place, (Success(typez, None), Set.empty), PsiModificationTracker.MODIFICATION_COUNT)
+    @CachedMappedWithRecursionGuard(place, (Success(typez, None), Set.empty), ModCount.getBlockModificationCount)
     private def eval(typez: ScType, expectedOption: Option[ScType]): (TypeResult[ScType], Set[ImportUsed]) = {
       expectedOption match {
         case Some(expected) if typez.conforms(expected) => (Success(typez, None), Set.empty)

--- a/src/org/jetbrains/plugins/scala/lang/psi/types/ScProjectionType.scala
+++ b/src/org/jetbrains/plugins/scala/lang/psi/types/ScProjectionType.scala
@@ -19,7 +19,7 @@ import org.jetbrains.plugins.scala.lang.psi.types.result.{Success, TypingContext
 import org.jetbrains.plugins.scala.lang.refactoring.util.ScTypeUtil.AliasType
 import org.jetbrains.plugins.scala.lang.resolve.processor.ResolveProcessor
 import org.jetbrains.plugins.scala.lang.resolve.{ResolveTargets, ScalaResolveResult}
-import org.jetbrains.plugins.scala.macroAnnotations.CachedMappedWithRecursionGuard
+import org.jetbrains.plugins.scala.macroAnnotations.{ModCount, CachedMappedWithRecursionGuard}
 import org.jetbrains.plugins.scala.util.ScEquivalenceUtil
 
 import scala.collection.immutable.HashSet
@@ -131,7 +131,7 @@ class ScProjectionType private (val projected: ScType, val element: PsiNamedElem
     }
   }
 
-  @CachedMappedWithRecursionGuard(element, None, PsiModificationTracker.MODIFICATION_COUNT)
+  @CachedMappedWithRecursionGuard(element, None, ModCount.getBlockModificationCount)
   private def actualImpl(projected: ScType, superReference: Boolean): Option[(PsiNamedElement, ScSubstitutor)] = {
     val emptySubst = new ScSubstitutor(Map.empty, Map.empty, Some(projected))
     val resolvePlace = {

--- a/src/org/jetbrains/plugins/scala/lang/resolve/ResolvableReferenceExpression.scala
+++ b/src/org/jetbrains/plugins/scala/lang/resolve/ResolvableReferenceExpression.scala
@@ -25,7 +25,7 @@ import org.jetbrains.plugins.scala.lang.psi.types._
 import org.jetbrains.plugins.scala.lang.psi.types.nonvalue.{ScMethodType, ScTypePolymorphicType}
 import org.jetbrains.plugins.scala.lang.psi.types.result.{Success, TypingContext}
 import org.jetbrains.plugins.scala.lang.resolve.processor._
-import org.jetbrains.plugins.scala.macroAnnotations.{CachedMappedWithRecursionGuard, CachedWithRecursionGuard}
+import org.jetbrains.plugins.scala.macroAnnotations.{ModCount, CachedMappedWithRecursionGuard, CachedWithRecursionGuard}
 
 import scala.annotation.tailrec
 import scala.collection.mutable.ArrayBuffer
@@ -34,7 +34,7 @@ trait ResolvableReferenceExpression extends ScReferenceExpression {
   private object Resolver extends ReferenceExpressionResolver(false)
   private object ShapesResolver extends ReferenceExpressionResolver(true)
 
-  @CachedMappedWithRecursionGuard(this, Array.empty, PsiModificationTracker.MODIFICATION_COUNT)
+  @CachedMappedWithRecursionGuard(this, Array.empty, ModCount.getBlockModificationCount)
   def multiResolveImpl(incomplete: Boolean): Array[ResolveResult] = Resolver.resolve(this, incomplete)
 
   def multiResolve(incomplete: Boolean): Array[ResolveResult] = {
@@ -42,7 +42,7 @@ trait ResolvableReferenceExpression extends ScReferenceExpression {
     else multiResolveImpl(incomplete)
   }
 
-  @CachedWithRecursionGuard[ResolvableReferenceExpression](this, Array.empty[ResolveResult], PsiModificationTracker.MODIFICATION_COUNT)
+  @CachedWithRecursionGuard[ResolvableReferenceExpression](this, Array.empty[ResolveResult], ModCount.getBlockModificationCount)
   private def shapeResolveImpl: Array[ResolveResult] = ShapesResolver.resolve(this, incomplete = false)
 
   def shapeResolve: Array[ResolveResult] = {

--- a/src/org/jetbrains/plugins/scala/lang/resolve/ResolvableStableCodeReferenceElement.scala
+++ b/src/org/jetbrains/plugins/scala/lang/resolve/ResolvableStableCodeReferenceElement.scala
@@ -24,7 +24,7 @@ import org.jetbrains.plugins.scala.lang.psi.{ScImportsHolder, ScalaPsiUtil}
 import org.jetbrains.plugins.scala.lang.resolve.ResolvableStableCodeReferenceElement.EMPTY_ARRAY
 import org.jetbrains.plugins.scala.lang.resolve.processor.{BaseProcessor, ExtractorResolveProcessor}
 import org.jetbrains.plugins.scala.lang.scaladoc.psi.api.ScDocResolvableCodeReference
-import org.jetbrains.plugins.scala.macroAnnotations.{CachedMappedWithRecursionGuard, CachedWithRecursionGuard}
+import org.jetbrains.plugins.scala.macroAnnotations.{CachedMappedWithRecursionGuard, CachedWithRecursionGuard, ModCount}
 
 trait ResolvableStableCodeReferenceElement extends ScStableCodeReferenceElement {
   private object Resolver extends StableCodeReferenceElementResolver(this, false, false, false)
@@ -54,7 +54,7 @@ trait ResolvableStableCodeReferenceElement extends ScStableCodeReferenceElement 
     }
   }
 
-  @CachedMappedWithRecursionGuard(this, Array.empty, PsiModificationTracker.MODIFICATION_COUNT)
+  @CachedMappedWithRecursionGuard(this, Array.empty, ModCount.getBlockModificationCount)
   private def multiResolveCached(incomplete: Boolean): Array[ResolveResult] = Resolver.resolve(this, incomplete)
 
   protected def processQualifierResolveResult(res: ResolveResult, processor: BaseProcessor, ref: ScStableCodeReferenceElement) {
@@ -225,15 +225,17 @@ trait ResolvableStableCodeReferenceElement extends ScStableCodeReferenceElement 
     }
   }
 
-  @CachedWithRecursionGuard[ResolvableStableCodeReferenceElement](this, EMPTY_ARRAY, PsiModificationTracker.MODIFICATION_COUNT)
+  @CachedWithRecursionGuard[ResolvableStableCodeReferenceElement](this, EMPTY_ARRAY, ModCount.getBlockModificationCount)
   private def resolveNoConstructorImpl(): Array[ResolveResult] = NoConstructorResolver.resolve(this, incomplete = false)
+
+
 
   def resolveNoConstructor: Array[ResolveResult] = {
     ProgressManager.checkCanceled()
     resolveNoConstructorImpl()
   }
 
-  @CachedWithRecursionGuard[ResolvableStableCodeReferenceElement](this, EMPTY_ARRAY, PsiModificationTracker.MODIFICATION_COUNT)
+  @CachedWithRecursionGuard[ResolvableStableCodeReferenceElement](this, EMPTY_ARRAY, ModCount.getBlockModificationCount)
   private def resolveAllConstructorsImpl(): Array[ResolveResult] = ResolverAllConstructors.resolve(this, incomplete = false)
 
   def resolveAllConstructors: Array[ResolveResult] = {
@@ -242,7 +244,7 @@ trait ResolvableStableCodeReferenceElement extends ScStableCodeReferenceElement 
   }
 
 
-  @CachedWithRecursionGuard[ResolvableStableCodeReferenceElement](this, EMPTY_ARRAY, PsiModificationTracker.MODIFICATION_COUNT)
+  @CachedWithRecursionGuard[ResolvableStableCodeReferenceElement](this, EMPTY_ARRAY, ModCount.getBlockModificationCount)
   private def shapeResolveImpl(): Array[ResolveResult] = ShapesResolver.resolve(this, incomplete = false)
 
   def shapeResolve: Array[ResolveResult] = {
@@ -252,7 +254,7 @@ trait ResolvableStableCodeReferenceElement extends ScStableCodeReferenceElement 
   }
 
 
-  @CachedWithRecursionGuard[ResolvableStableCodeReferenceElement](this, EMPTY_ARRAY, PsiModificationTracker.MODIFICATION_COUNT)
+  @CachedWithRecursionGuard[ResolvableStableCodeReferenceElement](this, EMPTY_ARRAY, ModCount.getBlockModificationCount)
   private def shapeResolveConstrImpl(): Array[ResolveResult] = ShapesResolverAllConstructors.resolve(this, incomplete = false)
 
   def shapeResolveConstr: Array[ResolveResult] = {

--- a/test/org/jetbrains/plugins/scala/macroAnnotations/CachedTest.scala
+++ b/test/org/jetbrains/plugins/scala/macroAnnotations/CachedTest.scala
@@ -13,7 +13,7 @@ import org.junit.Assert
 class CachedTest extends CachedTestBase {
   def testNoParametersSingleThread(): Unit = {
     class Foo extends Managed {
-      @Cached(synchronized = false, ModCount.getModificationCount, getManager)
+      @Cached(synchronized = false, ModCount.getModificationCount, this)
       def currentTime(): Long = System.currentTimeMillis()
     }
 
@@ -42,7 +42,7 @@ class CachedTest extends CachedTestBase {
 
       val allThreadsStartedLock: ReentrantLock = new ReentrantLock()
 
-      @Cached(synchronized = true, ModCount.getModificationCount, getManager)
+      @Cached(synchronized = true, ModCount.getModificationCount, this)
       def runSynchronized(): Unit = {
 
         allThreadsStartedLock.lock()
@@ -93,7 +93,7 @@ class CachedTest extends CachedTestBase {
 
   def testModificationTrackers(): Unit = {
     object Foo extends Managed {
-      @Cached(synchronized = false, modificationCount = ModCount.getOutOfCodeBlockModificationCount, getManager)
+      @Cached(synchronized = false, modificationCount = ModCount.getOutOfCodeBlockModificationCount, this)
       def currentTime: Long = System.currentTimeMillis()
     }
 
@@ -106,7 +106,7 @@ class CachedTest extends CachedTestBase {
 
   def testWithParameters(): Unit = {
     object Foo extends Managed {
-      @Cached(synchronized = false, ModCount.getModificationCount, getManager)
+      @Cached(synchronized = false, ModCount.getModificationCount, this)
       def currentTime(a: Int, b: Int): Long = System.currentTimeMillis()
     }
 


### PR DESCRIPTION
When you're inside a function that has a return type, you don't need to
invalidate all caches, just the caches inside this function
This algorithm is currently implemented in ReSharper but not in IDEA
