### PR TITLE
Cache  invalidator: Do not rely on subtreeChanged method #SCL-9390 Fixed

### DIFF
--- a/src/org/jetbrains/plugins/scala/caches/CachesUtil.scala
+++ b/src/org/jetbrains/plugins/scala/caches/CachesUtil.scala
@@ -281,7 +281,7 @@ object CachesUtil {
 
   def enclosingBlockExprModTrackerOrOutOfCodeBlockModTracker(elem: PsiElement): Object = {
     Option(PsiTreeUtil.getParentOfType(elem, classOf[ScBlockExprImpl])) match {
-      case Some(block) if block.shouldChangeModificationCount(elem) => block.getModificationTracker
+      case Some(block) => block.getModificationTracker
       case _ => PsiModificationTracker.OUT_OF_CODE_BLOCK_MODIFICATION_COUNT
     }
   }

--- a/src/org/jetbrains/plugins/scala/lang/psi/impl/expr/ScBlockExprImpl.scala
+++ b/src/org/jetbrains/plugins/scala/lang/psi/impl/expr/ScBlockExprImpl.scala
@@ -60,10 +60,7 @@ class ScBlockExprImpl(text: CharSequence) extends LazyParseablePsiElement(ScalaE
     null
   }
 
-  override def subtreeChanged(): Unit = {
-    blockModificationCount.incrementAndGet()
-    super.subtreeChanged()
-  }
+  def incModificationCount(): Long = blockModificationCount.incrementAndGet()
 
   def shouldChangeModificationCount(place: PsiElement): Boolean = {
     var parent = getParent


### PR DESCRIPTION
Implemented a listener, which updates modification count on every change
