### PR TITLE
[Cache Invalidator] Use getContextOfType instead of getParentOfType

### DIFF
--- a/macroAnnotations/src/org/jetbrains/plugins/scala/macroAnnotations/CachedMacroUtil.scala
+++ b/macroAnnotations/src/org/jetbrains/plugins/scala/macroAnnotations/CachedMacroUtil.scala
@@ -111,7 +111,7 @@ object CachedMacroUtil {
       case q"$v" =>
         ModCount.values.find(_.toString == v.toString) match {
           case Some(ModCount.getBlockModificationCount) =>
-            q"$cachesUtilFQN.enclosingBlockExprModTrackerOrOutOfCodeBlockModTracker($psiElement)"
+            q"$cachesUtilFQN.enclosingModificationOwner($psiElement)"
           case Some(ModCount.getOutOfCodeBlockModificationCount) =>
             q"$psiModificationTrackerFQN.OUT_OF_CODE_BLOCK_MODIFICATION_COUNT"
           case Some(ModCount.getModificationCount) => q"$psiModificationTrackerFQN.MODIFICATION_COUNT"

--- a/src/org/jetbrains/plugins/scala/caches/CachesUtil.scala
+++ b/src/org/jetbrains/plugins/scala/caches/CachesUtil.scala
@@ -10,7 +10,6 @@ import com.intellij.psi._
 import com.intellij.psi.impl.compiled.ClsFileImpl
 import com.intellij.psi.util._
 import com.intellij.util.containers.{ContainerUtil, Stack}
-import org.jetbrains.plugins.scala.lang.psi.ScalaPsiUtil
 import org.jetbrains.plugins.scala.lang.psi.api.ScalaFile
 import org.jetbrains.plugins.scala.lang.psi.api.statements.ScFunction
 import org.jetbrains.plugins.scala.lang.psi.api.toplevel.typedef.ScTypeDefinition
@@ -264,7 +263,7 @@ object CachesUtil {
   }
 
   //def getDependentItem(element: PsiElement)(dep_item: Object = PsiModificationTracker.OUT_OF_CODE_BLOCK_MODIFICATION_COUNT): Option[Object] = {
-  def getDependentItem(element: PsiElement)(dep_item: Object = enclosingBlockExprModTrackerOrOutOfCodeBlockModTracker(element)): Option[Object] = {
+  def getDependentItem(element: PsiElement)(dep_item: Object = enclosingModificationOwner(element)): Option[Object] = {
     element.getContainingFile match {
       case file: ScalaFile if file.isCompiled =>
         if (!ProjectRootManager.getInstance(element.getProject).getFileIndex.isInContent(file.getVirtualFile)) {
@@ -282,10 +281,10 @@ object CachesUtil {
   }
 
   @tailrec
-  def enclosingBlockExprModTrackerOrOutOfCodeBlockModTracker(elem: PsiElement): Object = {
-    Option(PsiTreeUtil.getParentOfType(elem, classOf[ScBlockExprImpl])) match {
+  def enclosingModificationOwner(elem: PsiElement): Object = {
+    Option(PsiTreeUtil.getContextOfType(elem, false, classOf[ScBlockExprImpl])) match {
       case Some(block) if block.isModificationCountOwner => block.getModificationTracker
-      case Some(block) => enclosingBlockExprModTrackerOrOutOfCodeBlockModTracker(block)
+      case Some(block) => enclosingModificationOwner(block)
       case _ => PsiModificationTracker.OUT_OF_CODE_BLOCK_MODIFICATION_COUNT
     }
   }

--- a/src/org/jetbrains/plugins/scala/lang/psi/impl/ScalaPsiManager.scala
+++ b/src/org/jetbrains/plugins/scala/lang/psi/impl/ScalaPsiManager.scala
@@ -325,13 +325,12 @@ class ScalaPsiManager(project: Project) extends ProjectComponent {
     keys.toSeq
   }
 
-
   PsiManager.getInstance(project).addPsiTreeChangeListener(CacheInvalidator, project)
 
   object CacheInvalidator extends PsiTreeChangeAdapter {
     @tailrec
     def updateModificationCount(elem: PsiElement): Unit = {
-      Option(PsiTreeUtil.getParentOfType(elem, classOf[ScBlockExprImpl], false)) match {
+      Option(PsiTreeUtil.getContextOfType(elem, false, classOf[ScBlockExprImpl])) match {
         case Some(block) if block.isModificationCountOwner => block.incModificationCount()
         case Some(block) => updateModificationCount(block.getContext)
         case _ =>


### PR DESCRIPTION
Use getContextOfType instead of getParentOfType when getting the modification count.
