### PR TITLE
change broken Plugin/DTD url to http://plugins.jetbrains.com/plugin.dtd

### DIFF
--- a/SDK/scalaDevPlugin/src/main/resources/META-INF/plugin.xml
+++ b/SDK/scalaDevPlugin/src/main/resources/META-INF/plugin.xml
@@ -13,7 +13,7 @@
   ~ limitations under the License.
   -->
 
-<!DOCTYPE idea-plugin PUBLIC "Plugin/DTD" "http://plugins.intellij.net/plugin.dtd">
+<!DOCTYPE idea-plugin PUBLIC "Plugin/DTD" "http://plugins.jetbrains.com/plugin.dtd">
 <idea-plugin url="http://www.jetbrains.net/confluence/display/SCA/Scala+Plugin+for+IntelliJ+IDEA" version="2" xmlns:xi="http://www.w3.org/2001/XInclude">
     <id>org.jetbrains.scaladev</id>
     <name>ScalaPlugin Development Tools</name>

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -13,7 +13,7 @@
   ~ limitations under the License.
   -->
 
-<!DOCTYPE idea-plugin PUBLIC "Plugin/DTD" "http://plugins.intellij.net/plugin.dtd">
+<!DOCTYPE idea-plugin PUBLIC "Plugin/DTD" "http://plugins.jetbrains.com/plugin.dtd">
 <idea-plugin url="http://www.jetbrains.net/confluence/display/SCA/Scala+Plugin+for+IntelliJ+IDEA" version="2"
     xmlns:xi="http://www.w3.org/2001/XInclude">
     <id>org.intellij.scala</id>

--- a/resources/META-INF/scala-gradle-integration.xml
+++ b/resources/META-INF/scala-gradle-integration.xml
@@ -14,7 +14,7 @@
   ~ limitations under the License.
   -->
 
-<!DOCTYPE idea-plugin PUBLIC "Plugin/DTD" "http://plugins.intellij.net/plugin.dtd">
+<!DOCTYPE idea-plugin PUBLIC "Plugin/DTD" "http://plugins.jetbrains.com/plugin.dtd">
 <idea-plugin version="2">
   <extensions defaultExtensionNs="org.jetbrains.plugins.gradle">
     <projectResolve implementation="org.jetbrains.plugins.gradle.integrations.scala.ScalaGradleProjectResolverExtension"/>

--- a/resources/META-INF/scala-maven-integration.xml
+++ b/resources/META-INF/scala-maven-integration.xml
@@ -14,7 +14,7 @@
   ~ limitations under the License.
   -->
 
-<!DOCTYPE idea-plugin PUBLIC "Plugin/DTD" "http://plugins.intellij.net/plugin.dtd">
+<!DOCTYPE idea-plugin PUBLIC "Plugin/DTD" "http://plugins.jetbrains.com/plugin.dtd">
 <idea-plugin version="2">
   <extensions xmlns="org.jetbrains.idea.maven">
     <importer implementation="org.jetbrains.plugins.scala.project.maven.ScalaMavenImporter"/>


### PR DESCRIPTION
Build #IU-143.381
scala plugin 2.0.0

Related issue https://youtrack.jetbrains.com/issue/SCL-9408

Changing `Plugin update channel` to any value throws this exception

```
2015-11-05 11:41:03,544 [  90400]  ERROR - llij.ide.plugins.PluginManager - null 
java.security.PrivilegedActionException: java.security.PrivilegedActionException: java.net.UnknownHostException: plugins.intellij.net
    at java.security.AccessController.doPrivileged(Native Method)
    at java.security.ProtectionDomain$1.doIntersectionPrivilege(ProtectionDomain.java:75)
    at java.awt.EventQueue.dispatchEvent(EventQueue.java:721)
    at com.intellij.ide.IdeEventQueue.f(IdeEventQueue.java:861)
    at com.intellij.ide.IdeEventQueue._dispatchEvent(IdeEventQueue.java:645)
    at com.intellij.ide.IdeEventQueue.dispatchEvent(IdeEventQueue.java:380)
    at java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:201)
    at java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:116)
    at java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:109)
    at java.awt.WaitDispatchSupport$2.run(WaitDispatchSupport.java:184)
    at java.awt.WaitDispatchSupport$4.run(WaitDispatchSupport.java:229)
    at java.awt.WaitDispatchSupport$4.run(WaitDispatchSupport.java:227)
    at java.security.AccessController.doPrivileged(Native Method)
    at java.awt.WaitDispatchSupport.enter(WaitDispatchSupport.java:227)
    at java.awt.Dialog.show(Dialog.java:1084)
    at com.intellij.openapi.ui.impl.DialogWrapperPeerImpl$MyDialog.show(DialogWrapperPeerImpl.java:792)
    at com.intellij.openapi.ui.impl.DialogWrapperPeerImpl.show(DialogWrapperPeerImpl.java:465)
    at com.intellij.openapi.ui.DialogWrapper.invokeShow(DialogWrapper.java:1637)
    at com.intellij.openapi.ui.DialogWrapper.show(DialogWrapper.java:1586)
    at com.intellij.ide.actions.ShowSettingsUtilImpl.showSettingsDialog(ShowSettingsUtilImpl.java:118)
    at com.intellij.ide.MacOSApplicationProvider$Worker$1.handlePreferences(MacOSApplicationProvider.java:99)
    at com.apple.eawt._AppEventLegacyHandler$2.dispatchEvent(_AppEventLegacyHandler.java:106)
    at com.apple.eawt._AppEventLegacyHandler.sendEventToEachListenerUntilHandled(_AppEventLegacyHandler.java:184)
    at com.apple.eawt._AppEventLegacyHandler.handlePreferences(_AppEventLegacyHandler.java:104)
    at com.apple.eawt._AppEventHandler$_PreferencesDispatcher.performUsing(_AppEventHandler.java:263)
    at com.apple.eawt._AppEventHandler$_PreferencesDispatcher.performUsing(_AppEventHandler.java:254)
    at com.apple.eawt._AppEventHandler$_AppEventDispatcher$1.run(_AppEventHandler.java:516)
    at java.awt.event.InvocationEvent.dispatch(InvocationEvent.java:311)
    at java.awt.EventQueue.dispatchEventImpl(EventQueue.java:749)
    at java.awt.EventQueue.access$500(EventQueue.java:97)
    at java.awt.EventQueue$3.run(EventQueue.java:702)
    at java.awt.EventQueue$3.run(EventQueue.java:696)
    at java.security.AccessController.doPrivileged(Native Method)
    at java.security.ProtectionDomain$1.doIntersectionPrivilege(ProtectionDomain.java:75)
    at java.awt.EventQueue.dispatchEvent(EventQueue.java:719)
    at com.intellij.ide.IdeEventQueue.f(IdeEventQueue.java:861)
    at com.intellij.ide.IdeEventQueue._dispatchEvent(IdeEventQueue.java:649)
    at com.intellij.ide.IdeEventQueue.dispatchEvent(IdeEventQueue.java:380)
    at java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:201)
    at java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:116)
    at java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:105)
    at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:101)
    at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:93)
    at java.awt.EventDispatchThread.run(EventDispatchThread.java:82)
Caused by: java.security.PrivilegedActionException: java.net.UnknownHostException: plugins.intellij.net
    at java.security.AccessController.doPrivileged(Native Method)
    at java.security.ProtectionDomain$1.doIntersectionPrivilege(ProtectionDomain.java:75)
    at java.security.ProtectionDomain$1.doIntersectionPrivilege(ProtectionDomain.java:86)
    at java.awt.EventQueue$4.run(EventQueue.java:724)
    at java.awt.EventQueue$4.run(EventQueue.java:722)
    ... 44 more
Caused by: java.net.UnknownHostException: plugins.intellij.net
    at java.net.AbstractPlainSocketImpl.connect(AbstractPlainSocketImpl.java:184)
    at java.net.SocksSocketImpl.connect(SocksSocketImpl.java:392)
    at java.net.Socket.connect(Socket.java:589)
    at java.net.Socket.connect(Socket.java:538)
    at sun.net.NetworkClient.doConnect(NetworkClient.java:180)
    at sun.net.www.http.HttpClient.openServer(HttpClient.java:432)
    at sun.net.www.http.HttpClient.openServer(HttpClient.java:527)
    at sun.net.www.http.HttpClient.<init>(HttpClient.java:211)
    at sun.net.www.http.HttpClient.New(HttpClient.java:308)
    at sun.net.www.http.HttpClient.New(HttpClient.java:326)
    at sun.net.www.protocol.http.HttpURLConnection.getNewHttpClient(HttpURLConnection.java:1168)
    at sun.net.www.protocol.http.HttpURLConnection.plainConnect0(HttpURLConnection.java:1104)
    at sun.net.www.protocol.http.HttpURLConnection.plainConnect(HttpURLConnection.java:998)
    at sun.net.www.protocol.http.HttpURLConnection.connect(HttpURLConnection.java:932)
    at sun.net.www.protocol.http.HttpURLConnection.getInputStream0(HttpURLConnection.java:1512)
    at sun.net.www.protocol.http.HttpURLConnection.getInputStream(HttpURLConnection.java:1440)
    at org.apache.xerces.impl.XMLEntityManager.setupCurrentEntity(Unknown Source)
    at org.apache.xerces.impl.XMLEntityManager.startEntity(Unknown Source)
    at org.apache.xerces.impl.XMLEntityManager.startDTDEntity(Unknown Source)
    at org.apache.xerces.impl.XMLDTDScannerImpl.setInputSource(Unknown Source)
    at org.apache.xerces.impl.XMLDocumentScannerImpl$DTDDispatcher.dispatch(Unknown Source)
    at org.apache.xerces.impl.XMLDocumentFragmentScannerImpl.scanDocument(Unknown Source)
    at org.apache.xerces.parsers.XML11Configuration.parse(Unknown Source)
    at org.apache.xerces.parsers.XML11Configuration.parse(Unknown Source)
    at org.apache.xerces.parsers.XMLParser.parse(Unknown Source)
    at org.apache.xerces.parsers.AbstractSAXParser.parse(Unknown Source)
    at org.apache.xerces.jaxp.SAXParserImpl$JAXPSAXParser.parse(Unknown Source)
    at org.apache.xerces.jaxp.SAXParserImpl.parse(Unknown Source)
    at scala.xml.factory.XMLLoader$class.loadXML(XMLLoader.scala:41)
    at scala.xml.XML$.loadXML(XML.scala:60)
    at scala.xml.factory.XMLLoader$class.load(XMLLoader.scala:53)
    at scala.xml.XML$.load(XML.scala:60)
    at org.jetbrains.plugins.scala.components.ScalaPluginUpdater$.patchPluginVersion(ScalaPluginUpdater.scala:301)
    at org.jetbrains.plugins.scala.components.ScalaPluginUpdater$.doUpdatePluginHosts(ScalaPluginUpdater.scala:98)
    at org.jetbrains.plugins.scala.components.ScalaPluginUpdater$.doUpdatePluginHostsAndCheck(ScalaPluginUpdater.scala:117)
    at org.jetbrains.plugins.scala.components.ScalaPluginUpdater.doUpdatePluginHostsAndCheck(ScalaPluginUpdater.scala)
    at org.jetbrains.plugins.scala.settings.ScalaProjectSettingsPanel.apply(ScalaProjectSettingsPanel.java:97)
    at org.jetbrains.plugins.scala.settings.ScalaProjectSettingsConfigurable.apply(ScalaProjectSettingsConfigurable.java:46)
    at com.intellij.openapi.options.ex.ConfigurableWrapper.apply(ConfigurableWrapper.java:180)
    at com.intellij.openapi.options.newEditor.ConfigurableEditor.apply(ConfigurableEditor.java:327)
    at com.intellij.openapi.options.newEditor.SettingsEditor$5.apply(SettingsEditor.java:165)
    at com.intellij.openapi.options.newEditor.ConfigurableEditor$2$1.run(ConfigurableEditor.java:81)
    at com.intellij.openapi.project.DumbPermissionServiceImpl.allowStartingDumbModeInside(DumbPermissionServiceImpl.java:35)
    at com.intellij.openapi.project.DumbService.allowStartingDumbModeInside(DumbService.java:281)
    at com.intellij.openapi.options.newEditor.ConfigurableEditor$2.actionPerformed(ConfigurableEditor.java:78)
    at javax.swing.AbstractButton.fireActionPerformed(AbstractButton.java:2022)
    at javax.swing.AbstractButton$Handler.actionPerformed(AbstractButton.java:2346)
    at javax.swing.DefaultButtonModel.fireActionPerformed(DefaultButtonModel.java:402)
    at javax.swing.DefaultButtonModel.setPressed(DefaultButtonModel.java:259)
    at javax.swing.plaf.basic.BasicButtonListener.mouseReleased(BasicButtonListener.java:252)
    at java.awt.Component.processMouseEvent(Component.java:6543)
    at javax.swing.JComponent.processMouseEvent(JComponent.java:3324)
    at java.awt.Component.processEvent(Component.java:6308)
    at java.awt.Container.processEvent(Container.java:2235)
    at java.awt.Component.dispatchEventImpl(Component.java:4899)
    at java.awt.Container.dispatchEventImpl(Container.java:2293)
    at java.awt.Component.dispatchEvent(Component.java:4721)
    at java.awt.LightweightDispatcher.retargetMouseEvent(Container.java:4897)
    at java.awt.LightweightDispatcher.processMouseEvent(Container.java:4532)
    at java.awt.LightweightDispatcher.dispatchEvent(Container.java:4461)
    at java.awt.Container.dispatchEventImpl(Container.java:2279)
    at java.awt.Window.dispatchEventImpl(Window.java:2750)
    at java.awt.Component.dispatchEvent(Component.java:4721)
    at java.awt.EventQueue.dispatchEventImpl(EventQueue.java:751)
    at java.awt.EventQueue.access$500(EventQueue.java:97)
    at java.awt.EventQueue$3.run(EventQueue.java:702)
    at java.awt.EventQueue$3.run(EventQueue.java:696)
    ... 49 more
2015-11-05 11:41:03,547 [  90403]  ERROR - llij.ide.plugins.PluginManager - IntelliJ IDEA 15.0  Build #IU-143.381.42 
2015-11-05 11:41:03,547 [  90403]  ERROR - llij.ide.plugins.PluginManager - JDK: 1.8.0_40-release 
2015-11-05 11:41:03,547 [  90403]  ERROR - llij.ide.plugins.PluginManager - VM: OpenJDK 64-Bit Server VM 
2015-11-05 11:41:03,547 [  90403]  ERROR - llij.ide.plugins.PluginManager - Vendor: JetBrains s.r.o 
2015-11-05 11:41:03,547 [  90403]  ERROR - llij.ide.plugins.PluginManager - OS: Mac OS X
```
