### PR TITLE
Add settings to enable/configure alternate continuation indentation for constructor args and parameter declarations

### DIFF
--- a/src/org/jetbrains/plugins/scala/lang/formatting/ScalaBlock.scala
+++ b/src/org/jetbrains/plugins/scala/lang/formatting/ScalaBlock.scala
@@ -113,7 +113,8 @@ extends Object with ScalaTokenTypes with ASTBlock {
       case _ if parent.getNode.getElementType == ScalaTokenTypes.kIF =>
         new ChildAttributes(Indent.getNormalIndent, null)
       case _: ScParameterClause =>
-        new ChildAttributes(if (scalaSettings.NOT_CONTINUATION_INDENT_FOR_PARAMS) Indent.getNormalIndent
+        new ChildAttributes(if (scalaSettings.USE_ALTERNATE_CONTINUATION_INDENT_FOR_PARAMS) Indent.getSpaceIndent(scalaSettings.ALTERNATE_CONTINUATION_INDENT_FOR_PARAMS, false)
+          else if (scalaSettings.NOT_CONTINUATION_INDENT_FOR_PARAMS) Indent.getNormalIndent
           else Indent.getContinuationWithoutFirstIndent, this.getAlignment)
       case _: ScValue =>
         new ChildAttributes(Indent.getNormalIndent, this.getAlignment) //by default suppose there will be simple expr

--- a/src/org/jetbrains/plugins/scala/lang/formatting/ScalaBlock.scala
+++ b/src/org/jetbrains/plugins/scala/lang/formatting/ScalaBlock.scala
@@ -113,7 +113,8 @@ extends Object with ScalaTokenTypes with ASTBlock {
       case _ if parent.getNode.getElementType == ScalaTokenTypes.kIF =>
         new ChildAttributes(Indent.getNormalIndent, null)
       case _: ScParameterClause =>
-        new ChildAttributes(if (scalaSettings.USE_ALTERNATE_CONTINUATION_INDENT_FOR_PARAMS) Indent.getSpaceIndent(scalaSettings.ALTERNATE_CONTINUATION_INDENT_FOR_PARAMS, false)
+        new ChildAttributes(
+          if (scalaSettings.USE_ALTERNATE_CONTINUATION_INDENT_FOR_PARAMS) Indent.getSpaceIndent(scalaSettings.ALTERNATE_CONTINUATION_INDENT_FOR_PARAMS, false)
           else if (scalaSettings.NOT_CONTINUATION_INDENT_FOR_PARAMS) Indent.getNormalIndent
           else Indent.getContinuationWithoutFirstIndent, this.getAlignment)
       case _: ScValue =>

--- a/src/org/jetbrains/plugins/scala/lang/formatting/processors/ScalaIndentProcessor.scala
+++ b/src/org/jetbrains/plugins/scala/lang/formatting/processors/ScalaIndentProcessor.scala
@@ -24,6 +24,8 @@ import org.jetbrains.plugins.scala.lang.psi.api.toplevel.templates._
 import org.jetbrains.plugins.scala.lang.psi.impl.expr.ScBlockImpl
 import org.jetbrains.plugins.scala.lang.scaladoc.lexer.ScalaDocTokenType
 import org.jetbrains.plugins.scala.lang.scaladoc.psi.api.ScDocComment
+import org.jetbrains.plugins.scala.lang.psi.api.base.ScPrimaryConstructor
+import org.jetbrains.plugins.scala.lang.psi.ScalaPsiUtil
 
 
 object ScalaIndentProcessor extends ScalaTokenTypes {
@@ -208,7 +210,7 @@ object ScalaIndentProcessor extends ScalaTokenTypes {
       case _: ScExtendsBlock if settings.CLASS_BRACE_STYLE == CommonCodeStyleSettings.NEXT_LINE_SHIFTED ||
         settings.CLASS_BRACE_STYLE == CommonCodeStyleSettings.NEXT_LINE_SHIFTED2 => Indent.getNormalIndent
       case _: ScExtendsBlock => Indent.getNoneIndent //Template body
-      case _: ScParameterClause if scalaSettings.USE_ALTERNATE_CONTINUATION_INDENT_FOR_PARAMS =>
+      case p: ScParameterClause if scalaSettings.USE_ALTERNATE_CONTINUATION_INDENT_FOR_PARAMS && isConstructorArgOrMemberFunctionParameter(p) =>
         Indent.getSpaceIndent(scalaSettings.ALTERNATE_CONTINUATION_INDENT_FOR_PARAMS, false)
       case cl: ScParameterClause if  scalaSettings.NOT_CONTINUATION_INDENT_FOR_PARAMS =>
         if (child.getElementType == ScalaTokenTypes.tRPARENTHESIS ||
@@ -239,5 +241,10 @@ object ScalaIndentProcessor extends ScalaTokenTypes {
         Indent.getContinuationIndent() //this is here to not break whatever processing there is before
       case _ => Indent.getNoneIndent
     }
+  }
+
+  private def isConstructorArgOrMemberFunctionParameter(paramClause: ScParameterClause): Boolean = {
+    val owner = paramClause.owner
+    owner != null && (owner.isInstanceOf[ScPrimaryConstructor] || owner.isInstanceOf[ScFunction])
   }
 }

--- a/src/org/jetbrains/plugins/scala/lang/formatting/processors/ScalaIndentProcessor.scala
+++ b/src/org/jetbrains/plugins/scala/lang/formatting/processors/ScalaIndentProcessor.scala
@@ -208,8 +208,8 @@ object ScalaIndentProcessor extends ScalaTokenTypes {
       case _: ScExtendsBlock if settings.CLASS_BRACE_STYLE == CommonCodeStyleSettings.NEXT_LINE_SHIFTED ||
         settings.CLASS_BRACE_STYLE == CommonCodeStyleSettings.NEXT_LINE_SHIFTED2 => Indent.getNormalIndent
       case _: ScExtendsBlock => Indent.getNoneIndent //Template body
-      case _: ScParameterClause if scalaSettings.CUSTOM_CONTINUATION_INDENT_FOR_PARAMS =>
-        Indent.getSpaceIndent(4, false);
+      case _: ScParameterClause if scalaSettings.USE_ALTERNATE_CONTINUATION_INDENT_FOR_PARAMS =>
+        Indent.getSpaceIndent(scalaSettings.ALTERNATE_CONTINUATION_INDENT_FOR_PARAMS, false);
       case cl: ScParameterClause if  scalaSettings.NOT_CONTINUATION_INDENT_FOR_PARAMS =>
         if (child.getElementType == ScalaTokenTypes.tRPARENTHESIS ||
                 child.getElementType == ScalaTokenTypes.tLPARENTHESIS) Indent.getNoneIndent

--- a/src/org/jetbrains/plugins/scala/lang/formatting/processors/ScalaIndentProcessor.scala
+++ b/src/org/jetbrains/plugins/scala/lang/formatting/processors/ScalaIndentProcessor.scala
@@ -209,7 +209,7 @@ object ScalaIndentProcessor extends ScalaTokenTypes {
         settings.CLASS_BRACE_STYLE == CommonCodeStyleSettings.NEXT_LINE_SHIFTED2 => Indent.getNormalIndent
       case _: ScExtendsBlock => Indent.getNoneIndent //Template body
       case _: ScParameterClause if scalaSettings.USE_ALTERNATE_CONTINUATION_INDENT_FOR_PARAMS =>
-        Indent.getSpaceIndent(scalaSettings.ALTERNATE_CONTINUATION_INDENT_FOR_PARAMS, false);
+        Indent.getSpaceIndent(scalaSettings.ALTERNATE_CONTINUATION_INDENT_FOR_PARAMS, false)
       case cl: ScParameterClause if  scalaSettings.NOT_CONTINUATION_INDENT_FOR_PARAMS =>
         if (child.getElementType == ScalaTokenTypes.tRPARENTHESIS ||
                 child.getElementType == ScalaTokenTypes.tLPARENTHESIS) Indent.getNoneIndent

--- a/src/org/jetbrains/plugins/scala/lang/formatting/processors/ScalaIndentProcessor.scala
+++ b/src/org/jetbrains/plugins/scala/lang/formatting/processors/ScalaIndentProcessor.scala
@@ -208,6 +208,8 @@ object ScalaIndentProcessor extends ScalaTokenTypes {
       case _: ScExtendsBlock if settings.CLASS_BRACE_STYLE == CommonCodeStyleSettings.NEXT_LINE_SHIFTED ||
         settings.CLASS_BRACE_STYLE == CommonCodeStyleSettings.NEXT_LINE_SHIFTED2 => Indent.getNormalIndent
       case _: ScExtendsBlock => Indent.getNoneIndent //Template body
+      case _: ScParameterClause if scalaSettings.CUSTOM_CONTINUATION_INDENT_FOR_PARAMS =>
+        Indent.getSpaceIndent(4, false);
       case cl: ScParameterClause if  scalaSettings.NOT_CONTINUATION_INDENT_FOR_PARAMS =>
         if (child.getElementType == ScalaTokenTypes.tRPARENTHESIS ||
                 child.getElementType == ScalaTokenTypes.tLPARENTHESIS) Indent.getNoneIndent

--- a/src/org/jetbrains/plugins/scala/lang/formatting/settings/OtherCodeStylePanel.form
+++ b/src/org/jetbrains/plugins/scala/lang/formatting/settings/OtherCodeStylePanel.form
@@ -79,7 +79,7 @@
             <properties/>
             <border type="none"/>
             <children>
-              <component id="654f0" class="javax.swing.JCheckBox" binding="customIndentationForParamsCheckBox" default-binding="true">
+              <component id="654f0" class="javax.swing.JCheckBox" binding="alternateIndentationForParamsCheckBox">
                 <constraints>
                   <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                 </constraints>
@@ -88,7 +88,7 @@
                   <verticalAlignment value="1"/>
                 </properties>
               </component>
-              <component id="6c26f" class="javax.swing.JSpinner" binding="customIndentationForParamsSpinner" default-binding="true">
+              <component id="6c26f" class="javax.swing.JSpinner" binding="alternateIndentationForParamsSpinner">
                 <constraints>
                   <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="1" use-parent-layout="false">
                     <minimum-size width="1" height="-1"/>

--- a/src/org/jetbrains/plugins/scala/lang/formatting/settings/OtherCodeStylePanel.form
+++ b/src/org/jetbrains/plugins/scala/lang/formatting/settings/OtherCodeStylePanel.form
@@ -3,12 +3,12 @@
   <grid id="27dc6" layout-manager="GridLayoutManager" row-count="1" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
-      <xy x="20" y="20" width="500" height="400"/>
+      <xy x="20" y="20" width="689" height="400"/>
     </constraints>
     <properties/>
     <border type="none"/>
     <children>
-      <grid id="d040d" binding="contentPanel" layout-manager="GridLayoutManager" row-count="7" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+      <grid id="d040d" binding="contentPanel" layout-manager="GridLayoutManager" row-count="8" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
           <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
@@ -26,7 +26,7 @@
           </component>
           <vspacer id="78b68">
             <constraints>
-              <grid row="6" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+              <grid row="7" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
             </constraints>
           </vspacer>
           <component id="c8e23" class="javax.swing.JCheckBox" binding="replaceWithUnicodeSymbolCheckBox" default-binding="true">
@@ -71,6 +71,48 @@
               <text value="Line comment on first column"/>
             </properties>
           </component>
+          <grid id="e81ff" binding="alternateParamIndentPanel" layout-manager="GridLayoutManager" row-count="1" column-count="4" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+            <margin top="0" left="0" bottom="0" right="0"/>
+            <constraints>
+              <grid row="6" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties/>
+            <border type="none"/>
+            <children>
+              <component id="654f0" class="javax.swing.JCheckBox" binding="customIndentationForParamsCheckBox" default-binding="true">
+                <constraints>
+                  <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                </constraints>
+                <properties>
+                  <text value="Alternate indentation for constructor args and parameter declarations:"/>
+                  <verticalAlignment value="1"/>
+                </properties>
+              </component>
+              <component id="6c26f" class="javax.swing.JSpinner" binding="customIndentationForParamsSpinner" default-binding="true">
+                <constraints>
+                  <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="1" use-parent-layout="false">
+                    <minimum-size width="1" height="-1"/>
+                    <preferred-size width="2" height="-1"/>
+                  </grid>
+                </constraints>
+                <properties/>
+              </component>
+              <component id="49840" class="javax.swing.JLabel" binding="spacesLabel">
+                <constraints>
+                  <grid row="0" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                </constraints>
+                <properties>
+                  <text value="spaces"/>
+                  <verticalAlignment value="1"/>
+                </properties>
+              </component>
+              <hspacer id="8fa07">
+                <constraints>
+                  <grid row="0" column="3" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+                </constraints>
+              </hspacer>
+            </children>
+          </grid>
         </children>
       </grid>
     </children>

--- a/src/org/jetbrains/plugins/scala/lang/formatting/settings/OtherCodeStylePanel.java
+++ b/src/org/jetbrains/plugins/scala/lang/formatting/settings/OtherCodeStylePanel.java
@@ -31,14 +31,14 @@ public class OtherCodeStylePanel extends CodeStyleAbstractPanel {
   private JCheckBox replaceInForGeneratorCheckBox;
   private JCheckBox replaceLambdaWithGreekLetter;
   private JCheckBox lineCommentAtFirstColumnCheckBox;
-  private JCheckBox customIndentationForParamsCheckBox;
-  private JSpinner customIndentationForParamsSpinner;
+  private JCheckBox alternateIndentationForParamsCheckBox;
+  private JSpinner alternateIndentationForParamsSpinner;
   private JPanel alternateParamIndentPanel;
   private JLabel spacesLabel;
 
   protected OtherCodeStylePanel(@NotNull CodeStyleSettings settings) {
     super(settings);
-    customIndentationForParamsSpinner.setModel(new SpinnerNumberModel(4, 1, null, 1));
+    alternateIndentationForParamsSpinner.setModel(new SpinnerNumberModel(4, 1, null, 1));
     resetImpl(settings);
   }
 
@@ -82,8 +82,8 @@ public class OtherCodeStylePanel extends CodeStyleAbstractPanel {
     scalaCodeStyleSettings.REPLACE_FOR_GENERATOR_ARROW_WITH_UNICODE_CHAR = replaceInForGeneratorCheckBox.isSelected();
     scalaCodeStyleSettings.REPLACE_LAMBDA_WITH_GREEK_LETTER = replaceLambdaWithGreekLetter.isSelected();
     commonCodeStyleSettings.LINE_COMMENT_AT_FIRST_COLUMN = lineCommentAtFirstColumnCheckBox.isSelected();
-    scalaCodeStyleSettings.USE_ALTERNATE_CONTINUATION_INDENT_FOR_PARAMS = customIndentationForParamsCheckBox.isSelected();
-    scalaCodeStyleSettings.ALTERNATE_CONTINUATION_INDENT_FOR_PARAMS = (Integer) customIndentationForParamsSpinner.getValue();
+    scalaCodeStyleSettings.USE_ALTERNATE_CONTINUATION_INDENT_FOR_PARAMS = alternateIndentationForParamsCheckBox.isSelected();
+    scalaCodeStyleSettings.ALTERNATE_CONTINUATION_INDENT_FOR_PARAMS = (Integer) alternateIndentationForParamsSpinner.getValue();
   }
 
   @Override
@@ -103,9 +103,9 @@ public class OtherCodeStylePanel extends CodeStyleAbstractPanel {
       return true;
     if (commonCodeStyleSettings.LINE_COMMENT_AT_FIRST_COLUMN != lineCommentAtFirstColumnCheckBox.isSelected())
       return true;
-    if (scalaCodeStyleSettings.USE_ALTERNATE_CONTINUATION_INDENT_FOR_PARAMS != customIndentationForParamsCheckBox.isSelected())
+    if (scalaCodeStyleSettings.USE_ALTERNATE_CONTINUATION_INDENT_FOR_PARAMS != alternateIndentationForParamsCheckBox.isSelected())
       return true;
-    if (scalaCodeStyleSettings.ALTERNATE_CONTINUATION_INDENT_FOR_PARAMS != (Integer) customIndentationForParamsSpinner.getValue())
+    if (scalaCodeStyleSettings.ALTERNATE_CONTINUATION_INDENT_FOR_PARAMS != (Integer) alternateIndentationForParamsSpinner.getValue())
       return true;
 
 
@@ -128,8 +128,8 @@ public class OtherCodeStylePanel extends CodeStyleAbstractPanel {
     replaceInForGeneratorCheckBox.setSelected(scalaCodeStyleSettings.REPLACE_FOR_GENERATOR_ARROW_WITH_UNICODE_CHAR);
     replaceLambdaWithGreekLetter.setSelected(scalaCodeStyleSettings.REPLACE_LAMBDA_WITH_GREEK_LETTER);
     lineCommentAtFirstColumnCheckBox.setSelected(commonCodeStyleSettings.LINE_COMMENT_AT_FIRST_COLUMN);
-    customIndentationForParamsCheckBox.setSelected(scalaCodeStyleSettings.USE_ALTERNATE_CONTINUATION_INDENT_FOR_PARAMS);
-    customIndentationForParamsSpinner.setValue(scalaCodeStyleSettings.ALTERNATE_CONTINUATION_INDENT_FOR_PARAMS);
+    alternateIndentationForParamsCheckBox.setSelected(scalaCodeStyleSettings.USE_ALTERNATE_CONTINUATION_INDENT_FOR_PARAMS);
+    alternateIndentationForParamsSpinner.setValue(scalaCodeStyleSettings.ALTERNATE_CONTINUATION_INDENT_FOR_PARAMS);
   }
 
   {
@@ -177,12 +177,12 @@ public class OtherCodeStylePanel extends CodeStyleAbstractPanel {
     alternateParamIndentPanel = new JPanel();
     alternateParamIndentPanel.setLayout(new GridLayoutManager(1, 4, new Insets(0, 0, 0, 0), -1, -1));
     contentPanel.add(alternateParamIndentPanel, new GridConstraints(6, 0, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_BOTH, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, null, null, null, 0, false));
-    customIndentationForParamsCheckBox = new JCheckBox();
-    customIndentationForParamsCheckBox.setText("Alternate indentation for constructor args and parameter declarations:");
-    customIndentationForParamsCheckBox.setVerticalAlignment(1);
-    alternateParamIndentPanel.add(customIndentationForParamsCheckBox, new GridConstraints(0, 0, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
-    customIndentationForParamsSpinner = new JSpinner();
-    alternateParamIndentPanel.add(customIndentationForParamsSpinner, new GridConstraints(0, 1, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_HORIZONTAL, GridConstraints.SIZEPOLICY_WANT_GROW, GridConstraints.SIZEPOLICY_FIXED, new Dimension(1, -1), new Dimension(2, -1), null, 1, false));
+    alternateIndentationForParamsCheckBox = new JCheckBox();
+    alternateIndentationForParamsCheckBox.setText("Alternate indentation for constructor args and parameter declarations:");
+    alternateIndentationForParamsCheckBox.setVerticalAlignment(1);
+    alternateParamIndentPanel.add(alternateIndentationForParamsCheckBox, new GridConstraints(0, 0, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
+    alternateIndentationForParamsSpinner = new JSpinner();
+    alternateParamIndentPanel.add(alternateIndentationForParamsSpinner, new GridConstraints(0, 1, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_HORIZONTAL, GridConstraints.SIZEPOLICY_WANT_GROW, GridConstraints.SIZEPOLICY_FIXED, new Dimension(1, -1), new Dimension(2, -1), null, 1, false));
     spacesLabel = new JLabel();
     spacesLabel.setText("spaces");
     spacesLabel.setVerticalAlignment(1);

--- a/src/org/jetbrains/plugins/scala/lang/formatting/settings/OtherCodeStylePanel.java
+++ b/src/org/jetbrains/plugins/scala/lang/formatting/settings/OtherCodeStylePanel.java
@@ -31,9 +31,14 @@ public class OtherCodeStylePanel extends CodeStyleAbstractPanel {
   private JCheckBox replaceInForGeneratorCheckBox;
   private JCheckBox replaceLambdaWithGreekLetter;
   private JCheckBox lineCommentAtFirstColumnCheckBox;
+  private JCheckBox customIndentationForParamsCheckBox;
+  private JSpinner customIndentationForParamsSpinner;
+  private JPanel alternateParamIndentPanel;
+  private JLabel spacesLabel;
 
   protected OtherCodeStylePanel(@NotNull CodeStyleSettings settings) {
     super(settings);
+    customIndentationForParamsSpinner.setModel(new SpinnerNumberModel(4, 1, null, 1));
     resetImpl(settings);
   }
 
@@ -77,6 +82,8 @@ public class OtherCodeStylePanel extends CodeStyleAbstractPanel {
     scalaCodeStyleSettings.REPLACE_FOR_GENERATOR_ARROW_WITH_UNICODE_CHAR = replaceInForGeneratorCheckBox.isSelected();
     scalaCodeStyleSettings.REPLACE_LAMBDA_WITH_GREEK_LETTER = replaceLambdaWithGreekLetter.isSelected();
     commonCodeStyleSettings.LINE_COMMENT_AT_FIRST_COLUMN = lineCommentAtFirstColumnCheckBox.isSelected();
+    scalaCodeStyleSettings.USE_ALTERNATE_CONTINUATION_INDENT_FOR_PARAMS = customIndentationForParamsCheckBox.isSelected();
+    scalaCodeStyleSettings.ALTERNATE_CONTINUATION_INDENT_FOR_PARAMS = (Integer) customIndentationForParamsSpinner.getValue();
   }
 
   @Override
@@ -95,6 +102,10 @@ public class OtherCodeStylePanel extends CodeStyleAbstractPanel {
     if (scalaCodeStyleSettings.REPLACE_LAMBDA_WITH_GREEK_LETTER != replaceLambdaWithGreekLetter.isSelected())
       return true;
     if (commonCodeStyleSettings.LINE_COMMENT_AT_FIRST_COLUMN != lineCommentAtFirstColumnCheckBox.isSelected())
+      return true;
+    if (scalaCodeStyleSettings.USE_ALTERNATE_CONTINUATION_INDENT_FOR_PARAMS != customIndentationForParamsCheckBox.isSelected())
+      return true;
+    if (scalaCodeStyleSettings.ALTERNATE_CONTINUATION_INDENT_FOR_PARAMS != (Integer) customIndentationForParamsSpinner.getValue())
       return true;
 
 
@@ -117,6 +128,8 @@ public class OtherCodeStylePanel extends CodeStyleAbstractPanel {
     replaceInForGeneratorCheckBox.setSelected(scalaCodeStyleSettings.REPLACE_FOR_GENERATOR_ARROW_WITH_UNICODE_CHAR);
     replaceLambdaWithGreekLetter.setSelected(scalaCodeStyleSettings.REPLACE_LAMBDA_WITH_GREEK_LETTER);
     lineCommentAtFirstColumnCheckBox.setSelected(commonCodeStyleSettings.LINE_COMMENT_AT_FIRST_COLUMN);
+    customIndentationForParamsCheckBox.setSelected(scalaCodeStyleSettings.USE_ALTERNATE_CONTINUATION_INDENT_FOR_PARAMS);
+    customIndentationForParamsSpinner.setValue(scalaCodeStyleSettings.ALTERNATE_CONTINUATION_INDENT_FOR_PARAMS);
   }
 
   {
@@ -137,13 +150,13 @@ public class OtherCodeStylePanel extends CodeStyleAbstractPanel {
     final JPanel panel1 = new JPanel();
     panel1.setLayout(new GridLayoutManager(1, 1, new Insets(0, 0, 0, 0), -1, -1));
     contentPanel = new JPanel();
-    contentPanel.setLayout(new GridLayoutManager(7, 1, new Insets(0, 0, 0, 0), -1, -1));
+    contentPanel.setLayout(new GridLayoutManager(8, 1, new Insets(0, 0, 0, 0), -1, -1));
     panel1.add(contentPanel, new GridConstraints(0, 0, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_BOTH, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, null, null, null, 0, false));
     enforceFunctionalSyntaxForCheckBox = new JCheckBox();
     enforceFunctionalSyntaxForCheckBox.setText("Enforce procedure syntax for methods with Unit return type");
     contentPanel.add(enforceFunctionalSyntaxForCheckBox, new GridConstraints(0, 0, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
     final Spacer spacer1 = new Spacer();
-    contentPanel.add(spacer1, new GridConstraints(6, 0, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_VERTICAL, 1, GridConstraints.SIZEPOLICY_WANT_GROW, null, null, null, 0, false));
+    contentPanel.add(spacer1, new GridConstraints(7, 0, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_VERTICAL, 1, GridConstraints.SIZEPOLICY_WANT_GROW, null, null, null, 0, false));
     replaceWithUnicodeSymbolCheckBox = new JCheckBox();
     replaceWithUnicodeSymbolCheckBox.setText("Replace '=>' with unicode symbol");
     contentPanel.add(replaceWithUnicodeSymbolCheckBox, new GridConstraints(1, 0, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
@@ -161,5 +174,20 @@ public class OtherCodeStylePanel extends CodeStyleAbstractPanel {
     lineCommentAtFirstColumnCheckBox.setSelected(false);
     lineCommentAtFirstColumnCheckBox.setText("Line comment on first column");
     contentPanel.add(lineCommentAtFirstColumnCheckBox, new GridConstraints(5, 0, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
+    alternateParamIndentPanel = new JPanel();
+    alternateParamIndentPanel.setLayout(new GridLayoutManager(1, 4, new Insets(0, 0, 0, 0), -1, -1));
+    contentPanel.add(alternateParamIndentPanel, new GridConstraints(6, 0, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_BOTH, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, null, null, null, 0, false));
+    customIndentationForParamsCheckBox = new JCheckBox();
+    customIndentationForParamsCheckBox.setText("Alternate indentation for constructor args and parameter declarations:");
+    customIndentationForParamsCheckBox.setVerticalAlignment(1);
+    alternateParamIndentPanel.add(customIndentationForParamsCheckBox, new GridConstraints(0, 0, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
+    customIndentationForParamsSpinner = new JSpinner();
+    alternateParamIndentPanel.add(customIndentationForParamsSpinner, new GridConstraints(0, 1, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_HORIZONTAL, GridConstraints.SIZEPOLICY_WANT_GROW, GridConstraints.SIZEPOLICY_FIXED, new Dimension(1, -1), new Dimension(2, -1), null, 1, false));
+    spacesLabel = new JLabel();
+    spacesLabel.setText("spaces");
+    spacesLabel.setVerticalAlignment(1);
+    alternateParamIndentPanel.add(spacesLabel, new GridConstraints(0, 2, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_FIXED, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
+    final Spacer spacer2 = new Spacer();
+    alternateParamIndentPanel.add(spacer2, new GridConstraints(0, 3, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_HORIZONTAL, GridConstraints.SIZEPOLICY_WANT_GROW, 1, null, null, null, 0, false));
   }
 }

--- a/src/org/jetbrains/plugins/scala/lang/formatting/settings/ScalaCodeStyleSettings.java
+++ b/src/org/jetbrains/plugins/scala/lang/formatting/settings/ScalaCodeStyleSettings.java
@@ -32,11 +32,13 @@ public class ScalaCodeStyleSettings extends CustomCodeStyleSettings {
   public boolean PLACE_SELF_TYPE_ON_NEW_LINE = true;
   public boolean ALIGN_IF_ELSE = false;
   //indents
-  public boolean CUSTOM_CONTINUATION_INDENT_FOR_PARAMS = true;
   public boolean NOT_CONTINUATION_INDENT_FOR_PARAMS = false;
   public boolean ALIGN_IN_COLUMNS_CASE_BRANCH = false;
   public boolean ALIGN_COMPOSITE_PATTERN = true;
   public boolean DO_NOT_ALIGN_BLOCK_EXPR_PARAMS = false;
+
+  public boolean USE_ALTERNATE_CONTINUATION_INDENT_FOR_PARAMS = false;
+  public int ALTERNATE_CONTINUATION_INDENT_FOR_PARAMS = 4;
 
   public boolean SPACE_AFTER_MODIFIERS_CONSTRUCTOR = false;
 

--- a/src/org/jetbrains/plugins/scala/lang/formatting/settings/ScalaCodeStyleSettings.java
+++ b/src/org/jetbrains/plugins/scala/lang/formatting/settings/ScalaCodeStyleSettings.java
@@ -32,6 +32,7 @@ public class ScalaCodeStyleSettings extends CustomCodeStyleSettings {
   public boolean PLACE_SELF_TYPE_ON_NEW_LINE = true;
   public boolean ALIGN_IF_ELSE = false;
   //indents
+  public boolean CUSTOM_CONTINUATION_INDENT_FOR_PARAMS = true;
   public boolean NOT_CONTINUATION_INDENT_FOR_PARAMS = false;
   public boolean ALIGN_IN_COLUMNS_CASE_BRANCH = false;
   public boolean ALIGN_COMPOSITE_PATTERN = true;

--- a/src/org/jetbrains/plugins/scala/lang/formatting/settings/ScalaLanguageCodeStyleSettingsProvider.scala
+++ b/src/org/jetbrains/plugins/scala/lang/formatting/settings/ScalaLanguageCodeStyleSettingsProvider.scala
@@ -128,13 +128,8 @@ class ScalaLanguageCodeStyleSettingsProvider extends LanguageCodeStyleSettingsPr
         CodeStyleSettingsCustomizable.WRAPPING_SWITCH_STATEMENT, CodeStyleSettingsCustomizable.BRACE_OPTIONS,
         CodeStyleSettingsCustomizable.BRACE_VALUES)
       showCustomOption("PLACE_CLOSURE_PARAMETERS_ON_NEW_LINE", "Parameters on new line", ANONYMOUS_METHOD)
-
       showCustomOption("NOT_CONTINUATION_INDENT_FOR_PARAMS", "Use normal indent for parameters",
         CodeStyleSettingsCustomizable.WRAPPING_METHOD_PARAMETERS)
-      //showCustomOption("INDENT_FOR_PARAMS", "Indent for parameters",
-      //  ScalaCodeStyleSettings.INDENT_FOR_PARAMS,
-      //  ScalaCodeStyleSettings.INDENT_FOR_PARAMS_OPTIONS, ScalaCodeStyleSettings.INDENT_FOR_PARAMS_VALUES)
-
       showCustomOption("DO_NOT_INDENT_CASE_CLAUSE_BODY", "Do not indent case clause body", CodeStyleSettingsCustomizable.WRAPPING_SWITCH_STATEMENT)
       showCustomOption("INDENT_BRACED_FUNCTION_ARGS", "Indent braced arguments", CodeStyleSettingsCustomizable.WRAPPING_METHOD_ARGUMENTS_WRAPPING)
       showCustomOption("ALIGN_IN_COLUMNS_CASE_BRANCH", "Align in columns 'case' branches",

--- a/src/org/jetbrains/plugins/scala/lang/formatting/settings/ScalaLanguageCodeStyleSettingsProvider.scala
+++ b/src/org/jetbrains/plugins/scala/lang/formatting/settings/ScalaLanguageCodeStyleSettingsProvider.scala
@@ -128,8 +128,13 @@ class ScalaLanguageCodeStyleSettingsProvider extends LanguageCodeStyleSettingsPr
         CodeStyleSettingsCustomizable.WRAPPING_SWITCH_STATEMENT, CodeStyleSettingsCustomizable.BRACE_OPTIONS,
         CodeStyleSettingsCustomizable.BRACE_VALUES)
       showCustomOption("PLACE_CLOSURE_PARAMETERS_ON_NEW_LINE", "Parameters on new line", ANONYMOUS_METHOD)
+
       showCustomOption("NOT_CONTINUATION_INDENT_FOR_PARAMS", "Use normal indent for parameters",
         CodeStyleSettingsCustomizable.WRAPPING_METHOD_PARAMETERS)
+      //showCustomOption("INDENT_FOR_PARAMS", "Indent for parameters",
+      //  ScalaCodeStyleSettings.INDENT_FOR_PARAMS,
+      //  ScalaCodeStyleSettings.INDENT_FOR_PARAMS_OPTIONS, ScalaCodeStyleSettings.INDENT_FOR_PARAMS_VALUES)
+
       showCustomOption("DO_NOT_INDENT_CASE_CLAUSE_BODY", "Do not indent case clause body", CodeStyleSettingsCustomizable.WRAPPING_SWITCH_STATEMENT)
       showCustomOption("INDENT_BRACED_FUNCTION_ARGS", "Indent braced arguments", CodeStyleSettingsCustomizable.WRAPPING_METHOD_ARGUMENTS_WRAPPING)
       showCustomOption("ALIGN_IN_COLUMNS_CASE_BRANCH", "Align in columns 'case' branches",

--- a/src/org/jetbrains/plugins/scala/lang/psi/api/statements/params/ScParameterClause.scala
+++ b/src/org/jetbrains/plugins/scala/lang/psi/api/statements/params/ScParameterClause.scala
@@ -39,4 +39,6 @@ trait ScParameterClause extends ScalaPsiElement {
     * if clause has repeated parameter, add before this parameter.
     */
   def addParameter(param: ScParameter): ScParameterClause
+
+  def owner: PsiElement
 }

--- a/src/org/jetbrains/plugins/scala/lang/psi/impl/statements/params/ScParameterClauseImpl.scala
+++ b/src/org/jetbrains/plugins/scala/lang/psi/impl/statements/params/ScParameterClauseImpl.scala
@@ -6,11 +6,13 @@ package statements
 package params
 
 import com.intellij.lang.ASTNode
+import com.intellij.psi.PsiElement
 import com.intellij.psi.stubs.StubElement
 import com.intellij.psi.tree.IElementType
 import org.jetbrains.plugins.scala.lang.lexer.ScalaTokenTypes
 import org.jetbrains.plugins.scala.lang.parser.ScalaElementTypes
 import org.jetbrains.plugins.scala.lang.psi.api.base.ScPrimaryConstructor
+import org.jetbrains.plugins.scala.lang.psi.api.expr.ScFunctionExpr
 import org.jetbrains.plugins.scala.lang.psi.api.statements.ScFunction
 import org.jetbrains.plugins.scala.lang.psi.api.statements.params._
 import org.jetbrains.plugins.scala.lang.psi.api.toplevel.ScTypeParametersOwner
@@ -108,5 +110,9 @@ class ScParameterClauseImpl private (stub: StubElement[ScParameterClause], nodeT
       node.addChild(space, rParen)
     }
     this
+  }
+
+  override def owner: PsiElement = {
+    ScalaPsiUtil.getContextOfType(this, true, classOf[ScFunctionExpr], classOf[ScFunction], classOf[ScPrimaryConstructor])
   }
 }

--- a/src/org/jetbrains/plugins/scala/lang/psi/light/scala/ScLightParameterClause.scala
+++ b/src/org/jetbrains/plugins/scala/lang/psi/light/scala/ScLightParameterClause.scala
@@ -1,10 +1,14 @@
 package org.jetbrains.plugins.scala
 package lang.psi.light.scala
 
+import com.intellij.psi.PsiElement
 import com.intellij.psi.impl.light.LightElement
-import org.jetbrains.plugins.scala.lang.psi.ScalaPsiElement
+import org.jetbrains.plugins.scala.lang.psi.api.base.ScPrimaryConstructor
+import org.jetbrains.plugins.scala.lang.psi.api.expr.ScFunctionExpr
+import org.jetbrains.plugins.scala.lang.psi.api.statements.ScFunction
 import org.jetbrains.plugins.scala.lang.psi.api.statements.params.{ScParameter, ScParameterClause}
 import org.jetbrains.plugins.scala.lang.psi.types.ScType
+import org.jetbrains.plugins.scala.lang.psi.{ScalaPsiElement, ScalaPsiUtil}
 
 /**
  * @author Alefas
@@ -30,4 +34,8 @@ class ScLightParameterClause(types: List[ScType], clause: ScParameterClause)
 
   override protected def findChildByClassScala[T >: Null <: ScalaPsiElement](clazz: Class[T]): T =
     throw new UnsupportedOperationException("Operation on light element")
+
+  override def owner: PsiElement = {
+    ScalaPsiUtil.getContextOfType(this, true, classOf[ScFunctionExpr], classOf[ScFunction], classOf[ScPrimaryConstructor])
+  }
 }


### PR DESCRIPTION
This adds an alternate Scala indentation setting for constructor arg and parameter declarations.

The goal is to make it possible to customize code style for the Scala editor to match the [official Scala style guide](http://docs.scala-lang.org/style/).

The relevant rules from the guide are:
- Continuation indent ([Line Wrapping in the Scala style guide](http://docs.scala-lang.org/style/indentation.html#line-wrapping)) should be 2-space.
- Constructor Arguments continuations should 4-space (["...indented four spaces"](http://docs.scala-lang.org/style/declarations.html#classes)).
- (While no guidance is explicitly provided in the official Scala style guide on indentation for continuations of long parameter list declarations, it is often assumed to be 4-space, just like Constructor Arguments are. Conveniently, `ScParameterClause` is used for both.)

Example from official guide:

``` scala
class Person(
    name: String,
    age: Int,
    birthdate: Date,
    astrologicalSign: String,
    shoeSize: Int,
    favoriteColor: java.awt.Color) {
  def firstMethod: Foo = ...
}
```

I looked briefly into how to add the indentation settings to the `Tabs and Indents` Scala Code Style tab, but was unable to figure out a reasonable way to add it. So I have instead added it as a setting to the "Other" page.  If there is a better way to introduce this setting, let me know.

I was also unable to figure out how to respect "Use tab character". So this settings always uses spaces...

I've set this alternate indentation setting to disabled by default.

Here's what the settings UI look like with the new "Alternate indentation for constructor args and parameter declarations" option:

![screen shot 2015-11-09 at 5 01 42 pm](https://cloud.githubusercontent.com/assets/523590/11051397/abc85006-8703-11e5-9238-0c6cf8ec13f5.png)
