### PR TITLE
Highlight anonymous classes that can be converted to SAM the same way it is highlighted in Java

### DIFF
--- a/test/org/jetbrains/plugins/scala/codeInspection/functionExpressions/ConvertExpressionToSAMInspectionTest.scala
+++ b/test/org/jetbrains/plugins/scala/codeInspection/functionExpressions/ConvertExpressionToSAMInspectionTest.scala
@@ -26,9 +26,9 @@ class ConvertExpressionToSAMInspectionTest extends ScalaLightInspectionFixtureTe
   def testThreadRunnable(): Unit = {
     val code =
       s"""
-         |new Thread(${START}new Runnable {
+         |new Thread(${START}new Runnable $END{
          |override def run() = println()
-         |}$END
+         |}
       """.stripMargin
     check(code)
     val text =
@@ -44,9 +44,9 @@ class ConvertExpressionToSAMInspectionTest extends ScalaLightInspectionFixtureTe
   def testValueDefinition(): Unit = {
     val code =
       s"""
-        |val y: Runnable = ${START}new Runnable {
+        |val y: Runnable = ${START}new Runnable $END{
         |  override def run(): Unit = ???
-        |}$END
+        |}
       """.stripMargin
     check(code)
     val text =
@@ -76,9 +76,9 @@ class ConvertExpressionToSAMInspectionTest extends ScalaLightInspectionFixtureTe
         |  def foo(): String
         |}
         |def bar(a: A) = println()
-        |bar(${START}new A {
+        |bar(${START}new A $END{
         |  override def foo(): String = "something"
-        |}$END)
+        |})
       """.stripMargin
     check(code)
     val text =
@@ -135,13 +135,13 @@ class ConvertExpressionToSAMInspectionTest extends ScalaLightInspectionFixtureTe
   def testInner(): Unit = {
     val code =
       s"""
-        |new Thread(${START}new Runnable {
+        |new Thread(${START}new Runnable $END{
         |  def run() {
         |    def foo(i: Int) = i
         |
         |    println(foo(10))
         |  }
-        |}$END)
+        |})
       """.stripMargin
     check(code)
     val text =
@@ -168,13 +168,13 @@ class ConvertExpressionToSAMInspectionTest extends ScalaLightInspectionFixtureTe
   def testMultiLine(): Unit = {
     val code =
       s"""
-        |new Thread(${START}new Runnable {
+        |new Thread(${START}new Runnable $END{
         |  override def run(): Unit = {
         |    val i = 2 + 3
         |    val z = 2
         |    println(i - z)
         |  }
-        |}$END)
+        |})
       """.stripMargin
     check(code)
     val text =


### PR DESCRIPTION
Highlighting in Java:
![java](https://cloud.githubusercontent.com/assets/5924452/11090807/2e4beb36-8886-11e5-9b3f-24256eda8d54.png)

Highlighting in Scala (after this commit)
![scala](https://cloud.githubusercontent.com/assets/5924452/11090821/42d6a0a0-8886-11e5-9cf7-52efec7637b0.png)
