### PR TITLE
[CacheInvalidator]Do not invalidate caches not only for all expressions

### DIFF
--- a/src/org/jetbrains/plugins/scala/lang/completion/ScalaBasicCompletionContributor.scala
+++ b/src/org/jetbrains/plugins/scala/lang/completion/ScalaBasicCompletionContributor.scala
@@ -22,7 +22,7 @@ import org.jetbrains.plugins.scala.lang.psi.ScalaPsiUtil
 import org.jetbrains.plugins.scala.lang.psi.api.ScalaFile
 import org.jetbrains.plugins.scala.lang.psi.api.base.patterns.ScBindingPattern
 import org.jetbrains.plugins.scala.lang.psi.api.base.{ScInterpolated, ScReferenceElement, ScStableCodeReferenceElement}
-import org.jetbrains.plugins.scala.lang.psi.api.expr.{ScBlock, ScNewTemplateDefinition, ScReferenceExpression}
+import org.jetbrains.plugins.scala.lang.psi.api.expr.{ScBlock, ScModificationTrackerOwner, ScNewTemplateDefinition, ScReferenceExpression}
 import org.jetbrains.plugins.scala.lang.psi.api.statements.ScFun
 import org.jetbrains.plugins.scala.lang.psi.api.statements.params.ScClassParameter
 import org.jetbrains.plugins.scala.lang.psi.api.toplevel.imports.ScImportStmt
@@ -31,7 +31,7 @@ import org.jetbrains.plugins.scala.lang.psi.fake.FakePsiMethod
 import org.jetbrains.plugins.scala.lang.psi.impl.ScalaPsiElementFactory
 import org.jetbrains.plugins.scala.lang.psi.impl.base.ScStableCodeReferenceElementImpl
 import org.jetbrains.plugins.scala.lang.psi.impl.base.types.ScTypeProjectionImpl
-import org.jetbrains.plugins.scala.lang.psi.impl.expr.{ScBlockExprImpl, ScReferenceExpressionImpl}
+import org.jetbrains.plugins.scala.lang.psi.impl.expr.ScReferenceExpressionImpl
 import org.jetbrains.plugins.scala.lang.psi.types.{ScAbstractType, ScType}
 import org.jetbrains.plugins.scala.lang.refactoring.util.ScalaNamesUtil
 import org.jetbrains.plugins.scala.lang.resolve.processor.CompletionProcessor
@@ -54,11 +54,11 @@ abstract class ScalaCompletionContributor extends CompletionContributor {
 
     @tailrec
     def inner(element: PsiElement): PsiElement = element match {
-      case null => parameters.getPosition //we got to the top of the tree and didn't find a modifierCountOwner
-      case block: ScBlockExprImpl if block.isModificationCountOwner =>
-        if (block.containingFile.contains(parameters.getOriginalFile)) {
-          block.getMirrorPositionForCompletion(getDummyIdentifier(parameters.getOffset, parameters.getOriginalFile),
-            parameters.getOffset - block.getTextOffset)
+      case null => parameters.getPosition //we got to the top of the tree and didn't find a modificationTrackerOwner
+      case owner: ScModificationTrackerOwner if owner.isValidModificationTrackerOwner =>
+        if (owner.containingFile.contains(parameters.getOriginalFile)) {
+          owner.getMirrorPositionForCompletion(getDummyIdentifier(parameters.getOffset, parameters.getOriginalFile),
+            parameters.getOffset - owner.getTextOffset)
         } else parameters.getPosition
       case _ => inner(element.getContext)
     }

--- a/src/org/jetbrains/plugins/scala/lang/psi/ScalaPsiUtil.scala
+++ b/src/org/jetbrains/plugins/scala/lang/psi/ScalaPsiUtil.scala
@@ -42,7 +42,6 @@ import org.jetbrains.plugins.scala.lang.psi.api.toplevel.templates.ScTemplateBod
 import org.jetbrains.plugins.scala.lang.psi.api.toplevel.typedef._
 import org.jetbrains.plugins.scala.lang.psi.api.{InferUtil, ScPackageLike, ScalaFile, ScalaRecursiveElementVisitor}
 import org.jetbrains.plugins.scala.lang.psi.impl.ScalaPsiManager.ClassCategory
-import org.jetbrains.plugins.scala.lang.psi.impl.expr.ScBlockExprImpl
 import org.jetbrains.plugins.scala.lang.psi.impl.toplevel.typedef.TypeDefinitionMembers
 import org.jetbrains.plugins.scala.lang.psi.impl.{ScalaPsiElementFactory, ScalaPsiManager}
 import org.jetbrains.plugins.scala.lang.psi.implicits.ScImplicitlyConvertible.ImplicitResolveResult
@@ -1876,23 +1875,6 @@ object ScalaPsiUtil {
             _: ScEarlyDefinitions | _: ScRefinement => true
     case e: ScPatternDefinition if e.getContext.isInstanceOf[ScCaseClause] => true // {case a => val a = 1}
     case _ => false
-  }
-
-  def shouldChangeModificationCount(place: PsiElement): Boolean = {
-    var parent = place.getParent
-    while (parent != null) {
-      parent match {
-        case f: ScFunction => f.returnTypeElement match {
-          case Some(ret) => return false
-          case None => if (!f.hasAssign) return false
-        }
-        case t: PsiClass => return true
-        case bl: ScBlockExprImpl => return bl.shouldChangeModificationCount(null)
-        case _ =>
-      }
-      parent = parent.getParent
-    }
-    false
   }
 
   def stringValueOf(e: PsiLiteral): Option[String] = e.getValue.toOption.flatMap(_.asOptionOf[String])

--- a/src/org/jetbrains/plugins/scala/lang/psi/api/expr/ScExpression.scala
+++ b/src/org/jetbrains/plugins/scala/lang/psi/api/expr/ScExpression.scala
@@ -31,7 +31,8 @@ import scala.collection.{Seq, Set}
  * @author ilyas, Alexander Podkhalyuzin
  */
 
-trait ScExpression extends ScBlockStatement with PsiAnnotationMemberValue with ImplicitParametersOwner {
+trait ScExpression extends ScBlockStatement with PsiAnnotationMemberValue with ImplicitParametersOwner
+  with ScModificationTrackerOwner {
   import org.jetbrains.plugins.scala.lang.psi.api.expr.ScExpression._
   /**
    * This method returns real type, after using implicit conversions.

--- a/src/org/jetbrains/plugins/scala/lang/psi/api/expr/ScModificationTrackerOwner.scala
+++ b/src/org/jetbrains/plugins/scala/lang/psi/api/expr/ScModificationTrackerOwner.scala
@@ -1,0 +1,74 @@
+package org.jetbrains.plugins.scala.lang.psi.api.expr
+
+import java.util.concurrent.atomic.AtomicLong
+
+import com.intellij.openapi.util.ModificationTracker
+import com.intellij.psi.util.PsiModificationTracker
+import com.intellij.psi.{PsiElement, PsiModifiableCodeBlock}
+import org.jetbrains.plugins.scala.lang.psi.ScalaPsiElement
+import org.jetbrains.plugins.scala.lang.psi.api.ScalaFile
+import org.jetbrains.plugins.scala.lang.psi.api.statements.{ScFunction, ScValue, ScVariable}
+import org.jetbrains.plugins.scala.lang.psi.impl.ScalaPsiElementFactory
+import org.jetbrains.plugins.scala.macroAnnotations.{Cached, ModCount}
+
+import scala.annotation.tailrec
+
+/**
+  * Author: Svyatoslav Ilinskiy
+  * Date: 11/09/2015
+  */
+trait ScModificationTrackerOwner extends ScalaPsiElement with PsiModifiableCodeBlock {
+  private val blockModificationCount = new AtomicLong(0L)
+
+  def rawModificationCount: Long = blockModificationCount.get()
+
+  def getModificationTracker: ModificationTracker = {
+    assert(isValidModificationTrackerOwner)
+    new ModificationTracker {
+      override def getModificationCount: Long = getModificationCountImpl
+    }
+  }
+
+  private def getModificationCountImpl: Long = {
+    @tailrec
+    def calc(place: PsiElement, sum: Long): Long = place match {
+      case null => sum + PsiModificationTracker.SERVICE.getInstance(getProject).getOutOfCodeBlockModificationCount
+      case file: ScalaFile => sum + file.getManager.getModificationTracker.getOutOfCodeBlockModificationCount
+      case owner: ScModificationTrackerOwner if owner.isValidModificationTrackerOwner =>
+        calc(owner.getContext, sum + owner.rawModificationCount)
+      case _ => calc(place.getContext, sum)
+    }
+
+    calc(this, 0L)
+  }
+
+  def incModificationCount(): Long = {
+    assert(isValidModificationTrackerOwner)
+    blockModificationCount.incrementAndGet()
+  }
+
+  def isValidModificationTrackerOwner: Boolean = {
+    getContext match {
+      case f: ScFunction => f.returnTypeElement match {
+        case Some(ret) =>  true
+        case None => !f.hasAssign
+      }
+      case v: ScValue => v.typeElement.isDefined
+      case v: ScVariable => v.typeElement.isDefined
+      case _ => false
+    }
+  }
+
+  //elem is always the child of this element because this function is called when going up the tree starting with elem
+  //if this is a valid modification tracker owner, no need to change modification count
+  override def shouldChangeModificationCount(elem: PsiElement) = !isValidModificationTrackerOwner
+
+  @Cached(synchronized = true, ModCount.getBlockModificationCount, this)
+  def getMirrorPositionForCompletion(dummyIdentifier: String, pos: Int): PsiElement = {
+    val text = new StringBuilder(getText)
+    text.insert(pos, dummyIdentifier)
+    val newBlock = ScalaPsiElementFactory.createExpressionWithContextFromText(text.toString(), getContext, this)
+    newBlock.findElementAt(pos)
+  }
+}
+

--- a/src/org/jetbrains/plugins/scala/lang/psi/api/statements/ScFunction.scala
+++ b/src/org/jetbrains/plugins/scala/lang/psi/api/statements/ScFunction.scala
@@ -97,7 +97,7 @@ trait ScFunction extends ScalaPsiElement with ScMember with ScTypeParametersOwne
   }
 
   def isParameterless = paramClauses.clauses.isEmpty
-  
+
   private val probablyRecursive: ThreadLocal[Boolean] = new ThreadLocal[Boolean]() {
     override def initialValue(): Boolean = false
   }

--- a/src/org/jetbrains/plugins/scala/lang/psi/impl/ScalaPsiManager.scala
+++ b/src/org/jetbrains/plugins/scala/lang/psi/impl/ScalaPsiManager.scala
@@ -21,10 +21,10 @@ import com.intellij.util.containers.WeakValueHashMap
 import org.jetbrains.plugins.scala.caches.ScalaShortNamesCacheManager
 import org.jetbrains.plugins.scala.extensions._
 import org.jetbrains.plugins.scala.finder.ScalaSourceFilterScope
+import org.jetbrains.plugins.scala.lang.psi.api.expr.ScModificationTrackerOwner
 import org.jetbrains.plugins.scala.lang.psi.api.statements.ScTypeAlias
 import org.jetbrains.plugins.scala.lang.psi.api.statements.params.ScTypeParam
 import org.jetbrains.plugins.scala.lang.psi.api.toplevel.typedef.{ScObject, ScTemplateDefinition}
-import org.jetbrains.plugins.scala.lang.psi.impl.expr.ScBlockExprImpl
 import org.jetbrains.plugins.scala.lang.psi.impl.toplevel.synthetic.{ScSyntheticPackage, SyntheticPackageCreator}
 import org.jetbrains.plugins.scala.lang.psi.impl.toplevel.typedef.TypeDefinitionMembers.ParameterlessNodes.{Map => PMap}
 import org.jetbrains.plugins.scala.lang.psi.impl.toplevel.typedef.TypeDefinitionMembers.SignatureNodes.{Map => SMap}
@@ -330,9 +330,9 @@ class ScalaPsiManager(project: Project) extends ProjectComponent {
   object CacheInvalidator extends PsiTreeChangeAdapter {
     @tailrec
     def updateModificationCount(elem: PsiElement): Unit = {
-      Option(PsiTreeUtil.getContextOfType(elem, false, classOf[ScBlockExprImpl])) match {
-        case Some(block) if block.isModificationCountOwner => block.incModificationCount()
-        case Some(block) => updateModificationCount(block.getContext)
+      Option(PsiTreeUtil.getContextOfType(elem, false, classOf[ScModificationTrackerOwner])) match {
+        case Some(owner) if owner.isValidModificationTrackerOwner => owner.incModificationCount()
+        case Some(owner) => updateModificationCount(owner.getContext)
         case _ =>
       }
     }

--- a/src/org/jetbrains/plugins/scala/lang/psi/impl/expr/ScBlockExprImpl.scala
+++ b/src/org/jetbrains/plugins/scala/lang/psi/impl/expr/ScBlockExprImpl.scala
@@ -6,20 +6,12 @@ package expr
 
 
 import java.util
-import java.util.concurrent.atomic.AtomicLong
 
-import com.intellij.openapi.util.ModificationTracker
 import com.intellij.psi.impl.source.tree.LazyParseablePsiElement
-import com.intellij.psi.util.PsiModificationTracker
-import com.intellij.psi.{PsiClass, PsiElement, PsiElementVisitor, PsiModifiableCodeBlock}
+import com.intellij.psi.{PsiElement, PsiElementVisitor}
 import org.jetbrains.plugins.scala.lang.parser.ScalaElementTypes
+import org.jetbrains.plugins.scala.lang.psi.api.ScalaElementVisitor
 import org.jetbrains.plugins.scala.lang.psi.api.expr._
-import org.jetbrains.plugins.scala.lang.psi.api.statements.{ScFunction, ScValue, ScVariable}
-import org.jetbrains.plugins.scala.lang.psi.api.{ScalaElementVisitor, ScalaFile}
-import org.jetbrains.plugins.scala.macroAnnotations.{CachedInsidePsiElement, ModCount, Cached}
-
-import scala.annotation.tailrec
-import scala.collection.mutable.StringBuilder
 
 /**
 * @author Alexander Podkhalyuzin
@@ -27,9 +19,7 @@ import scala.collection.mutable.StringBuilder
 */
 
 class ScBlockExprImpl(text: CharSequence) extends LazyParseablePsiElement(ScalaElementTypes.BLOCK_EXPR, text)
-  with ScBlockExpr with PsiModifiableCodeBlock { self =>
-
-  private val blockModificationCount = new AtomicLong(0L)
+  with ScBlockExpr {
 
   //todo: bad architecture to have it duplicated here, as ScBlockExprImpl is not instance of ScalaPsiElementImpl
   override def getContext: PsiElement = {
@@ -62,65 +52,6 @@ class ScBlockExprImpl(text: CharSequence) extends LazyParseablePsiElement(ScalaE
     null
   }
 
-  def isModificationCountOwner: Boolean = {
-    getContext match {
-      case f: ScFunction => f.returnTypeElement match {
-        case Some(ret) =>  true
-        case None => !f.hasAssign
-      }
-      case v: ScValue => v.typeElement.isDefined
-      case v: ScVariable => v.typeElement.isDefined
-      case _ => false
-    }
-  }
-
-  def incModificationCount(): Long = {
-    assert(isModificationCountOwner)
-    blockModificationCount.incrementAndGet()
-  }
-
-  def shouldChangeModificationCount(place: PsiElement): Boolean = {
-    var parent = getParent
-    while (parent != null) {
-      parent match {
-        case f: ScFunction => f.returnTypeElement match {
-          case Some(ret) => return false
-          case None =>
-            if (!f.hasAssign) return false
-            return ScalaPsiUtil.shouldChangeModificationCount(f)
-        }
-        case v: ScValue => return ScalaPsiUtil.shouldChangeModificationCount(v)
-        case v: ScVariable => return ScalaPsiUtil.shouldChangeModificationCount(v)
-        case t: PsiClass => return true
-        case bl: ScBlockExprImpl => return bl.shouldChangeModificationCount(this)
-        case _ =>
-      }
-      parent = parent.getParent
-    }
-    false
-  }
-
-  def getRawModificationCount: Long = blockModificationCount.get()
-
-  def getModificationTracker: ModificationTracker = {
-    assert(isModificationCountOwner)
-    new ModificationTracker {
-      override def getModificationCount: Long = getThisBlockExprModificationCount
-    }
-  }
-
-  def getThisBlockExprModificationCount: Long = {
-    @tailrec
-    def calc(place: PsiElement, sum: Long): Long = place match {
-      case null => sum + PsiModificationTracker.SERVICE.getInstance(place.getProject).getOutOfCodeBlockModificationCount
-      case file: ScalaFile => sum + file.getManager.getModificationTracker.getOutOfCodeBlockModificationCount
-      case block: ScBlockExprImpl if block.isModificationCountOwner => calc(block.getContext, sum + block.getRawModificationCount)
-      case _ => calc(place.getContext, sum)
-    }
-
-    calc(this, 0L)
-  }
-
   override def accept(visitor: ScalaElementVisitor) = {visitor.visitBlockExpression(this)}
 
   override def accept(visitor: PsiElementVisitor) {
@@ -128,13 +59,5 @@ class ScBlockExprImpl(text: CharSequence) extends LazyParseablePsiElement(ScalaE
       case s: ScalaElementVisitor => accept(s)
       case _ => super.accept(visitor)
     }
-  }
-
-  @Cached(synchronized = true, ModCount.getBlockModificationCount, this)
-  def getMirrorPositionForCompletion(dummyIdentifier: String, pos: Int): PsiElement = {
-    val text = new StringBuilder(getText)
-    text.insert(pos, dummyIdentifier)
-    val newBlock = ScalaPsiElementFactory.createExpressionWithContextFromText(text.toString, getContext, this)
-    newBlock.findElementAt(pos)
   }
 }


### PR DESCRIPTION
If a modified expression is in the right hand side of a definition with
explicit return type, modification count will not be changed.
NOTE: if the definition is its direct parent, modification count will
be changed, this is a limitation of IDEA platform. Perhaps, we can
come up with some workaround.
