### PR TITLE
Do not invalidate caches when inside while loop

### DIFF
--- a/src/org/jetbrains/plugins/scala/lang/psi/api/expr/ScModificationTrackerOwner.scala
+++ b/src/org/jetbrains/plugins/scala/lang/psi/api/expr/ScModificationTrackerOwner.scala
@@ -56,6 +56,7 @@ trait ScModificationTrackerOwner extends ScalaPsiElement with PsiModifiableCodeB
       case v: ScValue => v.typeElement.isDefined
       case v: ScVariable => v.typeElement.isDefined
       case _: ScWhileStmt => true
+      case _: ScFinallyBlock => true
       case _ => false
     }
   }

--- a/src/org/jetbrains/plugins/scala/lang/psi/api/expr/ScModificationTrackerOwner.scala
+++ b/src/org/jetbrains/plugins/scala/lang/psi/api/expr/ScModificationTrackerOwner.scala
@@ -57,6 +57,7 @@ trait ScModificationTrackerOwner extends ScalaPsiElement with PsiModifiableCodeB
       case v: ScVariable => v.typeElement.isDefined
       case _: ScWhileStmt => true
       case _: ScFinallyBlock => true
+      case _: ScDoStmt => true
       case _ => false
     }
   }

--- a/src/org/jetbrains/plugins/scala/lang/psi/api/expr/ScModificationTrackerOwner.scala
+++ b/src/org/jetbrains/plugins/scala/lang/psi/api/expr/ScModificationTrackerOwner.scala
@@ -55,6 +55,7 @@ trait ScModificationTrackerOwner extends ScalaPsiElement with PsiModifiableCodeB
       }
       case v: ScValue => v.typeElement.isDefined
       case v: ScVariable => v.typeElement.isDefined
+      case _: ScWhileStmt => true
       case _ => false
     }
   }


### PR DESCRIPTION
If you are inside a while statement, you can only return if you use
return keyword. However, if you use `return`, you have to have return
type declared, so return type of the function cannot change when you
are inside a while loop
