### PR TITLE
Fix cache invalidation bug with substitutors

### DIFF
--- a/src/org/jetbrains/plugins/scala/lang/parameterInfo/ScalaFunctionParameterInfoHandler.scala
+++ b/src/org/jetbrains/plugins/scala/lang/parameterInfo/ScalaFunctionParameterInfoHandler.scala
@@ -457,13 +457,13 @@ class ScalaFunctionParameterInfoHandler extends ParameterInfoHandlerWithTabActio
               val gen = args.callGeneric.getOrElse(null: ScGenericCall)
               def collectSubstitutor(element: PsiElement): ScSubstitutor = {
                 if (gen == null) return ScSubstitutor.empty
-                val tp: Array[(String, String)] = element match {
+                val tp: Array[(String, PsiElement)] = element match {
                   case tpo: ScTypeParametersOwner => tpo.typeParameters.map(p => (p.name, ScalaPsiUtil.getPsiElementId(p))).toArray
                   case ptpo: PsiTypeParameterListOwner => ptpo.getTypeParameters.map(p => (p.name, ScalaPsiUtil.getPsiElementId(p)))
                   case _ => return ScSubstitutor.empty
                 }
                 val typeArgs: Seq[ScTypeElement] = gen.arguments
-                val map = new collection.mutable.HashMap[(String, String), ScType]
+                val map = new collection.mutable.HashMap[(String, PsiElement), ScType]
                 for (i <- 0 to Math.min(tp.length, typeArgs.length) - 1) {
                   map += ((tp(i), typeArgs(i).calcType))
                 }
@@ -546,7 +546,7 @@ class ScalaFunctionParameterInfoHandler extends ParameterInfoHandlerWithTabActio
                           case gen: ScParameterizedTypeElement =>
                             val tp = clazz.typeParameters.map(p => (p.name, ScalaPsiUtil.getPsiElementId(p)))
                             val typeArgs: Seq[ScTypeElement] = gen.typeArgList.typeArgs
-                            val map = new collection.mutable.HashMap[(String, String), ScType]
+                            val map = new collection.mutable.HashMap[(String, PsiElement), ScType]
                             for (i <- 0 to Math.min(tp.length, typeArgs.length) - 1) {
                               map += ((tp(i), typeArgs(i).calcType))
                             }
@@ -576,7 +576,7 @@ class ScalaFunctionParameterInfoHandler extends ParameterInfoHandlerWithTabActio
                         case gen: ScParameterizedTypeElement =>
                           val tp = clazz.getTypeParameters.map(p => (p.name, ScalaPsiUtil.getPsiElementId(p)))
                           val typeArgs: Seq[ScTypeElement] = gen.typeArgList.typeArgs
-                          val map = new collection.mutable.HashMap[(String, String), ScType]
+                          val map = new collection.mutable.HashMap[(String, PsiElement), ScType]
                           for (i <- 0 to Math.min(tp.length, typeArgs.length) - 1) {
                             map += ((tp(i), typeArgs(i).calcType))
                           }

--- a/src/org/jetbrains/plugins/scala/lang/psi/api/statements/params/ScTypeParam.scala
+++ b/src/org/jetbrains/plugins/scala/lang/psi/api/statements/params/ScTypeParam.scala
@@ -29,9 +29,7 @@ trait ScTypeParam extends ScalaPsiElement with ScPolymorphicElement with PsiType
 
   def typeParameterText: String
 
-  def getPsiElementId: String = {
-    s" in:$getContainingFileName:$getOffsetInFile"
-  }
+  def getPsiElementId: PsiElement
 }
 
 object ScTypeParam {

--- a/src/org/jetbrains/plugins/scala/lang/psi/impl/base/ScConstructorImpl.scala
+++ b/src/org/jetbrains/plugins/scala/lang/psi/impl/base/ScConstructorImpl.scala
@@ -125,7 +125,7 @@ class ScConstructorImpl(node: ASTNode) extends ScalaPsiElementImpl(node) with Sc
       s.getParent match {
         case p: ScParameterizedTypeElement =>
           val zipped = p.typeArgList.typeArgs.zip(typeParameters)
-          val appSubst = new ScSubstitutor(new HashMap[(String, String), ScType] ++ zipped.map {
+          val appSubst = new ScSubstitutor(new HashMap[(String, PsiElement), ScType] ++ zipped.map {
             case (arg, typeParam) =>
               ((typeParam.name, ScalaPsiUtil.getPsiElementId(typeParam.ptp)), arg.getType(TypingContext.empty).getOrAny)
           }, Map.empty, None)

--- a/src/org/jetbrains/plugins/scala/lang/psi/impl/base/types/ScSimpleTypeElementImpl.scala
+++ b/src/org/jetbrains/plugins/scala/lang/psi/impl/base/types/ScSimpleTypeElementImpl.scala
@@ -161,11 +161,10 @@ class ScSimpleTypeElementImpl(node: ASTNode) extends ScalaPsiElementImpl(node) w
       getContext match {
         case p: ScParameterizedTypeElement =>
           val zipped = p.typeArgList.typeArgs.zip(typeParameters)
-          val appSubst = new ScSubstitutor(new HashMap[(String, String), ScType] ++ zipped.map{case (arg, typeParam) =>
-            ((typeParam.name, ScalaPsiUtil.getPsiElementId(typeParam.ptp)),
-              arg.getType(TypingContext.empty).getOrAny
-              )},
-            Map.empty, None)
+          val appSubst = new ScSubstitutor(new HashMap[(String, PsiElement), ScType] ++ zipped.map{
+            case (arg, typeParam) =>
+              ((typeParam.name, ScalaPsiUtil.getPsiElementId(typeParam.ptp)), arg.getType(TypingContext.empty).getOrAny)
+          }, Map.empty, None)
           val newRes = appSubst.subst(res)
           updateImplicits(newRes, withExpected = false, params = params, lastImplicit = lastImplicit)
           return newRes
@@ -269,11 +268,10 @@ class ScSimpleTypeElementImpl(node: ASTNode) extends ScalaPsiElementImpl(node) w
           }
 
           val zipped = p.typeArgList.typeArgs.zip(typeParameters)
-          val appSubst = new ScSubstitutor(new HashMap[(String, String), ScType] ++ zipped.map { case (arg, typeParam) =>
-            ((typeParam.name, ScalaPsiUtil.getPsiElementId(typeParam.ptp)),
-                    arg.getType(TypingContext.empty).getOrAny)
-          },
-            Map.empty, None)
+          val appSubst = new ScSubstitutor(new HashMap[(String, PsiElement), ScType] ++ zipped.map {
+            case (arg, typeParam) =>
+              ((typeParam.name, ScalaPsiUtil.getPsiElementId(typeParam.ptp)), arg.getType(TypingContext.empty).getOrAny)
+          }, Map.empty, None)
           (appSubst.subst(res), appSubst)
         }
         val constrRef = ref.isConstructorReference && !noConstructor

--- a/src/org/jetbrains/plugins/scala/lang/psi/impl/statements/params/ScTypeParamImpl.scala
+++ b/src/org/jetbrains/plugins/scala/lang/psi/impl/statements/params/ScTypeParamImpl.scala
@@ -37,6 +37,8 @@ class ScTypeParamImpl private (stub: StubElement[ScTypeParam], nodeType: IElemen
 
   override def toString: String = "TypeParameter: " + name
 
+  override def getPsiElementId: PsiElement = this
+
   def getOffsetInFile: Int = {
     val stub = getStub
     if (stub != null) {
@@ -93,7 +95,7 @@ class ScTypeParamImpl private (stub: StubElement[ScTypeParam], nodeType: IElemen
     getText
   }
 
-  def owner  = getContext.getContext.asInstanceOf[ScTypeParametersOwner]
+  def owner: ScTypeParametersOwner = getContext.getContext.asInstanceOf[ScTypeParametersOwner]
 
   override def getUseScope  = new LocalSearchScope(owner).intersectWith(super.getUseScope)
 

--- a/src/org/jetbrains/plugins/scala/lang/psi/impl/toplevel/synthetic/ScSyntheticClass.scala
+++ b/src/org/jetbrains/plugins/scala/lang/psi/impl/toplevel/synthetic/ScSyntheticClass.scala
@@ -50,6 +50,8 @@ extends SyntheticNamedElement(manager, name) with ScTypeParam with PsiClassFake 
 
   override def getPresentation: ItemPresentation = super[ScTypeParam].getPresentation
 
+  def getPsiElementId: PsiElement = null
+
   def getOffsetInFile: Int = 0
 
   def getContainingFileName: String = "NoFile"

--- a/src/org/jetbrains/plugins/scala/lang/psi/light/scala/ScLightTypeParam.scala
+++ b/src/org/jetbrains/plugins/scala/lang/psi/light/scala/ScLightTypeParam.scala
@@ -42,6 +42,8 @@ class ScLightTypeParam(t: TypeParameter, tParam: ScTypeParam)
 
   override def getOffsetInFile: Int = tParam.getOffsetInFile
 
+  override def getPsiElementId: PsiElement = tParam.getPsiElementId
+
   override def owner: ScTypeParametersOwner = tParam.owner
 
   override def isContravariant: Boolean = tParam.isContravariant

--- a/src/org/jetbrains/plugins/scala/lang/psi/types/Conformance.scala
+++ b/src/org/jetbrains/plugins/scala/lang/psi/types/Conformance.scala
@@ -1329,8 +1329,8 @@ object Conformance {
               undefinedSubst = t._2
             }
             if (result == null) {
-              val filterFunction: (((String, String), HashSet[ScType])) => Boolean = {
-                case (id: (String, String), types: HashSet[ScType]) =>
+              val filterFunction: (((String, PsiElement), HashSet[ScType])) => Boolean = {
+                case (id: (String, PsiElement), types: HashSet[ScType]) =>
                   !tptsMap.values.exists {
                     case tpt: ScTypeParameterType => id ==(tpt.name, ScalaPsiUtil.getPsiElementId(tpt.param))
                   }
@@ -1693,7 +1693,7 @@ object Conformance {
             undefinedSubst = t._2
             i = i + 1
           }
-          val subst = new ScSubstitutor(new collection.immutable.HashMap[(String, String), ScType] ++ typeParameters1.zip(typeParameters2).map({
+          val subst = new ScSubstitutor(new collection.immutable.HashMap[(String, PsiElement), ScType] ++ typeParameters1.zip(typeParameters2).map({
             tuple => ((tuple._1.name, ScalaPsiUtil.getPsiElementId(tuple._1.ptp)),
               new ScTypeParameterType(tuple._2.name,
                 tuple._2.ptp match {

--- a/src/org/jetbrains/plugins/scala/lang/psi/types/ScExistentialType.scala
+++ b/src/org/jetbrains/plugins/scala/lang/psi/types/ScExistentialType.scala
@@ -520,7 +520,7 @@ case class ScExistentialArgument(name : String, args : List[ScTypeParameterType]
 
   def equivInner(exist: ScExistentialArgument, uSubst: ScUndefinedSubstitutor, falseUndef: Boolean): (Boolean, ScUndefinedSubstitutor) = {
     var undefinedSubst = uSubst
-    val s = (exist.args zip args).foldLeft(ScSubstitutor.empty) {(s, p) => s bindT ((p._1.name, ""), p._2)}
+    val s = (exist.args zip args).foldLeft(ScSubstitutor.empty) {(s, p) => s bindT ((p._1.name, null), p._2)}
     val t = Equivalence.equivInner(lowerBound, s.subst(exist.lowerBound), undefinedSubst, falseUndef)
     if (!t._1) return (false, undefinedSubst)
     undefinedSubst = t._2

--- a/src/org/jetbrains/plugins/scala/lang/psi/types/ScParameterizedType.scala
+++ b/src/org/jetbrains/plugins/scala/lang/psi/types/ScParameterizedType.scala
@@ -125,7 +125,7 @@ class ScParameterizedType private (val designator : ScType, val typeArgs : Seq[S
   private def substitutorInner : ScSubstitutor = {
     def forParams[T](paramsIterator: Iterator[T], initial: ScSubstitutor, map: T => ScTypeParameterType): ScSubstitutor = {
       val argsIterator = typeArgs.iterator
-      val builder = ListMap.newBuilder[(String, String), ScType]
+      val builder = ListMap.newBuilder[(String, PsiElement), ScType]
       while (paramsIterator.hasNext && argsIterator.hasNext) {
         val p1 = map(paramsIterator.next())
         val p2 = argsIterator.next()
@@ -348,14 +348,7 @@ case class ScTypeParameterType(name: String, args: List[ScTypeParameterType],
              ScalaPsiManager.instance(ptp.getProject).psiTypeParameterUpperType(ptp))})}, ptp)
   }
 
-  @volatile
-  private var id: String = null
-  def getId: String = {
-    if (id == null) {
-      id = ScalaPsiUtil.getPsiElementId(param)
-    }
-    id
-  }
+  def getId: PsiElement = ScalaPsiUtil.getPsiElementId(param)
 
   def isCovariant = {
     param match {

--- a/src/org/jetbrains/plugins/scala/lang/psi/types/ScSubstitutor.scala
+++ b/src/org/jetbrains/plugins/scala/lang/psi/types/ScSubstitutor.scala
@@ -29,7 +29,7 @@ object ScSubstitutor {
   private val followLimit = 800
 }
 
-class ScSubstitutor(val tvMap: Map[(String, String), ScType],
+class ScSubstitutor(val tvMap: Map[(String, PsiElement), ScType],
                     val aliasesMap: Map[String, Suspension[ScType]],
                     val updateThisType: Option[ScType]) {
   //use ScSubstitutor.empty instead
@@ -39,7 +39,7 @@ class ScSubstitutor(val tvMap: Map[(String, String), ScType],
     this(Map.empty, Map.empty, Some(updateThisType))
   }
 
-  def this(tvMap: Map[(String, String), ScType],
+  def this(tvMap: Map[(String, PsiElement), ScType],
                     aliasesMap: Map[String, Suspension[ScType]],
                     updateThisType: Option[ScType],
                     follower: ScSubstitutor) = {
@@ -71,7 +71,7 @@ class ScSubstitutor(val tvMap: Map[(String, String), ScType],
   override def toString: String =
     s"ScSubstitutor($tvMap, $aliasesMap, $updateThisType)${ if (follower != null) " >> " + follower.toString else "" }"
 
-  def bindT(name : (String, String), t: ScType) = {
+  def bindT(name : (String, PsiElement), t: ScType) = {
     val res = new ScSubstitutor(tvMap + ((name, t)), aliasesMap, updateThisType, follower)
     res.myDependentMethodTypesFun = myDependentMethodTypesFun
     res.myDependentMethodTypesFunDefined = myDependentMethodTypesFunDefined
@@ -181,7 +181,7 @@ class ScSubstitutor(val tvMap: Map[(String, String), ScType],
       }
 
       override def visitTypeVariable(tv: ScTypeVariable): Unit = {
-        result = tvMap.get((tv.name, "")) match {
+        result = tvMap.get((tv.name, null)) match {
           case None => tv
           case Some(v) => v
         }
@@ -440,19 +440,19 @@ class ScSubstitutor(val tvMap: Map[(String, String), ScType],
   }
 }
 
-class ScUndefinedSubstitutor(val upperMap: Map[(String, String), HashSet[ScType]] = HashMap.empty,
-                             val lowerMap: Map[(String, String), HashSet[ScType]] = HashMap.empty,
-                             val upperAdditionalMap: Map[(String, String), HashSet[ScType]] = HashMap.empty,
-                             val lowerAdditionalMap: Map[(String, String), HashSet[ScType]] = HashMap.empty) {
+class ScUndefinedSubstitutor(val upperMap: Map[(String, PsiElement), HashSet[ScType]] = HashMap.empty,
+                             val lowerMap: Map[(String, PsiElement), HashSet[ScType]] = HashMap.empty,
+                             val upperAdditionalMap: Map[(String, PsiElement), HashSet[ScType]] = HashMap.empty,
+                             val lowerAdditionalMap: Map[(String, PsiElement), HashSet[ScType]] = HashMap.empty) {
 
-  def copy(upperMap: Map[(String, String), HashSet[ScType]] = upperMap,
-           lowerMap: Map[(String, String), HashSet[ScType]] = lowerMap,
-           upperAdditionalMap: Map[(String, String), HashSet[ScType]] = upperAdditionalMap,
-           lowerAdditionalMap: Map[(String, String), HashSet[ScType]] = lowerAdditionalMap): ScUndefinedSubstitutor = {
+  def copy(upperMap: Map[(String, PsiElement), HashSet[ScType]] = upperMap,
+           lowerMap: Map[(String, PsiElement), HashSet[ScType]] = lowerMap,
+           upperAdditionalMap: Map[(String, PsiElement), HashSet[ScType]] = upperAdditionalMap,
+           lowerAdditionalMap: Map[(String, PsiElement), HashSet[ScType]] = lowerAdditionalMap): ScUndefinedSubstitutor = {
     new ScUndefinedSubstitutor(upperMap, lowerMap, upperAdditionalMap, lowerAdditionalMap)
   }
 
-  type Name = (String, String)
+  type Name = (String, PsiElement)
 
   def isEmpty: Boolean = upperMap.isEmpty && lowerMap.isEmpty && upperAdditionalMap.isEmpty && lowerAdditionalMap.isEmpty
 


### PR DESCRIPTION
Previously, substitutors relied on PsiElementId, which was calculated from
PsiElement by taking the containing filename and offset in file
However, sometimes offset would be cached in one place but not in another
which would cause errors.
Now we rely on PsiElement itself
