### PR TITLE
Fixed Scala compiler encoding setting when imported from Gradle

### DIFF
--- a/src/org/jetbrains/plugins/scala/project/gradle/ScalaGradleDataService.scala
+++ b/src/org/jetbrains/plugins/scala/project/gradle/ScalaGradleDataService.scala
@@ -88,7 +88,10 @@ private object ScalaGradleDataService {
           options.isUnchecked -> "-unchecked",
           options.isOptimize -> "-optimise",
           !isEmpty(options.getDebugLevel) -> s"-g:${options.getDebugLevel}",
-          !isEmpty(options.getEncoding) -> s"-encoding ${options.getEncoding}",
+          !isEmpty(options.getEncoding) -> s"-encoding",
+          // the encoding value needs to be a separate option, otherwise the -encoding flag and the value will be
+          // treated as a single flag
+          !isEmpty(options.getEncoding) -> options.getEncoding,
           !isEmpty(data.getTargetCompatibility) -> s"-target:jvm-${data.getTargetCompatibility}")
 
         val additionalOptions =

--- a/test/org/jetbrains/plugins/scala/project/gradle/ScalaGradleDataServiceTest.scala
+++ b/test/org/jetbrains/plugins/scala/project/gradle/ScalaGradleDataServiceTest.scala
@@ -128,7 +128,7 @@ class ScalaGradleDataServiceTest extends ProjectDataServiceTestCase with UsefulT
 
     assert(compilerConfiguration.debuggingInfoLevel == DebuggingInfoLevel.Source)
     assert(compilerConfiguration.plugins == Seq("test-plugin.jar"))
-    assert(compilerConfiguration.additionalCompilerOptions.toSet == Set("-encoding utf-8", "-target:jvm-1.5"))
+    assert(compilerConfiguration.additionalCompilerOptions == Seq("-encoding", "utf-8", "-target:jvm-1.5"))
     assert(compilerConfiguration.experimental)
     assert(compilerConfiguration.continuations)
     assert(compilerConfiguration.deprecationWarnings)


### PR DESCRIPTION
This commit fixes #SCL-9597 (Importing/opening a Gradle Scala project
incorrectly configures the Scala compiler encoding setting).

The fix is to add the "-encoding" and the user-provided encoding value
as separate compiler options in the ScalaGradleDataService. Otherwise,
the encoding setting will ultimately be passed to the compiler as a
qouted combined string (e.g., literally, "-encoding utf-8"). With the
fix in place, the values are correctly passed and parsed by scalac
(e.g., literally "-encoding" "utf-8").
