### PR TITLE
fix loosing comments when removing brackets

### DIFF
--- a/src/org/jetbrains/plugins/scala/codeInsight/intention/IntentionUtil.scala
+++ b/src/org/jetbrains/plugins/scala/codeInsight/intention/IntentionUtil.scala
@@ -1,0 +1,50 @@
+package org.jetbrains.plugins.scala.codeInsight.intention
+
+import com.intellij.openapi.util.text.StringUtil
+import com.intellij.psi.impl.source.codeStyle.CodeEditUtil
+import com.intellij.psi.util.PsiTreeUtil
+import com.intellij.psi.{PsiComment, PsiElement, PsiWhiteSpace}
+import org.jetbrains.plugins.scala.extensions.PsiElementExt
+
+object IntentionUtil {
+  def collectComments(element: PsiElement, onElementLine: Boolean = false): CommentsAroundElement = {
+    def hasLineBreaks(whiteSpace: PsiElement): Boolean = {
+      if (!onElementLine) false
+      else StringUtil.containsLineBreak(whiteSpace.getText)
+    }
+
+    def getElements(it: Iterator[PsiElement]) = {
+      def acceptableElem(elem: PsiElement) = {
+        (elem.isInstanceOf[PsiComment] || elem.isInstanceOf[PsiWhiteSpace]) && !hasLineBreaks(elem)
+      }
+
+      it.takeWhile { a => acceptableElem(a) }.filter(a => a.isInstanceOf[PsiComment]).toSeq
+    }
+
+    CommentsAroundElement(getElements(element.prevSiblings).reverse, getElements(element.nextSiblings).reverse)
+  }
+
+
+  def hasOtherComments(element: PsiElement, commentsAroundElement: CommentsAroundElement): Boolean = {
+    val allComments = PsiTreeUtil.getChildrenOfTypeAsList(element, classOf[PsiComment])
+    allComments.size() > commentsAroundElement.before.size + commentsAroundElement.after.size
+  }
+
+  def addComments(commentsAroundElement: CommentsAroundElement, parent: PsiElement, anchor: PsiElement): Unit = {
+    if ((parent == null) || (anchor == null)) return
+
+    val before = commentsAroundElement.before
+    val after = commentsAroundElement.after
+
+    before.foreach(c => CodeEditUtil.setNodeGenerated(c.getNode, true))
+    after.foreach(c => CodeEditUtil.setNodeGenerated(c.getNode, true))
+
+    after.foreach(c =>
+      if (anchor.getNextSibling != null) parent.getNode.addChild(c.getNode, anchor.getNextSibling.getNode)
+      else parent.getNode.addChild(c.getNode)
+    )
+    before.foreach(c => parent.getNode.addChild(c.getNode, anchor.getNode))
+  }
+
+  case class CommentsAroundElement(before: Seq[PsiElement], after: Seq[PsiElement])
+}

--- a/src/org/jetbrains/plugins/scala/codeInspection/parentheses/ScalaUnnecessaryParenthesesInspectionBase.scala
+++ b/src/org/jetbrains/plugins/scala/codeInspection/parentheses/ScalaUnnecessaryParenthesesInspectionBase.scala
@@ -7,6 +7,7 @@ import com.intellij.codeInspection.ui.SingleCheckboxOptionsPanel
 import com.intellij.codeInspection.{ProblemHighlightType, ProblemsHolder}
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
+import org.jetbrains.plugins.scala.codeInsight.intention.IntentionUtil
 import org.jetbrains.plugins.scala.codeInspection.{AbstractFixOnPsiElement, AbstractInspection, InspectionBundle}
 import org.jetbrains.plugins.scala.lang.psi.ScalaPsiUtil
 import org.jetbrains.plugins.scala.lang.psi.api.expr._
@@ -47,6 +48,10 @@ class UnnecessaryParenthesesQuickFix(parenthesized: ScParenthesisedExpr, textOfS
 
     val newExpr = ScalaPsiElementFactory.createExpressionFromText(textOfStripped, parenthExpr.getManager)
     val replaced = parenthExpr.replaceExpression(newExpr, removeParenthesis = true)
+
+    val comments = Option(parenthExpr.expr.get).map(expr => IntentionUtil.collectComments(expr))
+    comments.foreach(value => IntentionUtil.addComments(value, replaced.getParent, replaced))
+
     ScalaPsiUtil.padWithWhitespaces(replaced)
   }
 }

--- a/test/org/jetbrains/plugins/scala/codeInspection/parentheses/UnnecessaryParenthesesInspectionTest.scala
+++ b/test/org/jetbrains/plugins/scala/codeInspection/parentheses/UnnecessaryParenthesesInspectionTest.scala
@@ -119,4 +119,23 @@ class UnnecessaryParenthesesInspectionTest extends ScalaLightInspectionFixtureTe
     checkTextHasNoErrors(text)
   }
 
+  def test_10(): Unit = {
+    val selected = START + "(/*b*/ 1 + /*a*/ 1 /*comment*/)" + END
+    check(selected)
+
+    val text = "(<caret>/*b*/ 1 + /*a*/ 1 /*comment*/)"
+    val result = "/*b*/ 1 + /*a*/ 1 /*comment*/"
+    val hint = hintBeginning + " (1 + 1)"
+    testFix(text, result, hint)
+  }
+
+  def test_11(): Unit = {
+    val selected = START + "(/*1*/ 6 /*2*/ /*3*/)" + END
+    check(selected)
+
+    val text = "(<caret>/*1*/ 6 /*2*/ /*3*/)"
+    val result = "/*1*/ 6 /*2*/\n\r/*3*/"
+    val hint = hintBeginning + " (6)"
+    testFix(text, result, hint)
+  }
 }


### PR DESCRIPTION
removing brackets may lead to loosing comments in RemoveBracesIntention (removing curly brackets now available when there is one statement and comments on current line) or in ScalaUnnecessaryParenthesesInspectionBase (removing parenthesis available as previous, but without loosing comments)
