### PR TITLE
[Conformance]If LHS is AnyVal, right side conforms if it's a Value Class

### DIFF
--- a/src/org/jetbrains/plugins/scala/lang/psi/types/Conformance.scala
+++ b/src/org/jetbrains/plugins/scala/lang/psi/types/Conformance.scala
@@ -521,7 +521,7 @@ object Conformance {
       }
 
       if (x eq types.AnyVal) {
-        result = (r.isInstanceOf[ValType], undefinedSubst)
+        result = (r.isInstanceOf[ValType] || ValueClassType.isValueType(r), undefinedSubst)
         return
       }
       if (l.isInstanceOf[ValType] && r.isInstanceOf[ValType]) {

--- a/src/org/jetbrains/plugins/scala/lang/psi/types/ValueClassType.scala
+++ b/src/org/jetbrains/plugins/scala/lang/psi/types/ValueClassType.scala
@@ -25,6 +25,8 @@ object ValueClassType {
     }
   }
 
+  def isValueType(tp: ScType): Boolean = unapply(tp).isDefined
+
   def isValueClass(cl: PsiClass) = cl match {
     case scClass: ScClass => scClass.supers.map(_.qualifiedName).contains("scala.AnyVal")
     case _ => false

--- a/test/org/jetbrains/plugins/scala/lang/typeConformance/generated/TypeConformanceBugTest.scala
+++ b/test/org/jetbrains/plugins/scala/lang/typeConformance/generated/TypeConformanceBugTest.scala
@@ -19,4 +19,6 @@ class TypeConformanceBugTest extends TypeConformanceTestBase {
   def testSCL3825() {doTest()}
 
   def testSCL4278() {doTest()}
+
+  def testSCL9627() {doTest()}
 }

--- a/testdata/typeConformance/bug/SCL9627.scala
+++ b/testdata/typeConformance/bug/SCL9627.scala
@@ -1,0 +1,4 @@
+class Value(val v: Int) extends AnyVal
+
+val v3: Option[AnyVal] = Some(new Value(1)) // IntelliJ marks this as error
+//True


### PR DESCRIPTION
or StdType #SCL-9627 Fixed
