### PR TITLE
ScalaPsiUtil cleanup: move some functions to InferUtil

### DIFF
--- a/src/org/jetbrains/plugins/scala/lang/psi/ScalaPsiUtil.scala
+++ b/src/org/jetbrains/plugins/scala/lang/psi/ScalaPsiUtil.scala
@@ -2,6 +2,8 @@ package org.jetbrains.plugins.scala
 package lang
 package psi
 
+import java.util.concurrent.ConcurrentMap
+
 import com.intellij.codeInsight.PsiEquivalenceUtil
 import com.intellij.lang.java.JavaLanguage
 import com.intellij.openapi.diagnostic.Logger
@@ -19,7 +21,7 @@ import com.intellij.psi.search.{GlobalSearchScope, LocalSearchScope, SearchScope
 import com.intellij.psi.stubs.StubElement
 import com.intellij.psi.tree.TokenSet
 import com.intellij.psi.util._
-import com.intellij.util.containers.ConcurrentWeakHashMap
+import com.intellij.util.containers.ContainerUtil
 import org.jetbrains.plugins.scala.caches.CachesUtil
 import org.jetbrains.plugins.scala.editor.typedHandler.ScalaTypedHandler
 import org.jetbrains.plugins.scala.extensions._
@@ -64,7 +66,6 @@ import scala.annotation.tailrec
 import scala.collection.mutable.ArrayBuffer
 import scala.collection.{Seq, Set, mutable}
 import scala.reflect.NameTransformer
-import scala.util.control.ControlThrowable
 
 /**
  * User: Alexander Podkhalyuzin
@@ -132,8 +133,8 @@ object ScalaPsiUtil {
                 contains(annot.typeElement.getText.replace(" ", ""))
       }
     } else {
-      s.hasAnnotation("scala.reflect.BooleanBeanProperty") != None ||
-        s.hasAnnotation("scala.beans.BooleanBeanProperty") != None
+      s.hasAnnotation("scala.reflect.BooleanBeanProperty").isDefined ||
+        s.hasAnnotation("scala.beans.BooleanBeanProperty").isDefined
     }
   }
 
@@ -145,8 +146,8 @@ object ScalaPsiUtil {
                 contains(annot.typeElement.getText.replace(" ", ""))
       }
     } else {
-      s.hasAnnotation("scala.reflect.BeanProperty") != None ||
-        s.hasAnnotation("scala.beans.BeanProperty") != None
+      s.hasAnnotation("scala.reflect.BeanProperty").isDefined ||
+        s.hasAnnotation("scala.beans.BeanProperty").isDefined
     }
   }
 
@@ -207,7 +208,6 @@ object ScalaPsiUtil {
     s match {
       case Seq() =>
         // object A { def foo(a: Any) = ()}; A foo () ==>> A.foo(()), or A.foo() ==>> A.foo( () )
-        val unitExpr = ScalaPsiElementFactory.createExpressionFromText("()", manager)
         Some(Seq(new Expression(types.Unit, place)))
       case _ =>
         val exprTypes: Seq[ScType] =
@@ -252,7 +252,7 @@ object ScalaPsiUtil {
   }
 
   /**
-  Pick all type parameters by method maps them to the appropriate type arguments, if they are
+  *Pick all type parameters by method maps them to the appropriate type arguments, if they are
    */
   def inferMethodTypesArgs(fun: PsiMethod, classSubst: ScSubstitutor): ScSubstitutor = {
 
@@ -350,7 +350,7 @@ object ScalaPsiUtil {
       } else if (implicitMap.isEmpty) checkImplicits(secondPart = false, noApplicability = true)
     }
     if (implicitMap.isEmpty) None
-    else if (implicitMap.length == 1) Some(implicitMap.apply(0))
+    else if (implicitMap.length == 1) Some(implicitMap.head)
     else MostSpecificUtil(ref, 1).mostSpecificForImplicit(implicitMap.toSet)
   }
 
@@ -359,6 +359,7 @@ object ScalaPsiUtil {
     Option[ImplicitResolveResult] = {
     val oldAlg = ScalaProjectSettings.getInstance(e.getProject).isUseOldImplicitConversionAlg
     if (oldAlg) {
+      //noinspection ScalaDeprecation
       return oldFindImplicitConversion(e, refName, ref, processor, noImplicitsForArgs)
     }
     lazy val funType = Option(
@@ -467,10 +468,10 @@ object ScalaPsiUtil {
       } else if (implicitMap.isEmpty) checkImplicits(secondPart = false, noApplicability = true)
     }
     if (implicitMap.length == 1) {
-      val rr = implicitMap.apply(0)
+      val rr = implicitMap.head
       specialExtractParameterType(rr) match {
         case Some(ScFunctionType(tp, _)) =>
-          Some(ImplicitResolveResult(tp, rr.getElement, rr.importsUsed, rr.substitutor, ScSubstitutor.empty, false)) //todo: from companion parameter
+          Some(ImplicitResolveResult(tp, rr.getElement, rr.importsUsed, rr.substitutor, ScSubstitutor.empty, isFromCompanion = false)) //todo: from companion parameter
         case _ => None
       }
     } else None
@@ -644,11 +645,11 @@ object ScalaPsiUtil {
   @tailrec
   def isAnonymousExpression(expr: ScExpression): (Int, ScExpression) = {
     val seq = ScUnderScoreSectionUtil.underscores(expr)
-    if (seq.length > 0) return (seq.length, expr)
+    if (seq.nonEmpty) return (seq.length, expr)
     expr match {
       case b: ScBlockExpr =>
         if (b.statements.length != 1) (-1, expr)
-        else if (b.lastExpr == None) (-1, expr)
+        else if (b.lastExpr.isEmpty) (-1, expr)
         else isAnonymousExpression(b.lastExpr.get)
       case p: ScParenthesisedExpr => p.expr match {case Some(x) => isAnonymousExpression(x) case _ => (-1, expr)}
       case f: ScFunctionExpr =>  (f.parameters.length, expr)
@@ -663,8 +664,8 @@ object ScalaPsiUtil {
     index.getModuleForFile(element.getContainingFile.getVirtualFile)
   }
 
-  val collectImplicitObjectsCache: ConcurrentWeakHashMap[(ScType, Project, GlobalSearchScope), Seq[ScType]] =
-    new ConcurrentWeakHashMap()
+  val collectImplicitObjectsCache: ConcurrentMap[(ScType, Project, GlobalSearchScope), Seq[ScType]] =
+    ContainerUtil.newConcurrentMap[(ScType, Project, GlobalSearchScope), Seq[ScType]]()
 
   def collectImplicitObjects(_tp: ScType, project: Project, scope: GlobalSearchScope): Seq[ScType] = {
     val tp = ScType.removeAliasDefinitions(_tp)
@@ -756,20 +757,6 @@ object ScalaPsiUtil {
       }
     }
 
-    case class MyType()
-    object MyImplicitTypeHelper {
-      class MyImplicitType{}
-
-      implicit def typeToImplicitType(in: MyType): MyImplicitType = ???
-    }
-    import MyImplicitTypeHelper._
-
-    def myFunc: MyImplicitType = {
-      val myType: MyType = MyType()
-      myType
-    }
-
-
     collectParts(tp)
     val res: mutable.HashMap[String, Seq[ScType]] = new mutable.HashMap
     def addResult(fqn: String, tp: ScType): Unit = {
@@ -786,6 +773,7 @@ object ScalaPsiUtil {
       val part = parts.dequeue()
       //here we want to convert projection types to right projections
       val visited = new mutable.HashSet[PsiClass]()
+      @tailrec
       def collectObjects(tp: ScType) {
         tp match {
           case types.Any =>
@@ -920,207 +908,6 @@ object ScalaPsiUtil {
 
   def getSettings(project: Project): ScalaCodeStyleSettings = {
     CodeStyleSettingsManager.getSettings(project).getCustomSettings(classOf[ScalaCodeStyleSettings])
-  }
-
-  def undefineSubstitutor(typeParams: Seq[TypeParameter]): ScSubstitutor = {
-    typeParams.foldLeft(ScSubstitutor.empty) {
-      (subst: ScSubstitutor, tp: TypeParameter) =>
-        subst.bindT((tp.name, ScalaPsiUtil.getPsiElementId(tp.ptp)),
-          new ScUndefinedType(new ScTypeParameterType(tp.ptp, ScSubstitutor.empty)))
-    }
-  }
-
-  def localTypeInference(retType: ScType, params: Seq[Parameter], exprs: Seq[Expression],
-                         typeParams: Seq[TypeParameter],
-                         shouldUndefineParameters: Boolean = true,
-                         safeCheck: Boolean = false,
-                         filterTypeParams: Boolean = true): ScTypePolymorphicType = {
-    localTypeInferenceWithApplicability(retType, params, exprs, typeParams, shouldUndefineParameters, safeCheck,
-      filterTypeParams)._1
-  }
-
-
-  class SafeCheckException extends ControlThrowable
-
-  //todo: move to InferUtil
-  def localTypeInferenceWithApplicability(retType: ScType, params: Seq[Parameter], exprs: Seq[Expression],
-                                          typeParams: Seq[TypeParameter],
-                                          shouldUndefineParameters: Boolean = true,
-                                          safeCheck: Boolean = false,
-                                          filterTypeParams: Boolean = true): (ScTypePolymorphicType, Seq[ApplicabilityProblem]) = {
-    val (tp, problems, _, _) = localTypeInferenceWithApplicabilityExt(retType, params, exprs, typeParams,
-      shouldUndefineParameters, safeCheck, filterTypeParams)
-    (tp, problems)
-  }
-
-  def localTypeInferenceWithApplicabilityExt(retType: ScType, params: Seq[Parameter], exprs: Seq[Expression],
-                                             typeParams: Seq[TypeParameter],
-                                             shouldUndefineParameters: Boolean = true,
-                                             safeCheck: Boolean = false,
-                                             filterTypeParams: Boolean = true
-    ): (ScTypePolymorphicType, Seq[ApplicabilityProblem], Seq[(Parameter, ScExpression)], Seq[(Parameter, ScType)]) = {
-    // See SCL-3052, SCL-3058
-    // This corresponds to use of `isCompatible` in `Infer#methTypeArgs` in scalac, where `isCompatible` uses `weak_<:<`
-    val s: ScSubstitutor = if (shouldUndefineParameters) undefineSubstitutor(typeParams) else ScSubstitutor.empty
-    val abstractSubst = ScTypePolymorphicType(retType, typeParams).abstractTypeSubstitutor
-    val paramsWithUndefTypes = params.map(p => p.copy(paramType = s.subst(p.paramType),
-      expectedType = abstractSubst.subst(p.paramType)))
-    val c = Compatibility.checkConformanceExt(checkNames = true, paramsWithUndefTypes, exprs, checkWithImplicits = true,
-      isShapesResolve = false)
-    val tpe = if (c.problems.isEmpty) {
-      var un: ScUndefinedSubstitutor = c.undefSubst
-      val subst = c.undefSubst
-      subst.getSubstitutor(!safeCheck) match {
-        case Some(unSubst) =>
-          if (!filterTypeParams) {
-            val undefiningSubstitutor = new ScSubstitutor(typeParams.map(typeParam => {
-              ((typeParam.name, ScalaPsiUtil.getPsiElementId(typeParam.ptp)), new ScUndefinedType(new ScTypeParameterType(typeParam.ptp, ScSubstitutor.empty)))
-            }).toMap, Map.empty, None)
-            ScTypePolymorphicType(retType, typeParams.map(tp => {
-              var lower = tp.lowerType()
-              var upper = tp.upperType()
-              def hasRecursiveTypeParameters(typez: ScType): Boolean = {
-                var hasRecursiveTypeParameters = false
-                typez.recursiveUpdate {
-                  case tpt: ScTypeParameterType =>
-                    typeParams.find(tp => (tp.name, ScalaPsiUtil.getPsiElementId(tp.ptp)) ==(tpt.name, tpt.getId)) match {
-                      case None => (true, tpt)
-                      case _ =>
-                        hasRecursiveTypeParameters = true
-                        (true, tpt)
-                    }
-                  case tp: ScType => (hasRecursiveTypeParameters, tp)
-                }
-                hasRecursiveTypeParameters
-              }
-              subst.lMap.get((tp.name, ScalaPsiUtil.getPsiElementId(tp.ptp))) match {
-                case Some(_addLower) =>
-                  val substedLowerType = unSubst.subst(lower)
-                  val addLower =
-                    if (tp.typeParams.nonEmpty && !_addLower.isInstanceOf[ScParameterizedType] &&
-                      !tp.typeParams.exists(_.name == "_"))
-                      ScParameterizedType(_addLower, tp.typeParams.map(ScTypeParameterType.toTypeParameterType))
-                    else _addLower
-                  if (hasRecursiveTypeParameters(substedLowerType)) lower = addLower
-                  else lower = Bounds.lub(substedLowerType, addLower)
-                case None =>
-                  lower = unSubst.subst(lower)
-              }
-              subst.rMap.get((tp.name, ScalaPsiUtil.getPsiElementId(tp.ptp))) match {
-                case Some(_addUpper) =>
-                  val substedUpperType = unSubst.subst(upper)
-                  val addUpper =
-                    if (tp.typeParams.nonEmpty && !_addUpper.isInstanceOf[ScParameterizedType] &&
-                      !tp.typeParams.exists(_.name == "_"))
-                      ScParameterizedType(_addUpper, tp.typeParams.map(ScTypeParameterType.toTypeParameterType))
-                    else _addUpper
-                  if (hasRecursiveTypeParameters(substedUpperType)) upper = addUpper
-                  else upper = Bounds.glb(substedUpperType, addUpper)
-                case None =>
-                  upper = unSubst.subst(upper)
-              }
-
-              if (safeCheck && !undefiningSubstitutor.subst(lower).conforms(undefiningSubstitutor.subst(upper), checkWeak = true))
-                throw new SafeCheckException
-              TypeParameter(tp.name, tp.typeParams /* doesn't important here */, () => lower, () => upper, tp.ptp)
-            }))
-          } else {
-            typeParams.foreach {case tp =>
-              val name = (tp.name, ScalaPsiUtil.getPsiElementId(tp.ptp))
-              if (un.names.contains(name)) {
-                def hasRecursiveTypeParameters(typez: ScType): Boolean = {
-                  var hasRecursiveTypeParameters = false
-                  typez.recursiveUpdate {
-                    case tpt: ScTypeParameterType =>
-                      typeParams.find(tp => (tp.name, ScalaPsiUtil.getPsiElementId(tp.ptp)) ==(tpt.name, tpt.getId)) match {
-                        case None => (true, tpt)
-                        case _ =>
-                          hasRecursiveTypeParameters = true
-                          (true, tpt)
-                      }
-                    case tp: ScType => (hasRecursiveTypeParameters, tp)
-                  }
-                  hasRecursiveTypeParameters
-                }
-                //todo: add only one of them according to variance
-                if (tp.lowerType() != Nothing) {
-                  val substedLowerType = unSubst.subst(tp.lowerType())
-                  if (!hasRecursiveTypeParameters(substedLowerType)) {
-                    un = un.addLower(name, substedLowerType, additional = true)
-                  }
-                }
-                if (tp.upperType() != Any) {
-                  val substedUpperType = unSubst.subst(tp.upperType())
-                  if (!hasRecursiveTypeParameters(substedUpperType)) {
-                    un = un.addUpper(name, substedUpperType, additional = true)
-                  }
-                }
-              }
-            }
-
-            def updateWithSubst(sub: ScSubstitutor): ScTypePolymorphicType = {
-              ScTypePolymorphicType(sub.subst(retType), typeParams.filter {
-                case tp =>
-                  val name = (tp.name, ScalaPsiUtil.getPsiElementId(tp.ptp))
-                  val removeMe: Boolean = un.names.contains(name)
-                  if (removeMe && safeCheck) {
-                    //let's check type parameter kinds
-                    def checkTypeParam(typeParam: ScTypeParam, tp: => ScType): Boolean = {
-                      val typeParams: Seq[ScTypeParam] = typeParam.typeParameters
-                      if (typeParams.isEmpty) return true
-                      tp match {
-                        case ScParameterizedType(_, typeArgs) =>
-                          if (typeArgs.length != typeParams.length) return false
-                          typeArgs.zip(typeParams).forall {
-                            case (tp: ScType, typeParam: ScTypeParam) => checkTypeParam(typeParam, tp)
-                          }
-                        case _ =>
-                          def checkNamed(named: PsiNamedElement, typeParams: Seq[ScTypeParam]): Boolean = {
-                            named match {
-                              case t: ScTypeParametersOwner =>
-                                if (typeParams.length != t.typeParameters.length) return false
-                                typeParams.zip(t.typeParameters).forall {
-                                  case (p1: ScTypeParam, p2: ScTypeParam) =>
-                                    if (p1.typeParameters.nonEmpty) checkNamed(p2, p1.typeParameters)
-                                    else true
-                                }
-                              case p: PsiTypeParameterListOwner =>
-                                if (typeParams.length != p.getTypeParameters.length) return false
-                                typeParams.forall(_.typeParameters.isEmpty)
-                              case _ => false
-                            }
-                          }
-                          ScType.extractDesignated(tp, withoutAliases = false) match {
-                            case Some((named, _)) => checkNamed(named, typeParams)
-                            case _ => tp match {
-                              case tpt: ScTypeParameterType => checkNamed(tpt.param, typeParams)
-                              case _ => false
-                            }
-                          }
-                      }
-                    }
-                    tp.ptp match {
-                      case typeParam: ScTypeParam =>
-                        if (!checkTypeParam(typeParam, sub.subst(new ScTypeParameterType(tp.ptp, ScSubstitutor.empty))))
-                          throw new SafeCheckException
-                      case _ =>
-                    }
-                  }
-                  !removeMe
-              }.map(tp => TypeParameter(tp.name, tp.typeParams /* doesn't important here */,
-                () => sub.subst(tp.lowerType()), () => sub.subst(tp.upperType()), tp.ptp)))
-            }
-
-            un.getSubstitutor match {
-              case Some(unSubstitutor) => updateWithSubst(unSubstitutor)
-              case _ if safeCheck => throw new SafeCheckException
-              case _ => updateWithSubst(unSubst)
-            }
-          }
-        case None => throw new SafeCheckException
-      }
-    } else ScTypePolymorphicType(retType, typeParams)
-    (tpe, c.problems, c.matchedArgs, c.matchedTypes)
   }
 
   def getElementsRange(start: PsiElement, end: PsiElement): Seq[PsiElement] = {
@@ -1263,7 +1050,7 @@ object ScalaPsiUtil {
 
   def typesCallSubstitutor(tp: Seq[(String, PsiElement)], typeArgs: Seq[ScType]): ScSubstitutor = {
     val map = new collection.mutable.HashMap[(String, PsiElement), ScType]
-    for (i <- 0 to math.min(tp.length, typeArgs.length) - 1) {
+    for (i <- 0 until math.min(tp.length, typeArgs.length)) {
       map += ((tp(i), typeArgs(i)))
     }
     new ScSubstitutor(Map(map.toSeq: _*), Map.empty, None)
@@ -1271,7 +1058,7 @@ object ScalaPsiUtil {
 
   def genericCallSubstitutor(tp: Seq[(String, PsiElement)], typeArgs: Seq[ScTypeElement]): ScSubstitutor = {
     val map = new collection.mutable.HashMap[(String, PsiElement), ScType]
-    for (i <- 0 to Math.min(tp.length, typeArgs.length) - 1) {
+    for (i <- 0 until Math.min(tp.length, typeArgs.length)) {
       map += ((tp(tp.length - 1 - i), typeArgs(typeArgs.length - 1 - i).getType(TypingContext.empty).getOrAny))
     }
     new ScSubstitutor(Map(map.toSeq: _*), Map.empty, None)
@@ -1520,8 +1307,8 @@ object ScalaPsiUtil {
             map { case (_, n) => n.info.asInstanceOf[PhysicalSignature] }
 
   def getMethodsForName(clazz: PsiClass, name: String): Seq[PhysicalSignature] = {
-    (for ((n: PhysicalSignature, _) <- TypeDefinitionMembers.getSignatures(clazz).forName(name)._1
-          if clazz.isInstanceOf[ScObject] || !n.method.hasModifierProperty("static")) yield n).toSeq
+    for ((n: PhysicalSignature, _) <- TypeDefinitionMembers.getSignatures(clazz).forName(name)._1
+         if clazz.isInstanceOf[ScObject] || !n.method.hasModifierProperty("static")) yield n
   }
 
   def getApplyMethods(clazz: PsiClass): Seq[PhysicalSignature] = {
@@ -1888,9 +1675,9 @@ object ScalaPsiUtil {
   def nthConstructorParam(cls: ScClass, n: Int): Option[ScParameter] = cls.constructor match {
     case Some(x: ScPrimaryConstructor) =>
       val clauses = x.parameterList.clauses
-      if (clauses.length == 0) None
+      if (clauses.isEmpty) None
       else {
-        val params = clauses(0).parameters
+        val params = clauses.head.parameters
         if (params.length > n)
           Some(params(n))
         else
@@ -1903,6 +1690,7 @@ object ScalaPsiUtil {
    * @return Some(parameter) if the expression is an argument expression that can be resolved to a corresponding
    *         parameter; None otherwise.
    */
+  @tailrec
   def parameterOf(exp: ScExpression): Option[Parameter] = {
     def forArgumentList(expr: ScExpression, args: ScArgumentExprList): Option[Parameter] = {
       args.getParent match {
@@ -2195,7 +1983,7 @@ object ScalaPsiUtil {
 
   def isViableForAssignmentFunction(fun: ScFunction): Boolean = {
     val clauses = fun.paramClauses.clauses
-    clauses.length == 0 || (clauses.length == 1 && clauses(0).isImplicit)
+    clauses.isEmpty || (clauses.length == 1 && clauses.head.isImplicit)
   }
 
   def padWithWhitespaces(element: PsiElement) {
@@ -2229,7 +2017,7 @@ object ScalaPsiUtil {
       case td: ScPatternDefinition => (td.bindings, td.expr)
       case _ => (Seq.empty[ScBindingPattern], None)
     }
-    if (bindings.size == 1 && expr.contains(instance)) Option(bindings(0))
+    if (bindings.size == 1 && expr.contains(instance)) Option(bindings.head)
     else {
       for (bind <- bindings) {
         if (bind.getType(TypingContext.empty).toOption == instance.getType(TypingContext.empty).toOption) return Option(bind)
@@ -2326,6 +2114,7 @@ object ScalaPsiUtil {
    * Should we check if it's a Single Abstract Method?
    * In 2.11 works with -Xexperimental
    * In 2.12 works by default
+ *
    * @return true if language level and flags are correct
    */
   def isSAMEnabled(e: PsiElement) = e.scalaLanguageLevel match {
@@ -2341,6 +2130,7 @@ object ScalaPsiUtil {
 
   /**
    * Determines if expected can be created with a Single Abstract Method and if so return the required ScType for it
+ *
    * @see SCL-6140
    * @see https://github.com/scala/scala/pull/3018/
    */

--- a/src/org/jetbrains/plugins/scala/lang/psi/api/InferUtil.scala
+++ b/src/org/jetbrains/plugins/scala/lang/psi/api/InferUtil.scala
@@ -2,35 +2,36 @@ package org.jetbrains.plugins.scala
 package lang.psi.api
 
 import com.intellij.openapi.diagnostic.Logger
-import com.intellij.psi.PsiElement
+import com.intellij.psi.{PsiElement, PsiNamedElement, PsiTypeParameterListOwner}
 import org.jetbrains.plugins.scala.caches.ScalaRecursionManager
 import org.jetbrains.plugins.scala.extensions._
-import org.jetbrains.plugins.scala.lang.psi.ScalaPsiUtil.SafeCheckException
 import org.jetbrains.plugins.scala.lang.psi.api.base.patterns.ScBindingPattern
 import org.jetbrains.plugins.scala.lang.psi.api.base.{ScFieldId, ScLiteral}
 import org.jetbrains.plugins.scala.lang.psi.api.expr.ScExpression
 import org.jetbrains.plugins.scala.lang.psi.api.macros.{MacroContext, ScalaMacroEvaluator}
 import org.jetbrains.plugins.scala.lang.psi.api.statements.ScFunction
-import org.jetbrains.plugins.scala.lang.psi.api.statements.params.ScParameter
-import org.jetbrains.plugins.scala.lang.psi.api.toplevel.ScNamedElement
+import org.jetbrains.plugins.scala.lang.psi.api.statements.params.{ScParameter, ScTypeParam}
 import org.jetbrains.plugins.scala.lang.psi.api.toplevel.typedef.ScObject
+import org.jetbrains.plugins.scala.lang.psi.api.toplevel.{ScNamedElement, ScTypeParametersOwner}
 import org.jetbrains.plugins.scala.lang.psi.impl.ScalaPsiElementFactory
 import org.jetbrains.plugins.scala.lang.psi.implicits.ImplicitCollector
 import org.jetbrains.plugins.scala.lang.psi.implicits.ImplicitCollector.ImplicitState
 import org.jetbrains.plugins.scala.lang.psi.types.Compatibility.Expression
 import org.jetbrains.plugins.scala.lang.psi.types._
-import org.jetbrains.plugins.scala.lang.psi.types.nonvalue.{Parameter, ScMethodType, ScTypePolymorphicType}
+import org.jetbrains.plugins.scala.lang.psi.types.nonvalue.{Parameter, ScMethodType, ScTypePolymorphicType, TypeParameter}
 import org.jetbrains.plugins.scala.lang.psi.types.result.{Success, TypeResult, TypingContext}
 import org.jetbrains.plugins.scala.lang.psi.{ScalaPsiUtil, types}
 import org.jetbrains.plugins.scala.lang.resolve.ScalaResolveResult
 import org.jetbrains.plugins.scala.project.ScalaLanguageLevel.Scala_2_10
 import org.jetbrains.plugins.scala.project._
 
+import scala.collection.Seq
 import scala.collection.mutable.ArrayBuffer
+import scala.util.control.ControlThrowable
 
 /**
- * @author Alexander Podkhalyuzin
- */
+  * @author Alexander Podkhalyuzin
+  */
 
 object InferUtil {
   val notFoundParameterName = "NotFoundParameter239239239"
@@ -38,22 +39,25 @@ object InferUtil {
     "scala.reflect.ClassTag", "scala.reflect.api.TypeTags.TypeTag",
     "scala.reflect.api.TypeTags.WeakTypeTag")
   private val LOG = Logger.getInstance("#org.jetbrains.plugins.scala.lang.psi.api.InferUtil$")
+
   private def isDebugImplicitParameters = LOG.isDebugEnabled
+
   def logInfo(searchLevel: Int, message: => String) {
     val indent = Seq.fill(searchLevel)("  ").mkString
-//    println(indent + message)
+    //    println(indent + message)
     if (isDebugImplicitParameters) {
       LOG.debug(indent + message)
     }
   }
 
   /**
-   * This method can find implicit parameters for given MethodType
-   * @param res MethodType or PolymorphicType(MethodType)
-   * @param element place to find implicit parameters
-   * @param check if true can throw SafeCheckException if it not found not ambiguous implicit parameters
-   * @return updated type and sequence of implicit parameters
-   */
+    * This method can find implicit parameters for given MethodType
+    *
+    * @param res     MethodType or PolymorphicType(MethodType)
+    * @param element place to find implicit parameters
+    * @param check   if true can throw SafeCheckException if it not found not ambiguous implicit parameters
+    * @return updated type and sequence of implicit parameters
+    */
   def updateTypeWithImplicitParameters(res: ScType, element: PsiElement, coreElement: Option[ScNamedElement], check: Boolean,
                                        searchImplicitsRecursively: Int = 0, fullInfo: Boolean): (ScType, Option[Seq[ScalaResolveResult]]) = {
     var resInner = res
@@ -61,7 +65,7 @@ object InferUtil {
     res match {
       case t@ScTypePolymorphicType(mt@ScMethodType(retType, params, impl), typeParams) if !impl =>
         // See SCL-3516
-        val (updatedType, ps) = 
+        val (updatedType, ps) =
           updateTypeWithImplicitParameters(t.copy(internalType = retType), element, coreElement, check, fullInfo = fullInfo)
         implicitParameters = ps
         updatedType match {
@@ -89,7 +93,7 @@ object InferUtil {
                 val abstractSubstitutor: ScSubstitutor = t.abstractTypeSubstitutor
                 val (paramsForInfer, exprs, resolveResults) =
                   findImplicits(paramsSingle, coreElement, element, check, searchImplicitsRecursively, abstractSubstitutor, polymorphicSubst)
-                resInner = ScalaPsiUtil.localTypeInference(retTypeSingle, paramsForInfer, exprs, typeParamsSingle,
+                resInner = localTypeInference(retTypeSingle, paramsForInfer, exprs, typeParamsSingle,
                   safeCheck = check || fullInfo)
                 paramsForInferBuffer ++= paramsForInfer
                 exprsBuffer ++= exprs
@@ -98,7 +102,7 @@ object InferUtil {
         }
         implicitParameters = Some(resolveResultsBuffer.toSeq)
         val dependentSubst = new ScSubstitutor(() => {
-          val level = element.languageLevel
+          val level = element.scalaLanguageLevelOrDefault
           if (level >= Scala_2_10) {
             paramsForInferBuffer.zip(exprsBuffer).map {
               case (param: Parameter, expr: Expression) =>
@@ -121,7 +125,7 @@ object InferUtil {
         implicitParameters = Some(resolveResults.toSeq)
         resInner = retType
         val dependentSubst = new ScSubstitutor(() => {
-          val level = element.languageLevel
+          val level = element.scalaLanguageLevelOrDefault
           if (level >= Scala_2_10) {
             paramsForInfer.zip(exprs).map {
               case (param: Parameter, expr: Expression) =>
@@ -201,15 +205,16 @@ object InferUtil {
   }
 
   /**
-   * Util method to update type according to expected type
-   * @param _nonValueType type, to update it should be PolymorphicType(MethodType)
-   * @param fromImplicitParameters we shouldn't update if it's anonymous function
-   *                               also we can update just for simple type without function
-   * @param expectedType appropriate expected type
-   * @param expr place
-   * @param check we fail to get right type then if check throw SafeCheckException
-   * @return updated type
-   */
+    * Util method to update type according to expected type
+    *
+    * @param _nonValueType          type, to update it should be PolymorphicType(MethodType)
+    * @param fromImplicitParameters we shouldn't update if it's anonymous function
+    *                               also we can update just for simple type without function
+    * @param expectedType           appropriate expected type
+    * @param expr                   place
+    * @param check                  we fail to get right type then if check throw SafeCheckException
+    * @return updated type
+    */
   def updateAccordingToExpectedType(_nonValueType: TypeResult[ScType],
                                     fromImplicitParameters: Boolean,
                                     filterTypeParams: Boolean,
@@ -222,12 +227,12 @@ object InferUtil {
         def updateRes(expected: ScType) {
           if (expected.equiv(types.Unit)) return //do not update according to Unit type
           val innerInternal = internal match {
-            case ScMethodType(inter, _, innerImpl) if innerImpl && !fromImplicitParameters => inter
-            case _ => internal
-          }
-          val update: ScTypePolymorphicType = ScalaPsiUtil.localTypeInference(m,
+              case ScMethodType(inter, _, innerImpl) if innerImpl && !fromImplicitParameters => inter
+              case _ => internal
+            }
+          val update: ScTypePolymorphicType = localTypeInference(m,
             Seq(Parameter("", None, expected, expected, isDefault = false, isRepeated = false, isByName = false)),
-            Seq(new Expression(ScalaPsiUtil.undefineSubstitutor(typeParams).subst(innerInternal.inferValueType))),
+            Seq(new Expression(undefineSubstitutor(typeParams).subst(innerInternal.inferValueType))),
             typeParams, shouldUndefineParameters = false, safeCheck = check, filterTypeParams = filterTypeParams)
           nonValueType = Success(update, Some(expr)) //here should work in different way:
         }
@@ -235,9 +240,9 @@ object InferUtil {
       //todo: Something should be unified, that's bad to have fromImplicitParameters parameter.
       case Success(ScTypePolymorphicType(internal, typeParams), _) if expectedType.isDefined && fromImplicitParameters =>
         def updateRes(expected: ScType) {
-          nonValueType = Success(ScalaPsiUtil.localTypeInference(internal,
+          nonValueType = Success(localTypeInference(internal,
             Seq(Parameter("", None, expected, expected, isDefault = false, isRepeated = false, isByName = false)),
-              Seq(new Expression(ScalaPsiUtil.undefineSubstitutor(typeParams).subst(internal.inferValueType))),
+            Seq(new Expression(undefineSubstitutor(typeParams).subst(internal.inferValueType))),
             typeParams, shouldUndefineParameters = false, safeCheck = check,
             filterTypeParams = filterTypeParams), Some(expr)) //here should work in different way:
         }
@@ -273,7 +278,7 @@ object InferUtil {
     }
 
     nonValueType.map {
-      case tpt @ ScTypePolymorphicType(mt: ScMethodType, typeParams) => tpt.copy(internalType = applyImplicitViewToResult(mt, expectedType))
+      case tpt@ScTypePolymorphicType(mt: ScMethodType, typeParams) => tpt.copy(internalType = applyImplicitViewToResult(mt, expectedType))
       case mt: ScMethodType => applyImplicitViewToResult(mt, expectedType)
       case tp => tp
     }
@@ -288,5 +293,205 @@ object InferUtil {
       case ScalaResolveResult(f: ScFieldId, subst) => subst.subst(f.getType(TypingContext.empty).get)
       case ScalaResolveResult(fun: ScFunction, subst) => subst.subst(fun.getTypeNoImplicits(TypingContext.empty).get)
     }
+  }
+
+  def undefineSubstitutor(typeParams: Seq[TypeParameter]): ScSubstitutor = {
+    typeParams.foldLeft(ScSubstitutor.empty) {
+      (subst: ScSubstitutor, tp: TypeParameter) =>
+        subst.bindT((tp.name, ScalaPsiUtil.getPsiElementId(tp.ptp)),
+          new ScUndefinedType(new ScTypeParameterType(tp.ptp, ScSubstitutor.empty)))
+    }
+  }
+
+  def localTypeInference(retType: ScType, params: Seq[Parameter], exprs: Seq[Expression],
+                         typeParams: Seq[TypeParameter],
+                         shouldUndefineParameters: Boolean = true,
+                         safeCheck: Boolean = false,
+                         filterTypeParams: Boolean = true): ScTypePolymorphicType = {
+    localTypeInferenceWithApplicability(retType, params, exprs, typeParams, shouldUndefineParameters, safeCheck,
+      filterTypeParams)._1
+  }
+
+
+  class SafeCheckException extends ControlThrowable
+
+  def localTypeInferenceWithApplicability(retType: ScType, params: Seq[Parameter], exprs: Seq[Expression],
+                                          typeParams: Seq[TypeParameter],
+                                          shouldUndefineParameters: Boolean = true,
+                                          safeCheck: Boolean = false,
+                                          filterTypeParams: Boolean = true): (ScTypePolymorphicType, Seq[ApplicabilityProblem]) = {
+    val (tp, problems, _, _) = localTypeInferenceWithApplicabilityExt(retType, params, exprs, typeParams,
+      shouldUndefineParameters, safeCheck, filterTypeParams)
+    (tp, problems)
+  }
+
+  def localTypeInferenceWithApplicabilityExt(retType: ScType, params: Seq[Parameter], exprs: Seq[Expression],
+                                             typeParams: Seq[TypeParameter],
+                                             shouldUndefineParameters: Boolean = true,
+                                             safeCheck: Boolean = false,
+                                             filterTypeParams: Boolean = true
+                                            ): (ScTypePolymorphicType, Seq[ApplicabilityProblem], Seq[(Parameter, ScExpression)], Seq[(Parameter, ScType)]) = {
+    // See SCL-3052, SCL-3058
+    // This corresponds to use of `isCompatible` in `Infer#methTypeArgs` in scalac, where `isCompatible` uses `weak_<:<`
+    val s: ScSubstitutor = if (shouldUndefineParameters) undefineSubstitutor(typeParams) else ScSubstitutor.empty
+    val abstractSubst = ScTypePolymorphicType(retType, typeParams).abstractTypeSubstitutor
+    val paramsWithUndefTypes = params.map(p => p.copy(paramType = s.subst(p.paramType),
+      expectedType = abstractSubst.subst(p.paramType)))
+    val c = Compatibility.checkConformanceExt(checkNames = true, paramsWithUndefTypes, exprs, checkWithImplicits = true,
+      isShapesResolve = false)
+    val tpe = if (c.problems.isEmpty) {
+      var un: ScUndefinedSubstitutor = c.undefSubst
+      val subst = c.undefSubst
+      subst.getSubstitutor(!safeCheck) match {
+        case Some(unSubst) =>
+          if (!filterTypeParams) {
+            val undefiningSubstitutor = new ScSubstitutor(typeParams.map(typeParam => {
+              ((typeParam.name, ScalaPsiUtil.getPsiElementId(typeParam.ptp)), new ScUndefinedType(new ScTypeParameterType(typeParam.ptp, ScSubstitutor.empty)))
+            }).toMap, Map.empty, None)
+            ScTypePolymorphicType(retType, typeParams.map(tp => {
+              var lower = tp.lowerType()
+              var upper = tp.upperType()
+              def hasRecursiveTypeParameters(typez: ScType): Boolean = {
+                var hasRecursiveTypeParameters = false
+                typez.recursiveUpdate {
+                  case tpt: ScTypeParameterType =>
+                    typeParams.find(tp => (tp.name, ScalaPsiUtil.getPsiElementId(tp.ptp)) ==(tpt.name, tpt.getId)) match {
+                      case None => (true, tpt)
+                      case _ =>
+                        hasRecursiveTypeParameters = true
+                        (true, tpt)
+                    }
+                  case tp: ScType => (hasRecursiveTypeParameters, tp)
+                }
+                hasRecursiveTypeParameters
+              }
+              subst.lMap.get((tp.name, ScalaPsiUtil.getPsiElementId(tp.ptp))) match {
+                case Some(_addLower) =>
+                  val substedLowerType = unSubst.subst(lower)
+                  val addLower =
+                    if (tp.typeParams.nonEmpty && !_addLower.isInstanceOf[ScParameterizedType] &&
+                      !tp.typeParams.exists(_.name == "_"))
+                      ScParameterizedType(_addLower, tp.typeParams.map(ScTypeParameterType.toTypeParameterType))
+                    else _addLower
+                  if (hasRecursiveTypeParameters(substedLowerType)) lower = addLower
+                  else lower = Bounds.lub(substedLowerType, addLower)
+                case None =>
+                  lower = unSubst.subst(lower)
+              }
+              subst.rMap.get((tp.name, ScalaPsiUtil.getPsiElementId(tp.ptp))) match {
+                case Some(_addUpper) =>
+                  val substedUpperType = unSubst.subst(upper)
+                  val addUpper =
+                    if (tp.typeParams.nonEmpty && !_addUpper.isInstanceOf[ScParameterizedType] &&
+                      !tp.typeParams.exists(_.name == "_"))
+                      ScParameterizedType(_addUpper, tp.typeParams.map(ScTypeParameterType.toTypeParameterType))
+                    else _addUpper
+                  if (hasRecursiveTypeParameters(substedUpperType)) upper = addUpper
+                  else upper = Bounds.glb(substedUpperType, addUpper)
+                case None =>
+                  upper = unSubst.subst(upper)
+              }
+
+              if (safeCheck && !undefiningSubstitutor.subst(lower).conforms(undefiningSubstitutor.subst(upper), checkWeak = true))
+                throw new SafeCheckException
+              TypeParameter(tp.name, tp.typeParams /* doesn't important here */ , () => lower, () => upper, tp.ptp)
+            }))
+          } else {
+            typeParams.foreach { case tp =>
+              val name = (tp.name, ScalaPsiUtil.getPsiElementId(tp.ptp))
+              if (un.names.contains(name)) {
+                def hasRecursiveTypeParameters(typez: ScType): Boolean = {
+                  var hasRecursiveTypeParameters = false
+                  typez.recursiveUpdate {
+                    case tpt: ScTypeParameterType =>
+                      typeParams.find(tp => (tp.name, ScalaPsiUtil.getPsiElementId(tp.ptp)) ==(tpt.name, tpt.getId)) match {
+                        case None => (true, tpt)
+                        case _ =>
+                          hasRecursiveTypeParameters = true
+                          (true, tpt)
+                      }
+                    case tp: ScType => (hasRecursiveTypeParameters, tp)
+                  }
+                  hasRecursiveTypeParameters
+                }
+                //todo: add only one of them according to variance
+                if (tp.lowerType() != Nothing) {
+                  val substedLowerType = unSubst.subst(tp.lowerType())
+                  if (!hasRecursiveTypeParameters(substedLowerType)) {
+                    un = un.addLower(name, substedLowerType, additional = true)
+                  }
+                }
+                if (tp.upperType() != Any) {
+                  val substedUpperType = unSubst.subst(tp.upperType())
+                  if (!hasRecursiveTypeParameters(substedUpperType)) {
+                    un = un.addUpper(name, substedUpperType, additional = true)
+                  }
+                }
+              }
+            }
+
+            def updateWithSubst(sub: ScSubstitutor): ScTypePolymorphicType = {
+              ScTypePolymorphicType(sub.subst(retType), typeParams.filter {
+                case tp =>
+                  val name = (tp.name, ScalaPsiUtil.getPsiElementId(tp.ptp))
+                  val removeMe: Boolean = un.names.contains(name)
+                  if (removeMe && safeCheck) {
+                    //let's check type parameter kinds
+                    def checkTypeParam(typeParam: ScTypeParam, tp: => ScType): Boolean = {
+                      val typeParams: Seq[ScTypeParam] = typeParam.typeParameters
+                      if (typeParams.isEmpty) return true
+                      tp match {
+                        case ScParameterizedType(_, typeArgs) =>
+                          if (typeArgs.length != typeParams.length) return false
+                          typeArgs.zip(typeParams).forall {
+                            case (tp: ScType, typeParam: ScTypeParam) => checkTypeParam(typeParam, tp)
+                          }
+                        case _ =>
+                          def checkNamed(named: PsiNamedElement, typeParams: Seq[ScTypeParam]): Boolean = {
+                            named match {
+                              case t: ScTypeParametersOwner =>
+                                if (typeParams.length != t.typeParameters.length) return false
+                                typeParams.zip(t.typeParameters).forall {
+                                  case (p1: ScTypeParam, p2: ScTypeParam) =>
+                                    if (p1.typeParameters.nonEmpty) checkNamed(p2, p1.typeParameters)
+                                    else true
+                                }
+                              case p: PsiTypeParameterListOwner =>
+                                if (typeParams.length != p.getTypeParameters.length) return false
+                                typeParams.forall(_.typeParameters.isEmpty)
+                              case _ => false
+                            }
+                          }
+                          ScType.extractDesignated(tp, withoutAliases = false) match {
+                            case Some((named, _)) => checkNamed(named, typeParams)
+                            case _ => tp match {
+                              case tpt: ScTypeParameterType => checkNamed(tpt.param, typeParams)
+                              case _ => false
+                            }
+                          }
+                      }
+                    }
+                    tp.ptp match {
+                      case typeParam: ScTypeParam =>
+                        if (!checkTypeParam(typeParam, sub.subst(new ScTypeParameterType(tp.ptp, ScSubstitutor.empty))))
+                          throw new SafeCheckException
+                      case _ =>
+                    }
+                  }
+                  !removeMe
+              }.map(tp => TypeParameter(tp.name, tp.typeParams /* doesn't important here */ ,
+                () => sub.subst(tp.lowerType()), () => sub.subst(tp.upperType()), tp.ptp)))
+            }
+
+            un.getSubstitutor match {
+              case Some(unSubstitutor) => updateWithSubst(unSubstitutor)
+              case _ if safeCheck => throw new SafeCheckException
+              case _ => updateWithSubst(unSubst)
+            }
+          }
+        case None => throw new SafeCheckException
+      }
+    } else ScTypePolymorphicType(retType, typeParams)
+    (tpe, c.problems, c.matchedArgs, c.matchedTypes)
   }
 }

--- a/src/org/jetbrains/plugins/scala/lang/psi/api/expr/MethodInvocation.scala
+++ b/src/org/jetbrains/plugins/scala/lang/psi/api/expr/MethodInvocation.scala
@@ -6,6 +6,7 @@ import com.intellij.psi.{PsiElement, PsiNamedElement}
 import org.jetbrains.plugins.scala.extensions._
 import org.jetbrains.plugins.scala.lang.psi.ScalaPsiUtil._
 import org.jetbrains.plugins.scala.lang.psi.api.InferUtil
+import org.jetbrains.plugins.scala.lang.psi.api.InferUtil.SafeCheckException
 import org.jetbrains.plugins.scala.lang.psi.api.toplevel.imports.usages.ImportUsed
 import org.jetbrains.plugins.scala.lang.psi.api.toplevel.typedef.ScTrait
 import org.jetbrains.plugins.scala.lang.psi.impl.ScalaPsiManager
@@ -28,6 +29,7 @@ trait MethodInvocation extends ScExpression with ScalaPsiElement {
   /**
    * For Infix, Postfix and Prefix expressions
    * it's refernce expression for operation
+ *
    * @return method reference or invoked expression for calls
    */
   def getInvokedExpr: ScExpression
@@ -39,6 +41,7 @@ trait MethodInvocation extends ScExpression with ScalaPsiElement {
 
   /**
    * Unwraps parenthesised expression for method calls
+ *
    * @return unwrapped invoked expression
    */
   def getEffectiveInvokedExpr: ScExpression = getInvokedExpr
@@ -46,12 +49,14 @@ trait MethodInvocation extends ScExpression with ScalaPsiElement {
   /**
    * Important method for method calls like: foo(expr) = assign.
    * Usually this is same as argumentExpressions
+ *
    * @return arguments with additional argument if call in update position
    */
   def argumentExpressionsIncludeUpdateCall: Seq[ScExpression] = argumentExpressions
 
   /**
    * Seq of application problems like type mismatch.
+ *
    * @return seq of application problems
    */
   def applicationProblems: Seq[ApplicabilityProblem] = {
@@ -78,6 +83,7 @@ trait MethodInvocation extends ScExpression with ScalaPsiElement {
 
   /**
    * In case if invoked expression converted implicitly to invoke apply or update method
+ *
    * @return imports used for implicit conversion
    */
   def getImportsUsed: collection.Set[ImportUsed] = {
@@ -86,6 +92,7 @@ trait MethodInvocation extends ScExpression with ScalaPsiElement {
 
   /**
    * In case if invoked expression converted implicitly to invoke apply or update method
+ *
    * @return actual conversion element
    */
   def getImplicitFunction: Option[PsiNamedElement] = {
@@ -104,6 +111,7 @@ trait MethodInvocation extends ScExpression with ScalaPsiElement {
   /**
    * It's arguments for method and infix call.
    * For prefix and postfix call it's just operation.
+ *
    * @return Element, which reflects arguments
    */
   def argsElement: PsiElement
@@ -155,7 +163,7 @@ trait MethodInvocation extends ScExpression with ScalaPsiElement {
     def checkConformanceWithInference(retType: ScType, psiExprs: Seq[Expression],
                                       typeParams: Seq[TypeParameter], parameters: Seq[Parameter]) = {
       tuplizyCase(psiExprs) { t =>
-        localTypeInferenceWithApplicabilityExt(retType, parameters, t, typeParams, safeCheck = withExpectedType)
+        InferUtil.localTypeInferenceWithApplicabilityExt(retType, parameters, t, typeParams, safeCheck = withExpectedType)
       }
     }
 

--- a/src/org/jetbrains/plugins/scala/lang/psi/api/expr/ScExpression.scala
+++ b/src/org/jetbrains/plugins/scala/lang/psi/api/expr/ScExpression.scala
@@ -9,7 +9,8 @@ import com.intellij.psi._
 import org.jetbrains.plugins.scala.caches.CachesUtil
 import org.jetbrains.plugins.scala.extensions.ElementText
 import org.jetbrains.plugins.scala.lang.lexer.ScalaTokenTypes
-import org.jetbrains.plugins.scala.lang.psi.ScalaPsiUtil.{MethodValue, SafeCheckException}
+import org.jetbrains.plugins.scala.lang.psi.ScalaPsiUtil.MethodValue
+import org.jetbrains.plugins.scala.lang.psi.api.InferUtil.SafeCheckException
 import org.jetbrains.plugins.scala.lang.psi.api.base.ScLiteral
 import org.jetbrains.plugins.scala.lang.psi.api.base.types.ScTypeElement
 import org.jetbrains.plugins.scala.lang.psi.api.toplevel.imports.usages.ImportUsed
@@ -37,6 +38,7 @@ trait ScExpression extends ScBlockStatement with PsiAnnotationMemberValue with I
   /**
    * This method returns real type, after using implicit conversions.
    * Second parameter to return is used imports for this conversion.
+ *
    * @param expectedOption to which type we trying to convert
    * @param ignoreBaseTypes parameter to avoid value discarding, literal narrowing, widening
    *                        this parameter is useful for refactorings (introduce variable)
@@ -356,6 +358,7 @@ trait ScExpression extends ScBlockStatement with PsiAnnotationMemberValue with I
    * Warning! There is a hack in scala compiler for ClassManifest and ClassTag.
    * In case of implicit parameter with type ClassManifest[T]
    * this method will return ClassManifest with substitutor of type T.
+ *
    * @return implicit parameters used for this expression
    */
   def findImplicitParameters: Option[Seq[ScalaResolveResult]] = {
@@ -453,6 +456,7 @@ trait ScExpression extends ScBlockStatement with PsiAnnotationMemberValue with I
   /**
    * This method should be used to get implicit conversions and used imports, while eta expanded method return was
    * implicitly converted
+ *
    * @return mirror for this expression, in case if it exists
    */
   def getAdditionalExpression: Option[(ScExpression, ScType)] = {
@@ -462,6 +466,7 @@ trait ScExpression extends ScBlockStatement with PsiAnnotationMemberValue with I
 
   /**
    * This method returns following values:
+ *
    * @return implicit conversions, actual value, conversions from the first part, conversions from the second part
    */
   def getImplicitConversions(fromUnder: Boolean = false,

--- a/src/org/jetbrains/plugins/scala/lang/psi/impl/base/ScConstructorImpl.scala
+++ b/src/org/jetbrains/plugins/scala/lang/psi/impl/base/ScConstructorImpl.scala
@@ -7,8 +7,7 @@ package base
 import com.intellij.lang.ASTNode
 import com.intellij.psi._
 import org.jetbrains.plugins.scala.extensions._
-import org.jetbrains.plugins.scala.lang.psi.ScalaPsiUtil.SafeCheckException
-import org.jetbrains.plugins.scala.lang.psi.api.ScalaElementVisitor
+import org.jetbrains.plugins.scala.lang.psi.api.InferUtil.SafeCheckException
 import org.jetbrains.plugins.scala.lang.psi.api.base._
 import org.jetbrains.plugins.scala.lang.psi.api.base.types.{ScParameterizedTypeElement, ScSimpleTypeElement, ScTypeElement}
 import org.jetbrains.plugins.scala.lang.psi.api.expr.ScNewTemplateDefinition
@@ -17,6 +16,7 @@ import org.jetbrains.plugins.scala.lang.psi.api.statements.params.ScTypeParam
 import org.jetbrains.plugins.scala.lang.psi.api.toplevel.ScTypeParametersOwner
 import org.jetbrains.plugins.scala.lang.psi.api.toplevel.templates.{ScClassParents, ScExtendsBlock}
 import org.jetbrains.plugins.scala.lang.psi.api.toplevel.typedef.ScTemplateDefinition
+import org.jetbrains.plugins.scala.lang.psi.api.{InferUtil, ScalaElementVisitor}
 import org.jetbrains.plugins.scala.lang.psi.impl.base.types.ScSimpleTypeElementImpl
 import org.jetbrains.plugins.scala.lang.psi.types.Compatibility.Expression
 import org.jetbrains.plugins.scala.lang.psi.types._
@@ -75,7 +75,7 @@ class ScConstructorImpl(node: ASTNode) extends ScalaPsiElementImpl(node) with Sc
 
   //todo: duplicate ScSimpleTypeElementImpl
   def parameterize(tp: ScType, clazz: PsiClass, subst: ScSubstitutor): ScType = {
-    if (clazz.getTypeParameters.length == 0) {
+    if (clazz.getTypeParameters.isEmpty) {
       tp
     } else {
       ScParameterizedType(tp, clazz.getTypeParameters.map {
@@ -87,7 +87,7 @@ class ScConstructorImpl(node: ASTNode) extends ScalaPsiElementImpl(node) with Sc
 
   def shapeType(i: Int): TypeResult[ScType] = {
     val seq = shapeMultiType(i)
-    if (seq.length == 1) seq(0)
+    if (seq.length == 1) seq.head
     else Failure("Can't resolve type", Some(this))
   }
 
@@ -116,9 +116,9 @@ class ScConstructorImpl(node: ASTNode) extends ScalaPsiElementImpl(node) with Sc
           ResolveUtils.javaMethodType(method, subst, getResolveScope, Some(subst.subst(tp)))
       }
       val typeParameters: Seq[TypeParameter] = r.getActualElement match {
-        case tp: ScTypeParametersOwner if tp.typeParameters.length > 0 =>
+        case tp: ScTypeParametersOwner if tp.typeParameters.nonEmpty =>
           tp.typeParameters.map(new TypeParameter(_))
-        case ptp: PsiTypeParameterListOwner if ptp.getTypeParameters.length > 0 =>
+        case ptp: PsiTypeParameterListOwner if ptp.getTypeParameters.nonEmpty =>
           ptp.getTypeParameters.toSeq.map(new TypeParameter(_))
         case _ => return Success(res, Some(this))
       }
@@ -135,9 +135,9 @@ class ScConstructorImpl(node: ASTNode) extends ScalaPsiElementImpl(node) with Sc
           expectedType match {
             case Some(expected) =>
               try {
-                nonValueType = ScalaPsiUtil.localTypeInference(nonValueType.internalType,
+                nonValueType = InferUtil.localTypeInference(nonValueType.internalType,
                   Seq(new Parameter("", None, expected, false, false, false, 0)),
-                  Seq(new Expression(ScalaPsiUtil.undefineSubstitutor(nonValueType.typeParameters).
+                  Seq(new Expression(InferUtil.undefineSubstitutor(nonValueType.typeParameters).
                     subst(subst.subst(tp).inferValueType))),
                   nonValueType.typeParameters, shouldUndefineParameters = false, filterTypeParams = false)
               } catch {

--- a/src/org/jetbrains/plugins/scala/lang/psi/impl/base/types/ScSimpleTypeElementImpl.scala
+++ b/src/org/jetbrains/plugins/scala/lang/psi/impl/base/types/ScSimpleTypeElementImpl.scala
@@ -11,7 +11,7 @@ import com.intellij.psi._
 import com.intellij.psi.util.PsiTreeUtil
 import org.jetbrains.plugins.scala.extensions._
 import org.jetbrains.plugins.scala.lang.lexer.ScalaTokenTypes
-import org.jetbrains.plugins.scala.lang.psi.ScalaPsiUtil.SafeCheckException
+import org.jetbrains.plugins.scala.lang.psi.api.InferUtil.SafeCheckException
 import org.jetbrains.plugins.scala.lang.psi.api.base._
 import org.jetbrains.plugins.scala.lang.psi.api.base.types._
 import org.jetbrains.plugins.scala.lang.psi.api.expr.{ScSuperReference, ScThisReference, ScUnderScoreSectionUtil}
@@ -182,7 +182,7 @@ class ScSimpleTypeElementImpl(node: ASTNode) extends ScalaPsiElementImpl(node) w
           //4. Implicit clauses if applicable
           //5. In case of SafeCheckException return to 3 to complete update without expected type
           while (i < params.length - 1 && i < c.arguments.length - 1) {
-            nonValueType = ScalaPsiUtil.localTypeInference(nonValueType.internalType, params(i),
+            nonValueType = InferUtil.localTypeInference(nonValueType.internalType, params(i),
               c.arguments(i).exprs.map(new Expression(_)), nonValueType.typeParameters)
             i += 1
           }
@@ -191,9 +191,9 @@ class ScSimpleTypeElementImpl(node: ASTNode) extends ScalaPsiElementImpl(node) w
             c.expectedType match {
               case Some(expected) if withExpected =>
                 def updateRes(expected: ScType) {
-                  nonValueType = ScalaPsiUtil.localTypeInference(nonValueType.internalType,
+                  nonValueType = InferUtil.localTypeInference(nonValueType.internalType,
                     Seq(new Parameter("", None, expected, false, false, false, 0)),
-                      Seq(new Expression(ScalaPsiUtil.undefineSubstitutor(nonValueType.typeParameters).subst(res.inferValueType))),
+                      Seq(new Expression(InferUtil.undefineSubstitutor(nonValueType.typeParameters).subst(res.inferValueType))),
                     nonValueType.typeParameters, shouldUndefineParameters = false, filterTypeParams = false) //here should work in different way:
                 }
                 val fromUnderscore = c.newTemplate match {
@@ -213,7 +213,7 @@ class ScSimpleTypeElementImpl(node: ASTNode) extends ScalaPsiElementImpl(node) w
 
             //last clause after expected types
             if (i < params.length && i < c.arguments.length) {
-              nonValueType = ScalaPsiUtil.localTypeInference(nonValueType.internalType, params(i),
+              nonValueType = InferUtil.localTypeInference(nonValueType.internalType, params(i),
                 c.arguments(i).exprs.map(new Expression(_)), nonValueType.typeParameters, safeCheck = withExpected)
               i += 1
             }

--- a/src/org/jetbrains/plugins/scala/lang/psi/implicits/ImplicitCollector.scala
+++ b/src/org/jetbrains/plugins/scala/lang/psi/implicits/ImplicitCollector.scala
@@ -4,12 +4,11 @@ package lang.psi.implicits
 import com.intellij.openapi.progress.ProgressManager
 import com.intellij.psi._
 import com.intellij.psi.util.PsiTreeUtil
-import com.intellij.util.SofterReference
 import com.intellij.util.containers.ContainerUtil
 import org.jetbrains.plugins.scala.caches.ScalaRecursionManager
 import org.jetbrains.plugins.scala.caches.ScalaRecursionManager.RecursionMap
 import org.jetbrains.plugins.scala.extensions._
-import org.jetbrains.plugins.scala.lang.psi.ScalaPsiUtil.SafeCheckException
+import org.jetbrains.plugins.scala.lang.psi.api.InferUtil.SafeCheckException
 import org.jetbrains.plugins.scala.lang.psi.api.base.ScFieldId
 import org.jetbrains.plugins.scala.lang.psi.api.base.patterns.ScBindingPattern
 import org.jetbrains.plugins.scala.lang.psi.api.base.types.ScExistentialClause
@@ -162,7 +161,7 @@ class ImplicitCollector(private var place: PsiElement, tp: ScType, expandedTp: S
       val named = element.asInstanceOf[PsiNamedElement]
       def fromType: Option[ScType] = state.get(BaseProcessor.FROM_TYPE_KEY).toOption
       lazy val subst: ScSubstitutor = fromType match {
-        case Some(tp) => getSubst(state).followUpdateThisType(tp)
+        case Some(t) => getSubst(state).followUpdateThisType(t)
         case _ => getSubst(state)
       }
       named match {

--- a/src/org/jetbrains/plugins/scala/lang/resolve/processor/MethodResolveProcessor.scala
+++ b/src/org/jetbrains/plugins/scala/lang/resolve/processor/MethodResolveProcessor.scala
@@ -6,6 +6,7 @@ package processor
 import com.intellij.psi._
 import org.jetbrains.plugins.scala.caches.CachesUtil
 import org.jetbrains.plugins.scala.extensions._
+import org.jetbrains.plugins.scala.lang.psi.api.InferUtil
 import org.jetbrains.plugins.scala.lang.psi.api.base.types.ScTypeElement
 import org.jetbrains.plugins.scala.lang.psi.api.base.{ScMethodLike, ScPrimaryConstructor}
 import org.jetbrains.plugins.scala.lang.psi.api.expr._
@@ -176,7 +177,7 @@ object MethodResolveProcessor {
     }
 
     val substitutor: ScSubstitutor =
-      undefinedSubstitutor(elementForUndefining, s, proc).followed(ScalaPsiUtil.undefineSubstitutor(prevTypeInfo))
+      undefinedSubstitutor(elementForUndefining, s, proc).followed(InferUtil.undefineSubstitutor(prevTypeInfo))
 
     val typeParameters: Seq[TypeParameter] = prevTypeInfo ++ (element match {
       case fun: ScFunction => fun.typeParameters.map(new TypeParameter(_))

--- a/src/org/jetbrains/plugins/scala/project/package.scala
+++ b/src/org/jetbrains/plugins/scala/project/package.scala
@@ -16,8 +16,8 @@ import org.jetbrains.plugins.scala.extensions._
 import org.jetbrains.plugins.scala.project.settings.{ScalaCompilerConfiguration, ScalaCompilerSettings}
 
 import scala.annotation.tailrec
-import scala.collection.immutable.HashSet
 import scala.collection.JavaConverters._
+import scala.language.implicitConversions
 import scala.util.matching.Regex
 
 /**
@@ -215,6 +215,8 @@ package object project {
     }
 
     def scalaLanguageLevel: Option[ScalaLanguageLevel] = module.flatMap(_.scalaSdk.map(_.languageLevel))
+
+    def scalaLanguageLevelOrDefault: ScalaLanguageLevel = scalaLanguageLevel.getOrElse(ScalaLanguageLevel.Default)
   }
 
   val LibraryVersion: Regex = """(?<=:|-)\d+\.\d+\.\d+[^:\s]*""".r


### PR DESCRIPTION
Remove accidentally committed code
Apply all inspections for modified files
