### PR TITLE
Fix macros compiler option

### DIFF
--- a/src/org/jetbrains/plugins/scala/project/settings/ScalaCompilerSettings.scala
+++ b/src/org/jetbrains/plugins/scala/project/settings/ScalaCompilerSettings.scala
@@ -49,7 +49,7 @@ class ScalaCompilerSettings(state: ScalaCompilerSettingsState) {
     ("-language:implicitConversions", () => implicitConversions, implicitConversions = _),
     ("-language:higherKinds", () => higherKinds, higherKinds = _),
     ("-language:existentials", () => existentials, existentials = _),
-    ("-language:macros", () => macros, macros = _),
+    ("-language:experimental.macros", () => macros, macros = _),
     ("-Xexperimental", () => experimental, experimental = _),
     ("-nowarn", () => !warnings, (b: Boolean) => warnings = !b),
     ("-deprecation", () => deprecationWarnings, deprecationWarnings = _),


### PR DESCRIPTION
Macros language option needs `experimental`

```
> scalac -language:help
Enable or disable language features
  dynamics             Allow direct or indirect subclasses of scala.Dynamic
  postfixOps           Allow postfix operator notation, such as `1 to 10 toList'
  reflectiveCalls      Allow reflective access to members of structural types
  implicitConversions  Allow definition of implicit functions called views
  higherKinds          Allow higher-kinded types
  existentials         Existential types (besides wildcard types) can be written and inferred
  experimental.macros  Allow macro definition (besides implementation and application)
```
