### PR TITLE
SCL-9861 Inspection: unnecessary partial function definition

### DIFF
--- a/resources/META-INF/scala-plugin-common.xml
+++ b/resources/META-INF/scala-plugin-common.xml
@@ -896,6 +896,9 @@
                          displayName="Non-value field is accessed in 'hashCode()'" groupPath="Scala" groupName="General"
                          shortName="HashCodeUsesVar" level="WEAK WARNING"
                          enabledByDefault="true" language="Scala"/>
+        <localInspection implementationClass="org.jetbrains.plugins.scala.codeInspection.functionExpressions.UnnecessaryPartialFunctionInspection"
+                         displayName="Unnecessary Partial Function" groupPath="Scala" groupName="General" shortName="UnnecessaryPartialFunction"
+                         id="UnnecessaryPartialFunction" level="WARNING" enabledByDefault="true" language="Scala"/>
         <!--<localInspection implementationClass="org.jetbrains.plugins.scala.codeInspection.allErrorsInspection.AnnotatorBasedErrorInspection"
                         displayName="All Errors Tool" groupPath="Scala" groupName="General"
                         shortName="ScalaAllErrors" level="WARNING"

--- a/resources/intentionDescriptions/ConvertToParenthesesIntention/description.html
+++ b/resources/intentionDescriptions/ConvertToParenthesesIntention/description.html
@@ -1,5 +1,5 @@
 <html>
 <body>
-Use curly braces around the generators of a for-comprenhension.
+Use parentheses around the generators of a for-comprenhension.
 </body>
 </html>

--- a/resources/org/jetbrains/plugins/scala/ScalaBundle.properties
+++ b/resources/org/jetbrains/plugins/scala/ScalaBundle.properties
@@ -574,6 +574,8 @@ intention.type.annotation.parameter.remove.text=Remove type annotation from para
 make.type.more.specific.fun=Make return type more specific
 make.type.more.specific=Make declared type more specific
 
+intention.for.comprehension.convert.to.parentheses=Convert to parentheses
+
 ########################################################################################################################
 # Scala test runner display name patterns
 ########################################################################################################################

--- a/resources/org/jetbrains/plugins/scala/codeInspection/InspectionBundle.properties
+++ b/resources/org/jetbrains/plugins/scala/codeInspection/InspectionBundle.properties
@@ -123,3 +123,6 @@ suppress.inspection.variable=Suppress for variable definiton
 suppress.inspection.argument=Suppress for argument
 
 convert.expression.to.sam=Convert expression to Single Abstract Method
+
+unnecessary.partial.function=Unnecessary partial function
+convert.to.anonymous.function=Convert to anonymous function

--- a/src/org/jetbrains/plugins/scala/codeInspection/functionExpressions/UnnecessaryPartialFunctionInspection.scala
+++ b/src/org/jetbrains/plugins/scala/codeInspection/functionExpressions/UnnecessaryPartialFunctionInspection.scala
@@ -1,7 +1,7 @@
 package org.jetbrains.plugins.scala.codeInspection.functionExpressions
 
 import com.intellij.codeInspection.{ProblemHighlightType, ProblemsHolder}
-import com.intellij.psi.{PsiClass, PsiElement}
+import com.intellij.psi.{PsiClass, PsiElement, PsiFile}
 import org.jetbrains.plugins.scala.codeInspection.functionExpressions.UnnecessaryPartialFunctionInspection._
 import org.jetbrains.plugins.scala.codeInspection.{AbstractInspection, InspectionBundle}
 import org.jetbrains.plugins.scala.lang.psi.api.base.patterns._
@@ -22,9 +22,9 @@ class UnnecessaryPartialFunctionInspection
   override def actionFor(holder: ProblemsHolder): PartialFunction[PsiElement, Any] = {
     case expression: ScBlockExpr =>
       def isNotPartialFunction(expectedType: ScType) =
-        findPartialFunctionType(holder).exists(!expectedType.conforms(_))
+        findPartialFunctionType(holder.getFile).exists(!expectedType.conforms(_))
       def conformsTo(expectedType: ScType) = (inputType: ScType, resultType: ScType) =>
-        findType(holder, Function1ClassName, _ => Seq(inputType, resultType)).exists(_.conforms(expectedType))
+        findType(holder.getFile, Function1ClassName, _ => Seq(inputType, resultType)).exists(_.conforms(expectedType))
 
       for{
         expectedExpressionType <- expression.expectedType()
@@ -36,19 +36,19 @@ class UnnecessaryPartialFunctionInspection
           caseKeyword,
           inspectionName,
           ProblemHighlightType.GENERIC_ERROR_OR_WARNING,
-          new UnnecessaryPartialFunctionQuickFix(singleCaseClause, expression))
+          new UnnecessaryPartialFunctionQuickFix(expression))
   }
 
-  private def findType(holder: ProblemsHolder, className: String, parameterTypes: PsiClass => Seq[ScType]): Option[ValueType] =
+  private def findType(file: PsiFile, className: String, parameterTypes: PsiClass => Seq[ScType]): Option[ValueType] =
     ScalaPsiManager
-      .instance(holder.getProject)
-      .getCachedClass(holder.getFile.getResolveScope, className)
+      .instance(file.getProject)
+      .getCachedClass(file.getResolveScope, className)
         .map(clazz =>
           ScParameterizedType(ScDesignatorType(clazz), parameterTypes(clazz)))
 
 
-  private def findPartialFunctionType(holder: ProblemsHolder): Option[ValueType] =
-    findType(holder, PartialFunctionClassName, undefinedTypeParameters)
+  private def findPartialFunctionType(file: PsiFile): Option[ValueType] =
+    findType(file, PartialFunctionClassName, undefinedTypeParameters)
 
   private def undefinedTypeParameters(clazz: PsiClass): Seq[ScUndefinedType] =
     clazz
@@ -62,10 +62,13 @@ class UnnecessaryPartialFunctionInspection
       caseClause.pattern.exists {
         case reference: ScReferencePattern => true
         case wildcard: ScWildcardPattern => true
-        case typed: ScTypedPattern =>
-          typed.typePattern.map(_.typeElement.calcType).exists(inputType =>
-            caseClause.expr.flatMap(_.expectedType()).exists(returnType =>
-                conformsToExpectedType(inputType, returnType)))
+        case typedPattern: ScTypedPattern =>
+          val patternType = typedPattern.typePattern.map(_.typeElement.calcType)
+          val expressionType = caseClause.expr.flatMap(_.getType().toOption)
+          (patternType, expressionType) match {
+            case (Some(inputType), Some(returnType)) => conformsToExpectedType(inputType, returnType)
+            case _ => false
+          }
         case _ => false
       }
 }

--- a/src/org/jetbrains/plugins/scala/codeInspection/functionExpressions/UnnecessaryPartialFunctionInspection.scala
+++ b/src/org/jetbrains/plugins/scala/codeInspection/functionExpressions/UnnecessaryPartialFunctionInspection.scala
@@ -1,0 +1,71 @@
+package org.jetbrains.plugins.scala.codeInspection.functionExpressions
+
+import com.intellij.codeInspection.{ProblemHighlightType, ProblemsHolder}
+import com.intellij.psi.{PsiClass, PsiElement}
+import org.jetbrains.plugins.scala.codeInspection.functionExpressions.UnnecessaryPartialFunctionInspection._
+import org.jetbrains.plugins.scala.codeInspection.{AbstractInspection, InspectionBundle}
+import org.jetbrains.plugins.scala.lang.psi.api.base.patterns._
+import org.jetbrains.plugins.scala.lang.psi.api.expr.ScBlockExpr
+import org.jetbrains.plugins.scala.lang.psi.impl.ScalaPsiManager
+import org.jetbrains.plugins.scala.lang.psi.types.{ScTypeParameterType, _}
+
+object UnnecessaryPartialFunctionInspection {
+  private val inspectionId = "UnnecessaryPartialFunction"
+  private val PartialFunctionClassName = classOf[PartialFunction[_, _]].getCanonicalName
+  private val Function1ClassName = classOf[(_) => _].getCanonicalName
+  val inspectionName = InspectionBundle.message("unnecessary.partial.function")
+}
+
+class UnnecessaryPartialFunctionInspection
+  extends AbstractInspection(inspectionId, inspectionName){
+
+  override def actionFor(holder: ProblemsHolder): PartialFunction[PsiElement, Any] = {
+    case expression: ScBlockExpr =>
+      def isNotPartialFunction(expectedType: ScType) =
+        findPartialFunctionType(holder).exists(!expectedType.conforms(_))
+      def conformsTo(expectedType: ScType) = (inputType: ScType, resultType: ScType) =>
+        findType(holder, Function1ClassName, _ => Seq(inputType, resultType)).exists(_.conforms(expectedType))
+
+      for{
+        expectedExpressionType <- expression.expectedType()
+        if isNotPartialFunction(expectedExpressionType)
+        Seq(singleCaseClause) <- expression.caseClauses.map(_.caseClauses)
+        if canBeConvertedToFunction(singleCaseClause, conformsTo(expectedExpressionType))
+        caseKeyword <- singleCaseClause.firstChild
+      } holder.registerProblem(
+          caseKeyword,
+          inspectionName,
+          ProblemHighlightType.GENERIC_ERROR_OR_WARNING,
+          new UnnecessaryPartialFunctionQuickFix(singleCaseClause, expression))
+  }
+
+  private def findType(holder: ProblemsHolder, className: String, parameterTypes: PsiClass => Seq[ScType]): Option[ValueType] =
+    ScalaPsiManager
+      .instance(holder.getProject)
+      .getCachedClass(holder.getFile.getResolveScope, className)
+        .map(clazz =>
+          ScParameterizedType(ScDesignatorType(clazz), parameterTypes(clazz)))
+
+
+  private def findPartialFunctionType(holder: ProblemsHolder): Option[ValueType] =
+    findType(holder, PartialFunctionClassName, undefinedTypeParameters)
+
+  private def undefinedTypeParameters(clazz: PsiClass): Seq[ScUndefinedType] =
+    clazz
+      .getTypeParameters
+      .map(typeParameter =>
+        new ScUndefinedType(new ScTypeParameterType(typeParameter, ScSubstitutor.empty)))
+      .toSeq
+
+  private def canBeConvertedToFunction(caseClause: ScCaseClause, conformsToExpectedType: (ScType, ScType) => Boolean) =
+    caseClause.guard.isEmpty &&
+      caseClause.pattern.exists {
+        case reference: ScReferencePattern => true
+        case wildcard: ScWildcardPattern => true
+        case typed: ScTypedPattern =>
+          typed.typePattern.map(_.typeElement.calcType).exists(inputType =>
+            caseClause.expr.flatMap(_.expectedType()).exists(returnType =>
+                conformsToExpectedType(inputType, returnType)))
+        case _ => false
+      }
+}

--- a/src/org/jetbrains/plugins/scala/codeInspection/functionExpressions/UnnecessaryPartialFunctionQuickFix.scala
+++ b/src/org/jetbrains/plugins/scala/codeInspection/functionExpressions/UnnecessaryPartialFunctionQuickFix.scala
@@ -3,8 +3,9 @@ package org.jetbrains.plugins.scala.codeInspection.functionExpressions
 import com.intellij.openapi.project.Project
 import org.jetbrains.plugins.scala.codeInspection.functionExpressions.UnnecessaryPartialFunctionQuickFix._
 import org.jetbrains.plugins.scala.codeInspection.{AbstractFixOnPsiElement, InspectionBundle}
-import org.jetbrains.plugins.scala.lang.psi.api.base.patterns.ScCaseClause
-import org.jetbrains.plugins.scala.lang.psi.api.expr.ScBlockExpr
+import org.jetbrains.plugins.scala.lang.psi.ScalaPsiUtil
+import org.jetbrains.plugins.scala.lang.psi.api.base.patterns.{ScCaseClause, ScReferencePattern, ScWildcardPattern}
+import org.jetbrains.plugins.scala.lang.psi.api.expr.{ScBlock, ScBlockExpr}
 import org.jetbrains.plugins.scala.lang.psi.impl.ScalaPsiElementFactory
 
 object UnnecessaryPartialFunctionQuickFix {
@@ -19,6 +20,7 @@ class UnnecessaryPartialFunctionQuickFix(caseClause: ScCaseClause, expression: S
     expressionCopy.caseClauses.map(_.caseClauses).foreach {
       case Seq(clause) =>
         removeCaseKeyword(clause)
+        if(canConvertBraces(clause)) ScalaPsiUtil.replaceBracesWithParentheses(expressionCopy)
         expression.replace(
           ScalaPsiElementFactory.createExpressionFromText(
             expressionCopy.getText,
@@ -31,4 +33,22 @@ class UnnecessaryPartialFunctionQuickFix(caseClause: ScCaseClause, expression: S
       caseKeyword <- clause.firstChild
       whitespaceBeforePattern <- clause.pattern.map(_.getPrevSibling)
     } clause.deleteChildRange(caseKeyword, whitespaceBeforePattern)
+
+  private def canConvertBraces(clause: ScCaseClause): Boolean =
+    patternIsReferenceOrWildcard(clause) && bodyIsExpressionOrOneStatementBlock(clause)
+
+  private def patternIsReferenceOrWildcard(clause: ScCaseClause): Boolean =
+    clause.pattern.exists {
+      case reference: ScReferencePattern => true
+      case wildcard: ScWildcardPattern => true
+      case _ => false
+    }
+
+  private def bodyIsExpressionOrOneStatementBlock(clause: ScCaseClause): Boolean = {
+    clause.expr.exists {
+      case expression: ScBlockExpr => true
+      case block: ScBlock if block.statements.size == 1 => true
+      case _ => false
+    }
+  }
 }

--- a/src/org/jetbrains/plugins/scala/codeInspection/functionExpressions/UnnecessaryPartialFunctionQuickFix.scala
+++ b/src/org/jetbrains/plugins/scala/codeInspection/functionExpressions/UnnecessaryPartialFunctionQuickFix.scala
@@ -1,0 +1,34 @@
+package org.jetbrains.plugins.scala.codeInspection.functionExpressions
+
+import com.intellij.openapi.project.Project
+import org.jetbrains.plugins.scala.codeInspection.functionExpressions.UnnecessaryPartialFunctionQuickFix._
+import org.jetbrains.plugins.scala.codeInspection.{AbstractFixOnPsiElement, InspectionBundle}
+import org.jetbrains.plugins.scala.lang.psi.api.base.patterns.ScCaseClause
+import org.jetbrains.plugins.scala.lang.psi.api.expr.ScBlockExpr
+import org.jetbrains.plugins.scala.lang.psi.impl.ScalaPsiElementFactory
+
+object UnnecessaryPartialFunctionQuickFix {
+  val hint = InspectionBundle.message("convert.to.anonymous.function")
+}
+
+class UnnecessaryPartialFunctionQuickFix(caseClause: ScCaseClause, expression: ScBlockExpr)
+  extends AbstractFixOnPsiElement(hint, caseClause) {
+
+  override def doApplyFix(project: Project): Unit = {
+    val expressionCopy = expression.copy().asInstanceOf[ScBlockExpr]
+    expressionCopy.caseClauses.map(_.caseClauses).foreach {
+      case Seq(clause) =>
+        removeCaseKeyword(clause)
+        expression.replace(
+          ScalaPsiElementFactory.createExpressionFromText(
+            expressionCopy.getText,
+            expression.getManager))
+    }
+  }
+
+  private def removeCaseKeyword(clause: ScCaseClause) =
+    for {
+      caseKeyword <- clause.firstChild
+      whitespaceBeforePattern <- clause.pattern.map(_.getPrevSibling)
+    } clause.deleteChildRange(caseKeyword, whitespaceBeforePattern)
+}

--- a/src/org/jetbrains/plugins/scala/lang/psi/ScalaPsiUtil.scala
+++ b/src/org/jetbrains/plugins/scala/lang/psi/ScalaPsiUtil.scala
@@ -25,6 +25,7 @@ import org.jetbrains.plugins.scala.caches.CachesUtil
 import org.jetbrains.plugins.scala.editor.typedHandler.ScalaTypedHandler
 import org.jetbrains.plugins.scala.extensions._
 import org.jetbrains.plugins.scala.lang.formatting.settings.ScalaCodeStyleSettings
+import org.jetbrains.plugins.scala.lang.lexer.ScalaTokenTypes
 import org.jetbrains.plugins.scala.lang.parser.util.ParserUtils
 import org.jetbrains.plugins.scala.lang.psi.api.base._
 import org.jetbrains.plugins.scala.lang.psi.api.base.patterns.{ScBindingPattern, ScCaseClause, ScPatternArgumentList}
@@ -2053,6 +2054,19 @@ object ScalaPsiUtil {
           case _ => false
         }
       case _ => false
+    }
+  }
+
+  def replaceBracesWithParentheses(element: ScalaPsiElement): Unit = {
+    val manager = element.getManager
+    val block = ScalaPsiElementFactory.parseElement("(_)", manager)
+
+    for (lBrace <- Option(element.findFirstChildByType(ScalaTokenTypes.tLBRACE))) {
+      lBrace.replace(block.getFirstChild)
+    }
+
+    for (rBrace <- Option(element.findFirstChildByType(ScalaTokenTypes.tRBRACE))) {
+      rBrace.replace(block.getLastChild)
     }
   }
 }

--- a/test/org/jetbrains/plugins/scala/codeInsight/intention/comprehension/ConvertToParenthesesIntentionTest.scala
+++ b/test/org/jetbrains/plugins/scala/codeInsight/intention/comprehension/ConvertToParenthesesIntentionTest.scala
@@ -1,0 +1,55 @@
+package org.jetbrains.plugins.scala.codeInsight.intention.comprehension
+
+import org.jetbrains.plugins.scala.codeInsight.intentions.ScalaIntentionTestBase
+import org.junit.Assert._
+
+class ConvertToParenthesesIntentionTest extends ScalaIntentionTestBase {
+  override def familyName = ConvertToParenthesesIntention.FamilyName
+
+  def testIntentionAvailableInSimpleForYieldStatement(): Unit = {
+    checkIntentionIsAvailable(s"for$CARET_MARKER{i <- 1 to 10} yield i + 1")
+  }
+
+  def testIntentionAvailableInLargeForYieldStatement(): Unit = {
+    checkIntentionIsAvailable(
+      s"""for$CARET_MARKER{
+        |  i <- 1 to 10
+        |  c <- 'a' to 'e'
+        |} yield "" + c + i""".stripMargin)
+  }
+
+  def testIntentionNotAvailableOnForKeyword(): Unit = {
+    checkIntentionIsNotAvailable(s"f${CARET_MARKER}or{i <- 1 to 10} yield i + 1")
+  }
+
+  def testIntentionNotAvailableInForBlock(): Unit = {
+    checkIntentionIsNotAvailable(s"for{${CARET_MARKER}i <- 1 to 10} yield i + 1")
+  }
+
+  def testIntentionNotAvailableInSimpleForStatementWithPatentheses(): Unit = {
+    checkIntentionIsNotAvailable(s"for$CARET_MARKER(i <- 1 to 10) yield i + 1")
+  }
+
+  def testIntentionNotAvailableInLargeForYieldStatementWithPatentheses(): Unit = {
+    checkIntentionIsNotAvailable(
+      s"""for$CARET_MARKER(
+          |  i <- 1 to 10;
+          |  c <- 'a' to 'e'
+          |) yield "" + c + i""".stripMargin)
+  }
+
+  def testIntentionActionForOnSimpleForStatement(): Unit = {
+    val text = s"for$CARET_MARKER{i <- 1 to 10} yield i + 1"
+    val result = "for (i <- 1 to 10) yield i + 1"
+    doTest(text, result, familyName)
+  }
+
+  def testIntentionActionOnLargeForYieldStatement(): Unit = {
+    val text = s"""for$CARET_MARKER{
+      |  i <- 1 to 10
+      |  c <- 'a' to 'e'
+      |} yield "" + c + i""".stripMargin
+    val result = """for (i <- 1 to 10; c <- 'a' to 'e') yield "" + c + i"""
+    doTest(text, result, familyName)
+  }
+}

--- a/test/org/jetbrains/plugins/scala/codeInspection/functionExpressions/UnnecessaryPartialFunctionInspectionTest.scala
+++ b/test/org/jetbrains/plugins/scala/codeInspection/functionExpressions/UnnecessaryPartialFunctionInspectionTest.scala
@@ -16,6 +16,16 @@ class UnnecessaryPartialFunctionInspectionTest extends ScalaLightInspectionFixtu
     testFix(text, fixed, hint)
   }
 
+  def testInspectionCapturesSimpleExpressionWithBlankLines(): Unit = {
+    val text = s"""val f: Int => String = {
+         |  ${START}case$END x => x.toString
+         |}""".stripMargin
+    val fixed = "val f: Int => String = (x => x.toString)"
+
+    checkTextHasError(text)
+    testFix(text, fixed, hint)
+  }
+
   def testInspectionCapturesMultiLineExpression(): Unit = {
     val text =
       s"""val f: Int => String = {
@@ -40,13 +50,15 @@ class UnnecessaryPartialFunctionInspectionTest extends ScalaLightInspectionFixtu
           |  ${START}case$END x => {
           |    val value = x.toString
           |    s"value of x is $$value"
-          |}}""".stripMargin
+          |  }
+          |}""".stripMargin
     val fixed =
-      s"""val f: Int => String = (
+      s"""val f: Int => String = {
           |  x => {
           |    val value = x.toString
           |    s"value of x is $$value"
-          |  })""".stripMargin
+          |  }
+          |}""".stripMargin
 
     checkTextHasError(text)
     testFix(text, fixed, hint)

--- a/test/org/jetbrains/plugins/scala/codeInspection/functionExpressions/UnnecessaryPartialFunctionInspectionTest.scala
+++ b/test/org/jetbrains/plugins/scala/codeInspection/functionExpressions/UnnecessaryPartialFunctionInspectionTest.scala
@@ -1,0 +1,142 @@
+package org.jetbrains.plugins.scala.codeInspection.functionExpressions
+
+import com.intellij.codeInspection.LocalInspectionTool
+import org.jetbrains.plugins.scala.codeInspection.ScalaLightInspectionFixtureTestAdapter
+
+class UnnecessaryPartialFunctionInspectionTest extends ScalaLightInspectionFixtureTestAdapter {
+  override protected val classOfInspection: Class[_ <: LocalInspectionTool] = classOf[UnnecessaryPartialFunctionInspection]
+  override protected val annotation: String = UnnecessaryPartialFunctionInspection.inspectionName
+  val hint = UnnecessaryPartialFunctionQuickFix.hint
+
+  def testInspectionCapturesSimpleExpression(): Unit = {
+    val text = s"val f: Int => String = {${START}case$END x => x.toString}"
+    val fixed = "val f: Int => String = { x => x.toString }"
+
+    checkTextHasError(text)
+    testFix(text, fixed, hint)
+  }
+
+  def testInspectionCapturesMultiLineExpression(): Unit = {
+    val text =
+      s"""val f: Int => String = {
+      |  ${START}case$END x =>
+      |    val value = x.toString
+      |    s"value of x is $$value"
+      |}""".stripMargin
+    val fixed =
+      s"""val f: Int => String = {
+          |  x =>
+          |    val value = x.toString
+          |    s"value of x is $$value"
+          |}""".stripMargin
+
+    checkTextHasError(text)
+    testFix(text, fixed, hint)
+  }
+
+  def testInspectionDoesNotCaptureSimpleExpressionIfItsTypeIsPartialFunction(): Unit = {
+    val text = s"val f: PartialFunction[Int, String] = {case x => x.toString}"
+    checkTextHasNoErrors(text)
+  }
+
+  def testInspectionDoesNotCaptureSimpleExpressionIfItsTypeIsPartialFunctionAlias(): Unit = {
+    val text =
+      s"""type Baz = PartialFunction[Int, String]
+         |val f: Baz = {case x => x.toString}""".stripMargin
+    checkTextHasNoErrors(text)
+  }
+
+  def testInspectionCapturesSimpleExpressionWithTypeConstraint(): Unit = {
+    val text = s"def f: Int => String = {${START}case$END x: Int => x.toString}"
+    val fixed = "def f: Int => String = { x: Int => x.toString }"
+
+    checkTextHasError(text)
+    testFix(text, fixed, hint)
+  }
+
+  def testInspectionDoesNotCaptureCaseWithTypeConstraintMoreRestrictiveThanExpectedInputType(): Unit = {
+    val text = s"def f: Any => String = {case x: Int  => x.toString}"
+
+    checkTextHasNoErrors(text)
+  }
+
+  def testInspectionCapturesCaseWithTypeConstraintLessRestrictiveThanExpectedInputType(): Unit = {
+    val text = s"def f: Int => String = {${START}case$END x: Any  => x.toString}"
+    val fixed = "def f: Int => String = { x: Any => x.toString }"
+
+    checkTextHasError(text)
+    testFix(text, fixed, hint)
+  }
+
+  def testInspectionCapturesCaseWithTypeConstraintWithTypeParameters(): Unit = {
+    val text = s"def f[T]: Option[T] => String = {${START}case$END x: Option[_]  => x.toString}"
+    val fixed = "def f[T]: Option[T] => String = { x: Option[_] => x.toString }"
+
+    checkTextHasError(text)
+    testFix(text, fixed, hint)
+  }
+
+  def testInspectionCapturesSimpleExpressionWithWildcardCase(): Unit = {
+    val text = s"""var f: Int => String = {${START}case$END _ => "foo"}"""
+    val fixed = """var f: Int => String = { _ => "foo" }"""
+    checkTextHasError(text)
+    testFix(text, fixed, hint)
+  }
+
+  def testInspectionDoesNotCaptureConstantMatchingCase(): Unit = {
+    val text = s"""def f: Int => String = {case 1 => "one"}"""
+    checkTextHasNoErrors(text)
+  }
+
+  def testInspectionDoesNotCaptureCaseWithGuard(): Unit = {
+    val text = s"""def f: Int => String = {case x if x % 2 == 0 => "one"}"""
+    checkTextHasNoErrors(text)
+  }
+
+  def testInspectionDoesNotCapturePatternMatchingCase(): Unit = {
+    val text = s"def f: Option[Int] => String = {case Some(x) => x.toString}"
+    checkTextHasNoErrors(text)
+  }
+
+  def testInspectionDoesNotCaptureMultiCaseFunction(): Unit = {
+    val text =
+      """def f: Int => String = {
+        |  case 1 => "one"
+        |  case _ => "tilt"
+        |}""".stripMargin
+    checkTextHasNoErrors(text)
+  }
+
+  def testInspectionDoesNotCaptureCaseInMatchStatement(): Unit = {
+    val text =
+      """def f: Int => String = (x: Int) => x match {
+        |  case a => "one"
+        |}""".stripMargin
+    checkTextHasNoErrors(text)
+  }
+
+  def testInspectionCapturesMethodArgument(): Unit = {
+    val text =
+      s"""def foo(bar: Int => String) = bar(42)
+         |foo{${START}case$END x => x.toString}""".stripMargin
+    val fixed = """def foo(bar: Int => String) = bar(42)
+                  |foo { x => x.toString }""".stripMargin
+    checkTextHasError(text)
+    testFix(text, fixed, hint)
+  }
+
+  def testInspectionDoesNotCaptureMethodArgumentIfItsTypeIsPartialFunction(): Unit = {
+    val text =
+      s"""def foo(bar: PartialFunction[Int, String]) = bar(42)
+          |foo{case x => x.toString}""".stripMargin
+    checkTextHasNoErrors(text)
+  }
+
+  def testInspectionDoesNotCaptureMethodArgumentIfItsTypeIsPartialFunctionAlias(): Unit = {
+    val text =
+      s"""type Baz = PartialFunction[Int, String]
+          |def foo(bar: Baz) = bar(42)
+          |foo{case x => x.toString}""".stripMargin
+    checkTextHasNoErrors(text)
+  }
+ }


### PR DESCRIPTION
It's up for discussion whether the scope of this task is complete - @pavelfatin was not very responsive recently. Some more conversions could be done in quick fix but I am not sure if they should.

Since I wanted to reuse part of ConvertToParenthesesIntention code I moved it to ScalaPsiUtils and did some cleanup, added few tests. I also reported recurring issue with hardcoded messages in YouTrack.
