### PR TITLE
Adds some useful details to CONTRIBUTING.mkdn

### DIFF
--- a/CONTRIBUTING.mkdn
+++ b/CONTRIBUTING.mkdn
@@ -19,3 +19,25 @@ You could also speed up fixing a bug by providing the following (if possible):
 We strongly recommend you to report bugs [straight to
 Youtrack](https://youtrack.jetbrains.com/newissue). This is the main place where
 we store issues. Your Github issue, most likely, will be moved there anyway.
+
+# Contributing
+
+I you haven't do so yet, read the section on [developing Scala plugin in the
+readme](https://github.com/JetBrains/intellij-scala#developing-scala-plugin).
+
+Reading the [IDEA plateform architectural
+overview](http://www.jetbrains.org/intellij/sdk/docs/basics/architectural_overview.html]
+is strongly recommended before perusing the code. Unfortunately there is no
+equivalent for the scala plugin itself at the moment but any of your questions
+are welcome on [intellij-scala gitter](https://gitter.im/JetBrains/intellij-scala)
+we will be glad to anwser them.
+
+Some guidelines for code, commits and pull requests:
+- Make sure you have a youtrack issue number before you start working.
+- Reference the youtrack issue number in your commits.
+- In the last commit of a series which fixes an issue, add a line `#SCL-XXXXX fixed` for each youtrack
+  issue which is fixed. This will close the youtrack issues automatically.
+- Try to keep commits focused to help reviewers.
+- Make sure your modifications are covered by tests.
+
+Happy coding !


### PR DESCRIPTION
Based on a post by Roman Shein in the [community
forum](https://intellij-support.jetbrains.com/hc/en-us/community/posts/206559689-Scala-plugin-roadmap-update-):
- add a link to IDEA platform architectural overview
- add a link ot intellij-scala gitter

Based on my exchanges with @niktrop on PR #329 :
- add reference to the `#SCL-XXXX fixed` trick

Propose additional commit, PR and code guidelines as found on many opensource
projects.
