### PR TITLE
Collection Inspection #SCL-9841 convert map.find(_ == k).map(_._2) to map(k)

### DIFF
--- a/resources/META-INF/scala-plugin-common.xml
+++ b/resources/META-INF/scala-plugin-common.xml
@@ -1040,8 +1040,8 @@
                          shortName="FilterSize" level="WARNING"
                          enabledByDefault="true" language="Scala"/>
         <localInspection implementationClass="org.jetbrains.plugins.scala.codeInspection.collections.FindAndMapToApplyInspection"
-                         displayName="Find and map to Map" groupPath="Scala, Collections" groupName="Simplifications: find and map to apply"
-                         shortName="FindAndMapToMap" level="WARNING"
+                         displayName="Find and map to apply" groupPath="Scala, Collections" groupName="Simplifications: find and map to apply"
+                         shortName="FindAndMapToApply" level="WARNING"
                          enabledByDefault="true" language="Scala"/>
         <localInspection implementationClass="org.jetbrains.plugins.scala.codeInspection.collections.ExistsEqualsInspection"
                          displayName="Exists simplifiable to contains" groupPath="Scala, Collections" groupName="Simplifications: filter and exists"

--- a/resources/META-INF/scala-plugin-common.xml
+++ b/resources/META-INF/scala-plugin-common.xml
@@ -1039,6 +1039,10 @@
                          displayName="Filter and size to count" groupPath="Scala, Collections" groupName="Simplifications: filter and exists"
                          shortName="FilterSize" level="WARNING"
                          enabledByDefault="true" language="Scala"/>
+        <localInspection implementationClass="org.jetbrains.plugins.scala.codeInspection.collections.FindAndMapToApplyInspection"
+                         displayName="Find and map to Map" groupPath="Scala, Collections" groupName="Simplifications: find and map to apply"
+                         shortName="FindAndMapToMap" level="WARNING"
+                         enabledByDefault="true" language="Scala"/>
         <localInspection implementationClass="org.jetbrains.plugins.scala.codeInspection.collections.ExistsEqualsInspection"
                          displayName="Exists simplifiable to contains" groupPath="Scala, Collections" groupName="Simplifications: filter and exists"
                          shortName="ExistsEquals" level="WARNING"

--- a/resources/META-INF/scala-plugin-common.xml
+++ b/resources/META-INF/scala-plugin-common.xml
@@ -1039,6 +1039,10 @@
                          displayName="Filter and size to count" groupPath="Scala, Collections" groupName="Simplifications: filter and exists"
                          shortName="FilterSize" level="WARNING"
                          enabledByDefault="true" language="Scala"/>
+        <localInspection implementationClass="org.jetbrains.plugins.scala.codeInspection.collections.FindAndMapToApplyInspection"
+                         displayName="Find and map to apply" groupPath="Scala, Collections" groupName="Simplifications: find and map to apply"
+                         shortName="FindAndMapToApply" level="WARNING"
+                         enabledByDefault="true" language="Scala"/>
         <localInspection implementationClass="org.jetbrains.plugins.scala.codeInspection.collections.ExistsEqualsInspection"
                          displayName="Exists simplifiable to contains" groupPath="Scala, Collections" groupName="Simplifications: filter and exists"
                          shortName="ExistsEquals" level="WARNING"

--- a/resources/inspectionDescriptions/FindAndMapToApply.html
+++ b/resources/inspectionDescriptions/FindAndMapToApply.html
@@ -1,0 +1,12 @@
+<html>
+<body>
+Replaces a call on a Map of find and map with apply. <br/>
+Before:
+<p><code>map.find(_ == k).map(_._2)</code></p>
+
+<p>After:</p>
+
+<p><code>map(k)</code></p>
+
+</body>
+</html>

--- a/resources/inspectionDescriptions/FindAndMapToMap.html
+++ b/resources/inspectionDescriptions/FindAndMapToMap.html
@@ -1,0 +1,12 @@
+<html>
+<body>
+Replaces a call on a Map of find and map with apply. <br/>
+Before:
+<p><code>map.find(_ == k).map(_._2)</code></p>
+
+<p>After:</p>
+
+<p><code>map(k)</code></p>
+
+</body>
+</html>

--- a/src/org/jetbrains/plugins/scala/codeInspection/collections/FindAndMapToApplyInspection.scala
+++ b/src/org/jetbrains/plugins/scala/codeInspection/collections/FindAndMapToApplyInspection.scala
@@ -1,0 +1,23 @@
+package org.jetbrains.plugins.scala.codeInspection.collections
+
+import org.jetbrains.plugins.scala.lang.psi.api.expr.ScExpression
+
+/**
+  * mattfowler
+  * 4/28/16
+  */
+class FindAndMapToApplyInspection extends OperationOnCollectionInspection {
+  override def possibleSimplificationTypes: Array[SimplificationType] = Array(FindAndMapToApply)
+}
+
+object FindAndMapToApply extends SimplificationType {
+  def hint = "Replace find and map with apply"
+
+  override def getSimplification(expr: ScExpression): Option[Simplification] = {
+    expr match {
+      case qual`.find`(underscore() `==` equalsRhsExpr)`.map`(`_._2`()) if isMap(qual) =>
+        Some(replace(expr).withText(qual.getText + argListText(Seq(equalsRhsExpr))).highlightFrom(qual))
+      case _ => None
+    }
+  }
+}

--- a/test/org/jetbrains/plugins/scala/codeInspection/collections/FindAndMapToApplyTest.scala
+++ b/test/org/jetbrains/plugins/scala/codeInspection/collections/FindAndMapToApplyTest.scala
@@ -1,0 +1,44 @@
+package org.jetbrains.plugins.scala.codeInspection.collections
+
+/**
+  * mattfowler
+  * 4/28/16
+  */
+class FindAndMapToApplyTest extends OperationsOnCollectionInspectionTest {
+
+  def test_inline_map() {
+
+    val selected = s"Map().${START}find(_ == 1).map(_._2)$END"
+
+    check(selected)
+
+    val text = "Map().find(_ == 1).map(_._2)"
+
+    val result = "Map()(1)"
+
+    testFix(text, result, hint)
+  }
+
+  def test_with_map_as_val() = {
+
+    val selected =
+      s"""val m = Map("k" -> "5", "v" -> "6")
+          m.${START}find(_ == "5").map(_._2)$END"""
+    check(selected)
+
+    val text =
+      s"""val m = Map("k" -> "5", "v" -> "6")
+          m.find(_ == "5").map(_._2)""".stripMargin
+
+    val result =
+      s"""val m = Map("k" -> "5", "v" -> "6")
+          m("5")""".stripMargin
+
+    testFix(text, result, hint)
+
+  }
+
+  override val inspectionClass = classOf[FindAndMapToApplyInspection]
+
+  override def hint: String = "Replace find and map with apply"
+}


### PR DESCRIPTION
Adds the functionality described in #SCL-9841 to convert map.find(_ == k).map(_._2) to map(k). Inspection is named "find and map to apply" but there may be a better name for this inspection.
