### PR TITLE
Inspection #SCL-9844 - Remove Redundant `new` on Case Class Instantiation

### DIFF
--- a/resources/META-INF/scala-plugin-common.xml
+++ b/resources/META-INF/scala-plugin-common.xml
@@ -707,6 +707,9 @@
         <localInspection implementationClass="org.jetbrains.plugins.scala.codeInspection.caseClassParamInspection.CaseClassParamInspection"
                          displayName="Case Class Parameter" groupPath="Scala" groupName="General" shortName="CaseClassParam"
                          id="CaseClassParam" level="WARNING" enabledByDefault="true" language="Scala"/>
+        <localInspection implementationClass="org.jetbrains.plugins.scala.codeInspection.caseClassRedundantNew.RedundantNewCaseClassInspection"
+                         displayName="Redundant New on Case Class" groupPath="Scala" groupName="General" shortName="RedundantNewCaseClass"
+                         id="RedundantNewCaseClass" level="WARNING" enabledByDefault="true" language="Scala"/>
         <localInspection implementationClass="org.jetbrains.plugins.scala.codeInspection.varCouldBeValInspection.VarCouldBeValInspection"
                          displayName="'var' could be a 'val'" groupPath="Scala" groupName="General" shortName="VarCouldBeVal"
                          level="WEAK WARNING" enabledByDefault="true" language="Scala"/>

--- a/resources/inspectionDescriptions/RedundantNewCaseClass.html
+++ b/resources/inspectionDescriptions/RedundantNewCaseClass.html
@@ -1,0 +1,2 @@
+<html><body>'new' modifier is redundant for instantiation of case classes since an apply method is automatically provided.
+</body></html>

--- a/resources/org/jetbrains/plugins/scala/ScalaBundle.properties
+++ b/resources/org/jetbrains/plugins/scala/ScalaBundle.properties
@@ -320,6 +320,7 @@ implicit.usage.tooltip=<html>\
   </html>
 implicit.usage.message=Implicit conversion ''{0}({1}): {2}'' detected.
 val.on.case.class.param.redundant='val' modifier is redundant for parameter of case class primary constructor
+new.on.case.class.instantiation.redundant='new' modifier is redundant for instantiation of case class
 suspicicious.inference=Inferred type of {0} is suspicious. If you really want this, explicitly annotate the type.
 suspicicious.newline=Newline before argument list is not inferred as a semicolon. Consider using '.' before the method name.
 constructor.invocation.expected='this' expected

--- a/src/org/jetbrains/plugins/scala/codeInspection/caseClassRedundantNew/RedundantNewCaseClassInspection.scala
+++ b/src/org/jetbrains/plugins/scala/codeInspection/caseClassRedundantNew/RedundantNewCaseClassInspection.scala
@@ -1,0 +1,92 @@
+package org.jetbrains.plugins.scala.codeInspection.caseClassRedundantNew
+
+import com.intellij.codeInspection.{ProblemHighlightType, ProblemsHolder}
+import com.intellij.psi.PsiElement
+import org.jetbrains.plugins.scala.ScalaBundle
+import org.jetbrains.plugins.scala.codeInspection.AbstractInspection
+import org.jetbrains.plugins.scala.lang.psi.api.base.{ScConstructor, ScPrimaryConstructor}
+import org.jetbrains.plugins.scala.lang.psi.api.expr.ScNewTemplateDefinition
+import org.jetbrains.plugins.scala.lang.psi.api.toplevel.templates.ScClassParents
+import org.jetbrains.plugins.scala.lang.psi.api.toplevel.typedef.ScClass
+import org.jetbrains.plugins.scala.lang.psi.types.api.designator.DesignatorOwner
+import org.jetbrains.plugins.scala.lang.psi.types.{ScParameterizedType, ScType}
+
+/**
+  * mattfowler
+  * 5/7/2016
+  */
+class RedundantNewCaseClassInspection extends AbstractInspection("RedundantNewCaseClass", "Redundant New on Case Class") {
+
+  override def actionFor(holder: ProblemsHolder): PartialFunction[PsiElement, Any] = {
+    case newTemplate: ScNewTemplateDefinition =>
+      if (hasRedundantNew(newTemplate)) {
+        holder.registerProblem(newTemplate.getFirstChild, ScalaBundle.message("new.on.case.class.instantiation.redundant"),
+          ProblemHighlightType.GENERIC_ERROR_OR_WARNING, new RemoveNewQuickFix(newTemplate))
+      }
+  }
+
+  private def hasRedundantNew(newTemplate: ScNewTemplateDefinition): Boolean = {
+    val constructor = getConstructorFromTemplate(newTemplate)
+    val maybeScType: Option[ScType] = getConstructorType(constructor)
+
+    isTypeCaseClass(maybeScType) && isCreatingSameType(newTemplate.getType().toOption, maybeScType) &&
+      constructorCallHasArgumentList(constructor) && isProblemlessPrimaryConstructor(constructor)
+  }
+
+  /**
+    * Determines if the type of the extends block is the same as the type of the new template type.
+    * This prevents us from incorrectly displaying a warning when creating anonymous classes or instances with
+    * mixin traits.
+    */
+  private def isCreatingSameType(newTemplateType: Option[ScType], extendsBlockType: Option[ScType]): Boolean = {
+    (for {
+      templateType <- newTemplateType
+      extendsType <- extendsBlockType
+    } yield {
+      templateType.equals(extendsType)
+    }).getOrElse(false)
+  }
+
+  private def getConstructorFromTemplate(newTemplate: ScNewTemplateDefinition): Option[ScConstructor] = {
+    newTemplate.extendsBlock.firstChild.flatMap {
+      case parents: ScClassParents => parents.constructor
+      case _ => None
+    }
+  }
+
+  private def getConstructorType(maybeConstructor: Option[ScConstructor]): Option[ScType] = {
+    maybeConstructor.flatMap(_.simpleTypeElement.map(_.getType().getOrNothing))
+  }
+
+  private def constructorCallHasArgumentList(maybeConstructor: Option[ScConstructor]): Boolean = {
+    maybeConstructor.flatMap(_.args).isDefined
+  }
+
+  private def isProblemlessPrimaryConstructor(maybeConstructor: Option[ScConstructor]): Boolean = {
+    (for {
+      constructor <- maybeConstructor
+      ref <- constructor.reference
+    } yield {
+      ref.advancedResolve.filter(_.problems.isEmpty)
+        .map(_.element).exists {
+        case primary: ScPrimaryConstructor => true
+        case _ => false
+      }
+    }).getOrElse(true)
+  }
+
+  private def isTypeCaseClass(maybeScType: Option[ScType]): Boolean = {
+    maybeScType.map {
+      case designatorOwner: DesignatorOwner => designatorOwner.element
+      case parameterizedType: ScParameterizedType =>
+        parameterizedType.designator match {
+          case designatorType: DesignatorOwner => designatorType.element
+          case _ => None
+        }
+      case _ => None
+    }.exists {
+      case classElement: ScClass => classElement.isCase
+      case _ => false
+    }
+  }
+}

--- a/src/org/jetbrains/plugins/scala/codeInspection/caseClassRedundantNew/RedundantNewCaseClassInspection.scala
+++ b/src/org/jetbrains/plugins/scala/codeInspection/caseClassRedundantNew/RedundantNewCaseClassInspection.scala
@@ -1,0 +1,81 @@
+package org.jetbrains.plugins.scala.codeInspection.caseClassRedundantNew
+
+import com.intellij.codeInspection.{ProblemHighlightType, ProblemsHolder}
+import com.intellij.psi.PsiElement
+import org.jetbrains.plugins.scala.ScalaBundle
+import org.jetbrains.plugins.scala.codeInspection.AbstractInspection
+import org.jetbrains.plugins.scala.lang.psi.api.base.{ScConstructor, ScPrimaryConstructor}
+import org.jetbrains.plugins.scala.lang.psi.api.expr.ScNewTemplateDefinition
+import org.jetbrains.plugins.scala.lang.psi.api.statements.ScTypeAlias
+import org.jetbrains.plugins.scala.lang.psi.api.toplevel.templates.ScClassParents
+import org.jetbrains.plugins.scala.lang.resolve.ScalaResolveResult
+
+/**
+  * mattfowler
+  * 5/7/2016
+  */
+class RedundantNewCaseClassInspection extends AbstractInspection("RedundantNewCaseClass", "Redundant New on Case Class") {
+
+  override def actionFor(holder: ProblemsHolder): PartialFunction[PsiElement, Any] = {
+    case newTemplate: ScNewTemplateDefinition =>
+      if (hasRedundantNew(newTemplate)) {
+        holder.registerProblem(newTemplate.getFirstChild, ScalaBundle.message("new.on.case.class.instantiation.redundant"),
+          ProblemHighlightType.GENERIC_ERROR_OR_WARNING, new RemoveNewQuickFix(newTemplate))
+      }
+  }
+
+  private def hasRedundantNew(newTemplate: ScNewTemplateDefinition): Boolean = {
+    val constructor = getConstructorFromTemplate(newTemplate)
+    val resolvedConstructor = resolveConstructor(constructor)
+
+    isCreatingSameType(newTemplate) && constructorCallHasArgumentList(constructor) &&
+      isProblemlessPrimaryConstructorOfCaseClass(resolvedConstructor) && !isTypeAlias(resolvedConstructor)
+  }
+
+  /**
+    * Determines if the type of the extends block is the same as the type of the new template type.
+    * This prevents us from incorrectly displaying a warning when creating anonymous classes or instances with
+    * mixin traits.
+    */
+  private def isCreatingSameType(newTemplate: ScNewTemplateDefinition): Boolean = {
+    newTemplate.extendsBlock.templateParents.exists(_.typeElementsWithoutConstructor.isEmpty)
+  }
+
+  private def isTypeAlias(maybeResolveResult: Option[ScalaResolveResult]): Boolean = {
+    maybeResolveResult.map(_.getActualElement).exists {
+      case _: ScTypeAlias => true
+      case _ => false
+    }
+  }
+
+  private def getConstructorFromTemplate(newTemplate: ScNewTemplateDefinition): Option[ScConstructor] = {
+    newTemplate.extendsBlock.firstChild.flatMap {
+      case parents: ScClassParents => parents.constructor
+      case _ => None
+    }
+  }
+
+  private def constructorCallHasArgumentList(maybeConstructor: Option[ScConstructor]): Boolean = {
+    maybeConstructor.flatMap(_.args).isDefined
+  }
+
+  private def resolveConstructor(maybeConstructor: Option[ScConstructor]): Option[ScalaResolveResult] = {
+    for {
+      constructor <- maybeConstructor
+      ref <- constructor.reference
+      resolved <- ref.advancedResolve
+    } yield {
+      resolved
+    }
+  }
+
+  private def isProblemlessPrimaryConstructorOfCaseClass(maybeResolveResult: Option[ScalaResolveResult]): Boolean = {
+    maybeResolveResult
+      .filter(_.problems.isEmpty)
+      .map(_.element)
+      .exists {
+        case ScPrimaryConstructor.ofClass(clazz) => clazz.isCase
+        case _ => false
+      }
+  }
+}

--- a/src/org/jetbrains/plugins/scala/codeInspection/caseClassRedundantNew/RemoveNewQuickFix.scala
+++ b/src/org/jetbrains/plugins/scala/codeInspection/caseClassRedundantNew/RemoveNewQuickFix.scala
@@ -1,0 +1,21 @@
+package org.jetbrains.plugins.scala.codeInspection.caseClassRedundantNew
+
+import com.intellij.openapi.project.Project
+import org.jetbrains.plugins.scala.ScalaBundle
+import org.jetbrains.plugins.scala.codeInspection.AbstractFixOnPsiElement
+import org.jetbrains.plugins.scala.lang.lexer.ScalaTokenTypes
+import org.jetbrains.plugins.scala.lang.psi.api.expr.ScNewTemplateDefinition
+import org.jetbrains.plugins.scala.lang.psi.impl.ScalaPsiElementFactory
+
+/**
+  * mattfowler
+  * 5/7/16.
+  */
+class RemoveNewQuickFix(param: ScNewTemplateDefinition) extends AbstractFixOnPsiElement(ScalaBundle.message("new.on.case.class.instantiation.redundant"), param) {
+  override def doApplyFix(project: Project): Unit = {
+    val p = getElement
+    if (!p.isValid) return
+    p.findFirstChildByType(ScalaTokenTypes.kNEW).delete()
+    p.replaceExpression(ScalaPsiElementFactory.createExpressionFromText(p.getText, p.getManager), false)
+  }
+}

--- a/src/org/jetbrains/plugins/scala/codeInspection/caseClassRedundantNew/RemoveNewQuickFix.scala
+++ b/src/org/jetbrains/plugins/scala/codeInspection/caseClassRedundantNew/RemoveNewQuickFix.scala
@@ -1,0 +1,21 @@
+package org.jetbrains.plugins.scala.codeInspection.caseClassRedundantNew
+
+import com.intellij.openapi.project.Project
+import org.jetbrains.plugins.scala.ScalaBundle
+import org.jetbrains.plugins.scala.codeInspection.AbstractFixOnPsiElement
+import org.jetbrains.plugins.scala.lang.lexer.ScalaTokenTypes
+import org.jetbrains.plugins.scala.lang.psi.api.expr.ScNewTemplateDefinition
+import org.jetbrains.plugins.scala.lang.psi.impl.ScalaPsiElementFactory
+
+/**
+  * mattfowler
+  * 5/7/16.
+  */
+class RemoveNewQuickFix(param: ScNewTemplateDefinition) extends AbstractFixOnPsiElement(ScalaBundle.message("new.on.case.class.instantiation.redundant"), param) {
+  override def doApplyFix(project: Project): Unit = {
+    val p = getElement
+    if (!p.isValid) return
+    param.findFirstChildByType(ScalaTokenTypes.kNEW).delete()
+    param.replaceExpression(ScalaPsiElementFactory.createExpressionFromText(param.getText, p.getManager), false)
+  }
+}

--- a/src/org/jetbrains/plugins/scala/codeInspection/caseClassRedundantNew/RemoveNewQuickFix.scala
+++ b/src/org/jetbrains/plugins/scala/codeInspection/caseClassRedundantNew/RemoveNewQuickFix.scala
@@ -15,7 +15,7 @@ class RemoveNewQuickFix(param: ScNewTemplateDefinition) extends AbstractFixOnPsi
   override def doApplyFix(project: Project): Unit = {
     val p = getElement
     if (!p.isValid) return
-    param.findFirstChildByType(ScalaTokenTypes.kNEW).delete()
-    param.replaceExpression(ScalaPsiElementFactory.createExpressionFromText(param.getText, p.getManager), false)
+    p.findFirstChildByType(ScalaTokenTypes.kNEW).delete()
+    p.replaceExpression(ScalaPsiElementFactory.createExpressionFromText(param.getText, p.getManager), false)
   }
 }

--- a/test/org/jetbrains/plugins/scala/codeInspection/caseClasses/RedundantNewCaseClassInspectionTest.scala
+++ b/test/org/jetbrains/plugins/scala/codeInspection/caseClasses/RedundantNewCaseClassInspectionTest.scala
@@ -1,0 +1,202 @@
+package org.jetbrains.plugins.scala.codeInspection.caseClasses
+
+import com.intellij.codeInspection.LocalInspectionTool
+import org.jetbrains.plugins.scala.ScalaBundle
+import org.jetbrains.plugins.scala.codeInspection.ScalaLightInspectionFixtureTestAdapter
+import org.jetbrains.plugins.scala.codeInspection.caseClassRedundantNew.RedundantNewCaseClassInspection
+
+/**
+  * mattfowler
+  * 5/7/2016
+  */
+class RedundantNewCaseClassInspectionTest extends ScalaLightInspectionFixtureTestAdapter {
+  override protected def annotation: String = ScalaBundle.message("new.on.case.class.instantiation.redundant")
+
+  override protected def classOfInspection: Class[_ <: LocalInspectionTool] = classOf[RedundantNewCaseClassInspection]
+
+  def testSimpleCaseClass(): Unit = {
+    val program =
+      s"""
+         |case class A(x: Int)
+         |val a = ${START}new$END A(5)
+     """.stripMargin
+
+    val expected =
+      s"""
+         |case class A(x: Int)
+         |val a = A(5)
+       """.stripMargin
+
+    check(program)
+
+    testFix(program, expected, annotation)
+  }
+
+  def testGenericCaseClass(): Unit = {
+    val program =
+      s"""
+         |case class A[T](x: T)
+         |val a = ${START}new$END A(5)
+     """
+
+    val expected =
+      s"""
+         |case class A[T](x: T)
+         |val a = A(5)
+       """.stripMargin
+
+    check(program.stripMargin)
+
+    testFix(program, expected, annotation)
+  }
+
+  def testNestedCaseClasses(): Unit = {
+    val program =
+      s"""
+         |abstract class List
+         |case class Node (value: Int, next: List) extends List
+         |object Empty extends List
+         |
+         |${START}new$END Node(1, new Node(2, Empty))
+          """.stripMargin
+
+    check(program)
+
+    val expected =
+      s"""
+         |abstract class List
+         |case class Node (value: Int, next: List) extends List
+         |object Empty extends List
+         |
+         |Node(1, new Node(2, Empty))
+          """.stripMargin
+
+    testFix(program, expected, annotation)
+  }
+
+  def testNestedCaseClassesWithNewNested(): Unit = {
+    val program =
+      s"""
+         |abstract class List
+         |case class Node (value: Int, next: List) extends List
+         |object Empty extends List
+         |
+         |Node(1, ${START}new$END Node(2, Empty))
+          """.stripMargin
+
+    check(program)
+
+    val expected =
+      s"""
+         |abstract class List
+         |case class Node (value: Int, next: List) extends List
+         |object Empty extends List
+         |
+         |Node(1, Node(2, Empty))
+          """.stripMargin
+
+    testFix(program, expected, annotation)
+  }
+
+  def testOverriddenApplyMethod(): Unit = {
+    val program =
+      s"""
+         |case class C(a: Int, x: String = "default")
+         |object C { def apply(a: Int): C = C(a, "xxx") }
+         |
+         |${START}new$END C(0)
+       """.stripMargin
+
+    check(program)
+
+    val expected =
+      s"""
+         |case class C(a: Int, x: String = "default")
+         |object C { def apply(a: Int): C = C(a, "xxx") }
+         |
+         |C(0)
+       """.stripMargin
+
+    testFix(program, expected, annotation)
+  }
+
+  def testCaseClassWithNormalClassNestedHasNoErrors(): Unit = checkTextHasNoErrors(
+    s"""
+       |class B()
+       |case class A(b: B)
+       |
+       |A(new B())
+     """.stripMargin)
+
+  def testSimpleNormalClassHasNoErrors(): Unit = checkTextHasNoErrors(
+    s"""class A(x: Int)
+        |val a = new A(5)
+     """.stripMargin)
+
+  def testCreationWithMixinTraitHasNoErrors(): Unit = checkTextHasNoErrors(
+    s"""
+       |case class A()
+       |
+       |trait B {
+       |  def method: Int = 1
+       |}
+       |
+       |val a = new A() with B
+     """.stripMargin
+  )
+
+  def testAnonymousCaseClassCreationHasNoErrors(): Unit = checkTextHasNoErrors(
+    s"""
+       |absract case class A() {
+       |  def b(): Int
+       |}
+       |
+       |val a = new A {
+       |  override def b: Int = 2
+       |}
+     """.stripMargin
+  )
+
+  def testTraitCreationHasNoErrors(): Unit = checkTextHasNoErrors(
+    s"""
+       |trait A() {
+       |  def b(): Int
+       |}
+       |
+       |val a = new A {
+       |  override def b: Int = 2
+       |}
+     """.stripMargin
+  )
+
+  def testCallingNonApplyMethodHasNoErrors(): Unit = checkTextHasNoErrors(
+    s"""
+       |case class Foo(x: Int, y: Int) {
+       |def this(x: Int) = this(x, 0)
+       |}
+       |
+       |val a = new Foo(1)""")
+
+  def testShouldNotShowIfProblemsExistInConstructorCall(): Unit = checkTextHasNoErrors(
+    s"""
+       |case class Foo(x: Long)
+       |val a = new Foo("z")
+     """.stripMargin
+  )
+
+  def testShouldNotShowIfNoArgumentListInCall(): Unit = checkTextHasNoErrors(
+    s"""
+       |case class Foo()
+       |val f = new Foo
+     """.stripMargin
+  )
+
+  def testShouldNotShowIfCallingTypeAlias(): Unit = checkTextHasNoErrors(
+    s"""
+       |case class Foo()
+       |type A = Foo
+       |val f = new A()
+     """.stripMargin
+  )
+
+}

--- a/test/org/jetbrains/plugins/scala/codeInspection/caseClasses/RedundantNewCaseClassInspectionTest.scala
+++ b/test/org/jetbrains/plugins/scala/codeInspection/caseClasses/RedundantNewCaseClassInspectionTest.scala
@@ -1,0 +1,172 @@
+package org.jetbrains.plugins.scala.codeInspection.caseClasses
+
+import com.intellij.codeInspection.LocalInspectionTool
+import org.jetbrains.plugins.scala.ScalaBundle
+import org.jetbrains.plugins.scala.codeInspection.ScalaLightInspectionFixtureTestAdapter
+import org.jetbrains.plugins.scala.codeInspection.caseClassRedundantNew.RedundantNewCaseClassInspection
+
+/**
+  * mattfowler
+  * 5/7/2016
+  */
+class RedundantNewCaseClassInspectionTest extends ScalaLightInspectionFixtureTestAdapter {
+  override protected def annotation: String = ScalaBundle.message("new.on.case.class.instantiation.redundant")
+
+  override protected def classOfInspection: Class[_ <: LocalInspectionTool] = classOf[RedundantNewCaseClassInspection]
+
+  def testSimpleCaseClass(): Unit = {
+    val program =
+      s"""
+         |case class A(x: Int)
+         |val a = ${START}new$END A(5)
+     """.stripMargin
+
+    val expected =
+      s"""
+         |case class A(x: Int)
+         |val a = A(5)
+       """.stripMargin
+
+    check(program)
+
+    testFix(program, expected, annotation)
+  }
+
+  def testGenericCaseClass(): Unit = {
+    val program =
+      s"""
+         |case class A[T](x: T)
+         |val a = ${START}new$END A(5)
+     """
+
+    val expected =
+      s"""
+         |case class A[T](x: T)
+         |val a = A(5)
+       """.stripMargin
+
+    check(program.stripMargin)
+
+    testFix(program, expected, annotation)
+  }
+
+  def testNestedCaseClasses(): Unit = {
+    val program =
+      s"""
+         |abstract class List
+         |case class Node (value: Int, next: List) extends List
+         |object Empty extends List
+         |
+         |${START}new$END Node(1, new Node(2, Empty))
+          """.stripMargin
+
+    check(program)
+
+    val expected =
+      s"""
+         |abstract class List
+         |case class Node (value: Int, next: List) extends List
+         |object Empty extends List
+         |
+         |Node(1, new Node(2, Empty))
+          """.stripMargin
+
+    testFix(program, expected, annotation)
+  }
+
+  def testNestedCaseClassesWithNewNested(): Unit = {
+    val program =
+      s"""
+         |abstract class List
+         |case class Node (value: Int, next: List) extends List
+         |object Empty extends List
+         |
+         |Node(1, ${START}new$END Node(2, Empty))
+          """.stripMargin
+
+    check(program)
+
+    val expected =
+      s"""
+         |abstract class List
+         |case class Node (value: Int, next: List) extends List
+         |object Empty extends List
+         |
+         |Node(1, Node(2, Empty))
+          """.stripMargin
+
+    testFix(program, expected, annotation)
+  }
+
+  def testCaseClassWithNormalClassNestedHasNoErrors(): Unit = checkTextHasNoErrors(
+    s"""
+       |class B()
+       |case class A(b: B)
+       |
+       |A(new B())
+     """.stripMargin)
+
+  def testSimpleNormalClassHasNoErrors(): Unit = checkTextHasNoErrors(
+    s"""class A(x: Int)
+        |val a = new A(5)
+     """.stripMargin)
+
+  def testCreationWithMixinTraitHasNoErrors(): Unit = checkTextHasNoErrors(
+    s"""
+       |case class A()
+       |
+       |trait B {
+       |  def method: Int = 1
+       |}
+       |
+       |val a = new A() with B
+     """.stripMargin
+  )
+
+  def testAnonymousCaseClassCreationHasNoErrors(): Unit = checkTextHasNoErrors(
+    s"""
+       |absract case class A() {
+       |  def b(): Int
+       |}
+       |
+       |val a = new A {
+       |  override def b: Int = 2
+       |}
+     """.stripMargin
+  )
+
+  def testTraitCreationHasNoErrors(): Unit = checkTextHasNoErrors(
+    s"""
+       |trait A() {
+       |  def b(): Int
+       |}
+       |
+        |val a = new A {
+       |  override def b: Int = 2
+       |}
+     """.stripMargin
+  )
+
+  def testCallingNonApplyMethodHasNoErrors(): Unit = checkTextHasNoErrors(
+    s"""
+       |case class Foo(x: Int, y: Int) {
+       |def this(x: Int) = this(x, 0)
+       |}
+       |
+       |val a = new Foo(1)""")
+
+  def testShouldNotShowIfProblemsExistInConstructorCall(): Unit = checkTextHasNoErrors(
+    s"""
+       |case class Foo(x: Long)
+       |val a = new Foo("z")
+     """.stripMargin
+  )
+
+  def testShouldNotShowIfNoArgumentListInCall(): Unit = checkTextHasNoErrors(
+    s"""
+       |case class Foo()
+       |val f = new Foo
+     """.stripMargin
+  )
+
+}

--- a/test/org/jetbrains/plugins/scala/codeInspection/caseClasses/RedundantNewCaseClassInspectionTest.scala
+++ b/test/org/jetbrains/plugins/scala/codeInspection/caseClasses/RedundantNewCaseClassInspectionTest.scala
@@ -98,6 +98,28 @@ class RedundantNewCaseClassInspectionTest extends ScalaLightInspectionFixtureTes
     testFix(program, expected, annotation)
   }
 
+  def testOverriddenApplyMethod(): Unit = {
+    val program =
+      s"""
+         |case class C(a: Int, x: String = "default")
+         |object C { def apply(a: Int): C = C(a, "xxx") }
+         |
+         |${START}new$END C(0)
+       """.stripMargin
+
+    check(program)
+
+    val expected =
+      s"""
+         |case class C(a: Int, x: String = "default")
+         |object C { def apply(a: Int): C = C(a, "xxx") }
+         |
+         |C(0)
+       """.stripMargin
+
+    testFix(program, expected, annotation)
+  }
+
   def testCaseClassWithNormalClassNestedHasNoErrors(): Unit = checkTextHasNoErrors(
     s"""
        |class B()
@@ -141,7 +163,7 @@ class RedundantNewCaseClassInspectionTest extends ScalaLightInspectionFixtureTes
        |  def b(): Int
        |}
        |
-        |val a = new A {
+       |val a = new A {
        |  override def b: Int = 2
        |}
      """.stripMargin
@@ -166,6 +188,14 @@ class RedundantNewCaseClassInspectionTest extends ScalaLightInspectionFixtureTes
     s"""
        |case class Foo()
        |val f = new Foo
+     """.stripMargin
+  )
+
+  def testShouldNotShowIfCallingTypeAlias(): Unit = checkTextHasNoErrors(
+    s"""
+       |case class Foo()
+       |type A = Foo
+       |val f = new A()
      """.stripMargin
   )
 


### PR DESCRIPTION
Adds an inspection to remove a redundant new on case class instantiation. 

There's a few corner cases in this (see unit tests), I believe I've got them all.  If there's any more you can think of I'm happy to take a look given a failing test case.
