### PR TITLE
New intention to regenerate type annotation for var/val/def

### DIFF
--- a/resources/META-INF/scala-plugin-common.xml
+++ b/resources/META-INF/scala-plugin-common.xml
@@ -414,6 +414,11 @@
 
         <intentionAction>
             <category>Scala/Type</category>
+            <className>org.jetbrains.plugins.scala.codeInsight.intention.types.RegenerateTypeAnnotation</className>
+        </intentionAction>
+
+        <intentionAction>
+            <category>Scala/Type</category>
             <className>org.jetbrains.plugins.scala.codeInsight.intention.types.MakeTypeMoreSpecificIntention</className>
         </intentionAction>
 

--- a/resources/intentionDescriptions/RegenerateTypeAnnotation/after.scala.template
+++ b/resources/intentionDescriptions/RegenerateTypeAnnotation/after.scala.template
@@ -1,0 +1,3 @@
+var actuallyChar: <spot>Char</spot> = 'a'
+val actuallInt: <spot>Int</spot> = 42
+def actuallyString: <spot>String</spot> = "hello world"

--- a/resources/intentionDescriptions/RegenerateTypeAnnotation/before.scala.template
+++ b/resources/intentionDescriptions/RegenerateTypeAnnotation/before.scala.template
@@ -1,0 +1,3 @@
+var actuallyChar: <spot>Int</spot> = 'a'
+val actuallInt: <spot>Char</spot> = 42
+def actuallyString: <spot>Double</spot> = "hello world"

--- a/resources/intentionDescriptions/RegenerateTypeAnnotation/description.html
+++ b/resources/intentionDescriptions/RegenerateTypeAnnotation/description.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+Removes the type annotation and adds the newly inferred one.
+</body>
+</html>

--- a/resources/org/jetbrains/plugins/scala/ScalaBundle.properties
+++ b/resources/org/jetbrains/plugins/scala/ScalaBundle.properties
@@ -561,14 +561,19 @@ type.info=Type Info
 
 intention.type.annotation.toggle.family=Toggle Type Annotation
 
+intention.type.annotation.regen.family=Regenerate Type Annotation
+
 intention.type.annotation.function.add.text=Add type annotation to function definition
 intention.type.annotation.function.remove.text=Remove type annotation from function definition
+intention.type.annotation.function.regenerate.text=Regenerate type annotation for function definition
 
 intention.type.annotation.value.add.text=Add type annotation to value definition
 intention.type.annotation.value.remove.text=Remove type annotation from value definition
+intention.type.annotation.value.regenerate.text=Regenerate type annotation for value definition
 
 intention.type.annotation.variable.add.text=Add type annotation to variable definition
 intention.type.annotation.variable.remove.text=Remove type annotation from variable definition
+intention.type.annotation.variable.regenerate.text=Regenerate type annotation for variable definition
 
 intention.type.annotation.pattern.add.text=Add type annotation to pattern definition
 intention.type.annotation.pattern.remove.text=Remove type annotation from pattern definition

--- a/src/org/jetbrains/plugins/scala/codeInsight/intention/types/Description.scala
+++ b/src/org/jetbrains/plugins/scala/codeInsight/intention/types/Description.scala
@@ -17,6 +17,9 @@ class Description(message: String => Unit) extends Strategy {
     message("intention.type.annotation.function.remove.text")
   }
 
+  override def redoFromFunction(function: ScFunctionDefinition): Unit =
+    message("intention.type.annotation.function.regenerate.text")
+
   def addToValue(value: ScPatternDefinition) {
     message("intention.type.annotation.value.add.text")
   }
@@ -25,6 +28,9 @@ class Description(message: String => Unit) extends Strategy {
     message("intention.type.annotation.value.remove.text")
   }
 
+  override def redoFromValue(value: ScPatternDefinition): Unit =
+    message("intention.type.annotation.value.regenerate.text")
+
   def addToVariable(variable: ScVariableDefinition) {
     message("intention.type.annotation.variable.add.text")
   }
@@ -32,6 +38,9 @@ class Description(message: String => Unit) extends Strategy {
   def removeFromVariable(variable: ScVariableDefinition) {
     message("intention.type.annotation.variable.remove.text")
   }
+
+  override def redoFromVariable(variable: ScVariableDefinition): Unit =
+    message("intention.type.annotation.variable.regenerate.text")
 
   def addToPattern(pattern: ScBindingPattern) {
     message("intention.type.annotation.pattern.add.text")

--- a/src/org/jetbrains/plugins/scala/codeInsight/intention/types/MakeTypeMoreSpecificIntention.scala
+++ b/src/org/jetbrains/plugins/scala/codeInsight/intention/types/MakeTypeMoreSpecificIntention.scala
@@ -37,7 +37,7 @@ class MakeTypeMoreSpecificIntention extends PsiElementBaseIntentionAction {
       }
       implicit val typeSystem = project.typeSystem
       val desc = new StrategyAdapter {
-        override def removeFromVariable(variable: ScVariableDefinition): Unit = {
+        override def variableWithType(variable: ScVariableDefinition): Unit = {
           for {
             declared <- variable.declaredType
             expr <- variable.expr
@@ -46,7 +46,7 @@ class MakeTypeMoreSpecificIntention extends PsiElementBaseIntentionAction {
           } text(ScalaBundle.message("make.type.more.specific"))
         }
 
-        override def removeFromValue(value: ScPatternDefinition): Unit = {
+        override def valueWithType(value: ScPatternDefinition): Unit = {
           for {
             declared <- value.declaredType
             expr <- value.expr
@@ -55,7 +55,7 @@ class MakeTypeMoreSpecificIntention extends PsiElementBaseIntentionAction {
           } text(ScalaBundle.message("make.type.more.specific"))
         }
 
-        override def removeFromFunction(function: ScFunctionDefinition): Unit = {
+        override def functionWithType(function: ScFunctionDefinition): Unit = {
           for {
             declared <- function.returnType
             expr <- function.body
@@ -90,7 +90,7 @@ class MakeTypeMoreSpecificStrategy(editor: Option[Editor])
   }
 
 
-  override def removeFromFunction(function: ScFunctionDefinition): Unit = {
+  override def functionWithType(function: ScFunctionDefinition): Unit = {
     for {
       edit <- editor
       te <- function.returnTypeElement
@@ -100,7 +100,7 @@ class MakeTypeMoreSpecificStrategy(editor: Option[Editor])
     } doTemplate(te, declared, tp, function.getParent, edit)
   }
 
-  override def removeFromValue(value: ScPatternDefinition): Unit = {
+  override def valueWithType(value: ScPatternDefinition): Unit = {
     for {
       edit <- editor
       te <- value.typeElement
@@ -110,7 +110,7 @@ class MakeTypeMoreSpecificStrategy(editor: Option[Editor])
     } doTemplate(te, declared, tp, value.getParent, edit)
   }
 
-  override def removeFromVariable(variable: ScVariableDefinition): Unit = {
+  override def variableWithType(variable: ScVariableDefinition): Unit = {
     for {
       edit <- editor
       te <- variable.typeElement
@@ -120,21 +120,21 @@ class MakeTypeMoreSpecificStrategy(editor: Option[Editor])
     } doTemplate(te, declared, tp, variable.getParent, edit)
   }
 
-  override def addToPattern(pattern: ScBindingPattern): Unit = ()
+  override def patternWithoutType(pattern: ScBindingPattern): Unit = ()
 
-  override def addToWildcardPattern(pattern: ScWildcardPattern): Unit = ()
+  override def wildcardPatternWithoutType(pattern: ScWildcardPattern): Unit = ()
 
-  override def addToValue(value: ScPatternDefinition): Unit = ()
+  override def valueWithoutType(value: ScPatternDefinition): Unit = ()
 
-  override def addToFunction(function: ScFunctionDefinition): Unit = ()
+  override def functionWithoutType(function: ScFunctionDefinition): Unit = ()
 
-  override def removeFromPattern(pattern: ScTypedPattern): Unit = ()
+  override def patternWithType(pattern: ScTypedPattern): Unit = ()
 
-  override def addToVariable(variable: ScVariableDefinition): Unit = ()
+  override def variableWithoutType(variable: ScVariableDefinition): Unit = ()
 
-  override def removeFromParameter(param: ScParameter): Unit = ()
+  override def parameterWithType(param: ScParameter): Unit = ()
 
-  override def addToParameter(param: ScParameter): Unit = ()
+  override def parameterWithoutType(param: ScParameter): Unit = ()
 }
 
 object MakeTypeMoreSpecificStrategy {

--- a/src/org/jetbrains/plugins/scala/codeInsight/intention/types/RegenerateTypeAnnotation.scala
+++ b/src/org/jetbrains/plugins/scala/codeInsight/intention/types/RegenerateTypeAnnotation.scala
@@ -1,0 +1,98 @@
+package org.jetbrains.plugins.scala
+package codeInsight.intention.types
+
+import com.intellij.codeInsight.intention.PsiElementBaseIntentionAction
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import org.jetbrains.plugins.scala.extensions._
+import org.jetbrains.plugins.scala.lang.psi.api.base.types.ScTypeElement
+import org.jetbrains.plugins.scala.lang.psi.api.statements._
+import org.jetbrains.plugins.scala.lang.psi.types.api.TypeSystem
+import org.jetbrains.plugins.scala.project.ProjectExt
+import org.jetbrains.plugins.scala.util.IntentionAvailabilityChecker
+
+class RegenerateTypeAnnotation extends PsiElementBaseIntentionAction {
+  import RegenerateTypeAnnotation._
+
+  def getFamilyName = RegenerateTypeAnnotation.getFamilyName
+
+  def isAvailable(project: Project, editor: Editor, element: PsiElement) = {
+    if (element == null || !IntentionAvailabilityChecker.checkIntention(this, element)) {
+      false
+    } else {
+      def message(key: String) {
+        setText(ScalaBundle.message(key))
+      }
+      implicit val typeSystem = project.typeSystem
+
+      getTypeAnnotation(element).isDefined &&
+        complete(new Description(message), element)
+    }
+  }
+
+  override def invoke(project: Project, editor: Editor, element: PsiElement): Unit = {
+    complete(new AddOrRemoveStrategy(Option(editor)), element)(project.typeSystem)
+  }
+}
+
+object RegenerateTypeAnnotation {
+  def getFamilyName = ScalaBundle.message("intention.type.annotation.regen.family")
+
+  def complete(strategy: Strategy, element: PsiElement)(implicit typeSystem: TypeSystem): Boolean = {
+    for {function <- element.parentsInFile.findByType(classOf[ScFunctionDefinition])
+         if function.hasAssign
+         body <- function.body
+         if !body.isAncestorOf(element)} {
+
+      strategy.redoFromFunction(function)
+
+      return true
+    }
+
+    for {value <- element.parentsInFile.findByType(classOf[ScPatternDefinition])
+         if value.expr.forall(!_.isAncestorOf(element))
+         if value.pList.allPatternsSimple
+         bindings = value.bindings
+         if bindings.size == 1
+         binding <- bindings} {
+
+      strategy.redoFromValue(value)
+
+      return true
+    }
+
+    for {variable <- element.parentsInFile.findByType(classOf[ScVariableDefinition])
+         if variable.expr.forall(!_.isAncestorOf(element))
+         if variable.pList.allPatternsSimple
+         bindings = variable.bindings
+         if bindings.size == 1
+         binding <- bindings} {
+
+      strategy.redoFromVariable(variable)
+
+      return true
+    }
+
+    false
+  }
+
+  private def getTypeAnnotation(element: PsiElement)
+                               (implicit typeSystem: TypeSystem): Option[ScTypeElement] = {
+    def funType: Option[ScTypeElement] = for {
+      function <- element.parentsInFile.findByType(classOf[ScFunctionDefinition])
+      if function.hasAssign
+      body <- function.body
+      if !body.isAncestorOf(element)
+      r <- function.returnTypeElement
+    } yield r
+
+    def valType: Option[ScTypeElement] =
+      element.parentsInFile.findByType(classOf[ScPatternDefinition]).flatMap(_.typeElement)
+
+    def varType: Option[ScTypeElement] =
+      element.parentsInFile.findByType(classOf[ScVariableDefinition]).flatMap(_.typeElement)
+
+    funType orElse valType orElse varType
+  }
+}

--- a/src/org/jetbrains/plugins/scala/codeInsight/intention/types/RegenerateTypeAnnotationDescription.scala
+++ b/src/org/jetbrains/plugins/scala/codeInsight/intention/types/RegenerateTypeAnnotationDescription.scala
@@ -1,0 +1,18 @@
+package org.jetbrains.plugins.scala.codeInsight.intention.types
+
+import org.jetbrains.plugins.scala.lang.psi.api.statements.{ScFunctionDefinition, ScPatternDefinition, ScVariableDefinition}
+
+/**
+  * Markus.Hauck, 18.05.2016
+  */
+
+class RegenerateTypeAnnotationDescription(message: String => Unit) extends StrategyAdapter {
+  override def functionWithType(function: ScFunctionDefinition): Unit =
+    message("intention.type.annotation.function.regenerate.text")
+
+  override def variableWithType(variable: ScVariableDefinition): Unit =
+    message("intention.type.annotation.variable.regenerate.text")
+
+  override def valueWithType(value: ScPatternDefinition): Unit =
+    message("intention.type.annotation.value.regenerate.text")
+}

--- a/src/org/jetbrains/plugins/scala/codeInsight/intention/types/Strategy.scala
+++ b/src/org/jetbrains/plugins/scala/codeInsight/intention/types/Strategy.scala
@@ -13,13 +13,28 @@ trait Strategy {
 
   def removeFromFunction(function: ScFunctionDefinition)
 
+  def redoFromFunction(function: ScFunctionDefinition) = {
+    removeFromFunction(function)
+    addToFunction(function)
+  }
+
   def addToValue(value: ScPatternDefinition)
 
   def removeFromValue(value: ScPatternDefinition)
 
+  def redoFromValue(value: ScPatternDefinition) = {
+    removeFromValue(value)
+    addToValue(value)
+  }
+
   def addToVariable(variable: ScVariableDefinition)
 
   def removeFromVariable(variable: ScVariableDefinition)
+
+  def redoFromVariable(variable: ScVariableDefinition) = {
+    removeFromVariable(variable)
+    addToVariable(variable)
+  }
 
   def addToPattern(pattern: ScBindingPattern)
 

--- a/src/org/jetbrains/plugins/scala/codeInsight/intention/types/Strategy.scala
+++ b/src/org/jetbrains/plugins/scala/codeInsight/intention/types/Strategy.scala
@@ -9,40 +9,25 @@ import org.jetbrains.plugins.scala.lang.psi.api.statements.{ScFunctionDefinition
  */
 
 trait Strategy {
-  def addToFunction(function: ScFunctionDefinition)
+  def functionWithoutType(function: ScFunctionDefinition)
 
-  def removeFromFunction(function: ScFunctionDefinition)
+  def functionWithType(function: ScFunctionDefinition)
 
-  def redoFromFunction(function: ScFunctionDefinition) = {
-    removeFromFunction(function)
-    addToFunction(function)
-  }
+  def valueWithoutType(value: ScPatternDefinition)
 
-  def addToValue(value: ScPatternDefinition)
+  def valueWithType(value: ScPatternDefinition)
 
-  def removeFromValue(value: ScPatternDefinition)
+  def variableWithoutType(variable: ScVariableDefinition)
 
-  def redoFromValue(value: ScPatternDefinition) = {
-    removeFromValue(value)
-    addToValue(value)
-  }
+  def variableWithType(variable: ScVariableDefinition)
 
-  def addToVariable(variable: ScVariableDefinition)
+  def patternWithoutType(pattern: ScBindingPattern)
 
-  def removeFromVariable(variable: ScVariableDefinition)
+  def wildcardPatternWithoutType(pattern: ScWildcardPattern)
 
-  def redoFromVariable(variable: ScVariableDefinition) = {
-    removeFromVariable(variable)
-    addToVariable(variable)
-  }
+  def patternWithType(pattern: ScTypedPattern)
 
-  def addToPattern(pattern: ScBindingPattern)
+  def parameterWithoutType(param: ScParameter)
 
-  def addToWildcardPattern(pattern: ScWildcardPattern)
-
-  def removeFromPattern(pattern: ScTypedPattern)
-
-  def addToParameter(param: ScParameter)
-
-  def removeFromParameter(param: ScParameter)
+  def parameterWithType(param: ScParameter)
 }

--- a/src/org/jetbrains/plugins/scala/codeInsight/intention/types/ToggleTypeAnnotation.scala
+++ b/src/org/jetbrains/plugins/scala/codeInsight/intention/types/ToggleTypeAnnotation.scala
@@ -29,7 +29,7 @@ class ToggleTypeAnnotation extends PsiElementBaseIntentionAction {
         setText(ScalaBundle.message(key))
       }
       implicit val typeSystem = project.typeSystem
-      ToggleTypeAnnotation.complete(new Description(message), element)
+      ToggleTypeAnnotation.complete(new ToggleTypeAnnotationDescription(message), element)
     }
   }
 
@@ -48,9 +48,9 @@ object ToggleTypeAnnotation {
          if !body.isAncestorOf(element)} {
 
       if (function.returnTypeElement.isDefined)
-        strategy.removeFromFunction(function)
+        strategy.functionWithType(function)
       else
-        strategy.addToFunction(function)
+        strategy.functionWithoutType(function)
 
       return true
     }
@@ -63,9 +63,9 @@ object ToggleTypeAnnotation {
          binding <- bindings} {
 
       if (value.typeElement.isDefined)
-        strategy.removeFromValue(value)
+        strategy.valueWithType(value)
       else
-        strategy.addToValue(value)
+        strategy.valueWithoutType(value)
 
       return true
     }
@@ -78,9 +78,9 @@ object ToggleTypeAnnotation {
          binding <- bindings} {
 
       if (variable.typeElement.isDefined)
-        strategy.removeFromVariable(variable)
+        strategy.variableWithType(variable)
       else
-        strategy.addToVariable(variable)
+        strategy.variableWithoutType(variable)
 
       return true
     }
@@ -91,14 +91,14 @@ object ToggleTypeAnnotation {
       param.parentsInFile.findByType(classOf[ScFunctionExpr]) match {
         case Some(func) =>
           if (param.typeElement.isDefined) {
-            strategy.removeFromParameter(param)
+            strategy.parameterWithType(param)
             return true
           } else {
             val index = func.parameters.indexOf(param)
             func.expectedType() match {
               case Some(FunctionType(_, params)) =>
                 if (index >= 0 && index < params.length) {
-                  strategy.addToParameter(param)
+                  strategy.parameterWithoutType(param)
                   return true
                 }
               case _ =>
@@ -111,16 +111,16 @@ object ToggleTypeAnnotation {
     for (pattern <- element.parentsInFile.findByType(classOf[ScBindingPattern])) {
       pattern match {
         case p: ScTypedPattern if p.typePattern.isDefined =>
-          strategy.removeFromPattern(p)
+          strategy.patternWithType(p)
           return true
         case _: ScReferencePattern =>
-          strategy.addToPattern(pattern)
+          strategy.patternWithoutType(pattern)
           return true
         case _ =>
       }
     }
     for (pattern <- element.parentsInFile.findByType(classOf[ScWildcardPattern])) {
-      strategy.addToWildcardPattern(pattern)
+      strategy.wildcardPatternWithoutType(pattern)
       return true
     }
 

--- a/src/org/jetbrains/plugins/scala/codeInsight/intention/types/ToggleTypeAnnotationDescription.scala
+++ b/src/org/jetbrains/plugins/scala/codeInsight/intention/types/ToggleTypeAnnotationDescription.scala
@@ -8,57 +8,48 @@ import org.jetbrains.plugins.scala.lang.psi.api.statements.{ScFunctionDefinition
  * Pavel.Fatin, 28.04.2010
  */
 
-class Description(message: String => Unit) extends Strategy {
-  def addToFunction(function: ScFunctionDefinition) {
+class ToggleTypeAnnotationDescription(message: String => Unit) extends Strategy {
+  def functionWithoutType(function: ScFunctionDefinition) {
     message("intention.type.annotation.function.add.text")
   }
 
-  def removeFromFunction(function: ScFunctionDefinition) {
+  def functionWithType(function: ScFunctionDefinition) {
     message("intention.type.annotation.function.remove.text")
   }
 
-  override def redoFromFunction(function: ScFunctionDefinition): Unit =
-    message("intention.type.annotation.function.regenerate.text")
-
-  def addToValue(value: ScPatternDefinition) {
+  def valueWithoutType(value: ScPatternDefinition) {
     message("intention.type.annotation.value.add.text")
   }
 
-  def removeFromValue(value: ScPatternDefinition) {
+  def valueWithType(value: ScPatternDefinition) {
     message("intention.type.annotation.value.remove.text")
   }
 
-  override def redoFromValue(value: ScPatternDefinition): Unit =
-    message("intention.type.annotation.value.regenerate.text")
-
-  def addToVariable(variable: ScVariableDefinition) {
+  def variableWithoutType(variable: ScVariableDefinition) {
     message("intention.type.annotation.variable.add.text")
   }
 
-  def removeFromVariable(variable: ScVariableDefinition) {
+  def variableWithType(variable: ScVariableDefinition) {
     message("intention.type.annotation.variable.remove.text")
   }
 
-  override def redoFromVariable(variable: ScVariableDefinition): Unit =
-    message("intention.type.annotation.variable.regenerate.text")
-
-  def addToPattern(pattern: ScBindingPattern) {
+  def patternWithoutType(pattern: ScBindingPattern) {
     message("intention.type.annotation.pattern.add.text")
   }
 
-  def addToWildcardPattern(pattern: ScWildcardPattern) {
+  def wildcardPatternWithoutType(pattern: ScWildcardPattern) {
     message("intention.type.annotation.pattern.add.text")
   }
 
-  def removeFromPattern(pattern: ScTypedPattern) {
+  def patternWithType(pattern: ScTypedPattern) {
     message("intention.type.annotation.pattern.remove.text")
   }
 
-  def addToParameter(param: ScParameter) {
+  def parameterWithoutType(param: ScParameter) {
     message("intention.type.annotation.parameter.add.text")
   }
 
-  def removeFromParameter(param: ScParameter) {
+  def parameterWithType(param: ScParameter) {
     message("intention.type.annotation.parameter.remove.text")
   }
 }

--- a/src/org/jetbrains/plugins/scala/codeInspection/catchAll/ReplaceDangerousCatchAllQuickFix.scala
+++ b/src/org/jetbrains/plugins/scala/codeInspection/catchAll/ReplaceDangerousCatchAllQuickFix.scala
@@ -22,8 +22,8 @@ class ReplaceDangerousCatchAllQuickFix(caseClause: ScCaseClause)
 
     val strategy = AddOnlyStrategy.withoutEditor
     pattern match {
-      case p: ScWildcardPattern => strategy.addToWildcardPattern(p)
-      case p: ScReferencePattern => strategy.addToPattern(p)
+      case p: ScWildcardPattern => strategy.wildcardPatternWithoutType(p)
+      case p: ScReferencePattern => strategy.patternWithoutType(p)
       //if pattern has another type - it's a bug
     }
   }

--- a/test/org/jetbrains/plugins/scala/codeInsight/intention/types/RegenerateTypeAnnotationTest.scala
+++ b/test/org/jetbrains/plugins/scala/codeInsight/intention/types/RegenerateTypeAnnotationTest.scala
@@ -1,0 +1,67 @@
+package org.jetbrains.plugins.scala.codeInsight.intention.types
+
+import org.jetbrains.plugins.scala.codeInsight.intentions.ScalaIntentionTestBase
+
+class RegenerateTypeAnnotationTest extends ScalaIntentionTestBase {
+  def familyName: String = RegenerateTypeAnnotation.getFamilyName
+
+  def testIntentionIsAvailable_Var() {
+    checkIntentionIsAvailable("var x: Int = 1")
+  }
+
+  def testIntentionIsAvailable_Var_Incorrect() {
+    checkIntentionIsAvailable("var x: Char = 1"
+    )
+  }
+
+  def testIntentionIsAvailable_Val() {
+    checkIntentionIsAvailable("val x: Int = 1")
+  }
+
+  def testIntentionIsAvailable_Val_Incorrect() {
+    checkIntentionIsAvailable("val x: Char = 1"
+    )
+  }
+
+  def testIntentionIsAvailable_Def() {
+    checkIntentionIsAvailable("def f: Int = 1")
+  }
+
+  def testIntentionIsAvailable_Def_Incorrect() {
+    checkIntentionIsAvailable("def f: Char = 1"
+    )
+  }
+
+  def testIntentionIsNotAvailable_Var_WithoutType() {
+    checkIntentionIsNotAvailable("var x = 1")
+  }
+
+  def testIntentionIsNotAvailable_Val_WithoutType() {
+    checkIntentionIsNotAvailable("val x = 1")
+  }
+
+  def testIntentionIsNotAvailable_Def_WithoutType() {
+    checkIntentionIsNotAvailable("def f = 1")
+  }
+
+  def testIntentionAction_Var() {
+    val text = "var x: Char = 1"
+    val resultText = "var x: Int = 1"
+
+    doTest(text, resultText)
+  }
+
+  def testIntentionAction_Val() {
+    val text = "val x: Char = 1"
+    val resultText = "val x: Int = 1"
+
+    doTest(text, resultText)
+  }
+
+  def testIntentionAction_Def() {
+    val text = "def f: Char = 1"
+    val resultText = "def f: Int = 1"
+
+    doTest(text, resultText)
+  }
+}


### PR DESCRIPTION
Adds a new intention to regenerate type annotations.  This essentially performs a "remove type annotation" followed by "add type annotation".  

The reason for adding this is that during refactoring, when I change the type of a method/var/val I always did the two steps above.  I thought it would be really helpful to do this in one step, so I added this as a separate intention.

I am not sure if I need a `youtrack` ticket for this?

Best,
Markus
