### PR TITLE
Fixing SCL-9840 and Documentation

### DIFF
--- a/README.mkdn
+++ b/README.mkdn
@@ -38,3 +38,9 @@ In order to take part in Scala plugin development, you need to:
 
 4. Open IntelliJ IDEA, select `File -> New -> Project from existing sources`, point to
 the directory where Scala plugin repository is and then import it as SBT project.
+
+## Troubleshooting
+
+1. I keep getting `Error: scalac: Error: GC overhead limit exceeded` when I run `All Tests`.
+
+Specify the JVM heap size to at least 2GB in the Scala Compiler Settings. Increase the scala compiler heap size by setting `Build process heap size` in the settings pane by going here `Build, Execution, Deployment > Compiler`. For more information, see this [link](https://www.jetbrains.com/help/idea/2016.1/compiler.html)

--- a/README.mkdn
+++ b/README.mkdn
@@ -38,13 +38,3 @@ In order to take part in Scala plugin development, you need to:
 
 4. Open IntelliJ IDEA, select `File -> New -> Project from existing sources`, point to
 the directory where Scala plugin repository is and then import it as SBT project.
-
-5. When importing is finished, go to Scala plugin repo directory and run
-
-  ```
-  $ git checkout .idea
-  ```
-
-  in order to get artifacts and run configurations for IDEA project.
-
-

--- a/resources/META-INF/scala-plugin-common.xml
+++ b/resources/META-INF/scala-plugin-common.xml
@@ -1117,6 +1117,10 @@
                          displayName="Extracting values manually" groupPath="Scala, Collections" groupName="Maps"
                          shortName="MapValues" level="WARNING"
                          enabledByDefault="true" language="Scala"/>
+      <localInspection implementationClass="org.jetbrains.plugins.scala.codeInspection.collections.MapGetGetInspection"
+                       displayName="Redundant get when getting a value from Map" groupPath="Scala, Collections" groupName="Maps"
+                       shortName="MapGetGet" level="WARNING"
+                       enabledByDefault="true" language="Scala"/>
         <!--options-->
         <localInspection implementationClass="org.jetbrains.plugins.scala.codeInspection.collections.RedundantHeadOrLastOptionInspection"
                          displayName="Redundant headOption or lastOption" groupPath="Scala, Collections" groupName="Options"

--- a/resources/inspectionDescriptions/MapGetGet.html
+++ b/resources/inspectionDescriptions/MapGetGet.html
@@ -1,0 +1,15 @@
+<html>
+<body>
+Removes unnecessary gets when getting a value from map given a key.
+
+<p>
+    Before: <br>
+    <code>map.get(k).get</code>
+</p>
+<p>
+    After: <br>
+    <code>map(k)</code>
+</p>
+
+</body>
+</html>

--- a/resources/org/jetbrains/plugins/scala/codeInspection/InspectionBundle.properties
+++ b/resources/org/jetbrains/plugins/scala/codeInspection/InspectionBundle.properties
@@ -48,6 +48,7 @@ forall.notEquals.hint=Replace forall with not contains
 getOrElse.null.hint=Replace getOrElse(null) with orNull
 drop.one.hint=Replace drop(1) with tail
 get.getOrElse.hint=Replace with getOrElse(key, defaultValue)
+get.get.hint=Replace with .(key)
 redundant.collection.conversion=Remove redundant collection conversion
 replace.with.head=Replace with .head
 replace.with.last=Replace with .last

--- a/src/org/jetbrains/plugins/scala/codeInspection/collections/MapGetGetInspection.scala
+++ b/src/org/jetbrains/plugins/scala/codeInspection/collections/MapGetGetInspection.scala
@@ -1,0 +1,33 @@
+package org.jetbrains.plugins.scala.codeInspection.collections
+
+import org.jetbrains.plugins.scala.codeInspection.InspectionBundle
+import org.jetbrains.plugins.scala.lang.psi.api.expr.ScExpression
+
+/**
+ * Nikolay.Tropin
+ * 2014-05-07
+ */
+class MapGetGetInspection extends OperationOnCollectionInspection {
+  override def possibleSimplificationTypes: Array[SimplificationType] =
+    Array(MapGetGet)
+}
+
+object MapGetGet extends SimplificationType() {
+
+  def hint = InspectionBundle.message("get.get.hint")
+
+  override def getSimplification(expr: ScExpression) = {
+    expr match {
+      case map`.getOnMap`(key)`.get`() =>
+        Some(replace(expr)
+          .withText(replacementText(map, key))
+          .highlightFrom(map))
+      case _ => None
+    }
+  }
+
+  def replacementText(qual: ScExpression, keyArg: ScExpression): String = {
+    val firstArgText = argListText(Seq(keyArg))
+    s"${qual.getText}$firstArgText"
+  }
+}

--- a/src/org/jetbrains/plugins/scala/codeInspection/collections/package.scala
+++ b/src/org/jetbrains/plugins/scala/codeInspection/collections/package.scala
@@ -65,6 +65,7 @@ package object collections {
   private[collections] val `.foldLeft` = invocation(Set("foldLeft", "/:")).from(likeCollectionClasses)
   private[collections] val `.reduce` = invocation(reduceMethodNames).from(likeCollectionClasses)
   private[collections] val `.getOrElse` = invocation("getOrElse").from(likeOptionClasses)
+  private[collections] val `.get` = invocation("get").from(likeOptionClasses)
   private[collections] val `.getOnMap` = invocation("get").from(likeCollectionClasses).ref(checkResolveToMap)
   private[collections] val `.mapOnOption` = invocation("map").from(likeOptionClasses).ref(checkScalaVersion)
   private[collections] val `.sort` = invocation(Set("sortWith", "sortBy", "sorted")).from(likeCollectionClasses)

--- a/test/org/jetbrains/plugins/scala/codeInspection/collections/MapGetGetTest.scala
+++ b/test/org/jetbrains/plugins/scala/codeInspection/collections/MapGetGetTest.scala
@@ -1,0 +1,56 @@
+package org.jetbrains.plugins.scala.codeInspection.collections
+
+import org.jetbrains.plugins.scala.codeInspection.InspectionBundle
+
+/**
+ * Nikolay.Tropin
+ * 2014-05-08
+ */
+class MapGetGetTest extends OperationsOnCollectionInspectionTest {
+  val hint = InspectionBundle.message("get.get.hint")
+  override val inspectionClass = classOf[MapGetGetInspection]
+
+  def test_1() {
+    val selected = s"""Map("a"->"x").${START}get("a").get$END"""
+    check(selected)
+    val text = """Map("a" -> "x").get("a").get"""
+    val result = """Map("a" -> "x")("a")"""
+    testFix(text, result, hint)
+  }
+
+  def test_2() {
+    val selected =
+      s"""val m = Map("a" -> "b")
+         |m.${START}get("a").get$END""".stripMargin
+    check(selected)
+    val text =
+      s"""val m = Map("a" -> "b")
+          |m.get("a").get""".stripMargin
+    val result =
+      s"""val m = Map("a" -> "b")
+          |m("a")""".stripMargin
+    testFix(text, result, hint)
+  }
+
+  def test_3() {
+    val selected =
+      s"""val m = Map(1 -> "b")
+          |m.${START}get(1).get$END""".stripMargin
+    check(selected)
+    val text =
+      s"""val m = Map(1 -> "b")
+          |m.get(1).get""".stripMargin
+    val result =
+      s"""val m = Map(1 -> "b")
+          |m(1)""".stripMargin
+    testFix(text, result, hint)
+  }
+
+  def test_4() {
+    val selected = s"""Map("a"->"x").${START}get(0).get$END"""
+    check(selected)
+    val text = """Map("a" -> "x").get(0).get"""
+    val result = """Map("a" -> "x")(0)"""
+    testFix(text, result, hint)
+  }
+}


### PR DESCRIPTION
Fixes the following bug
[SCL-9840: Collection inspection: convert map.get(k).get to map(k)](https://youtrack.jetbrains.com/issue/SCL-9840)

and updating the documentation as well.
