### PR TITLE
Fixes for SCL-10285 (language fixes) and SCL-10285, SCL-10287

### DIFF
--- a/resources/inspectionDescriptions/RedundantNewCaseClass.html
+++ b/resources/inspectionDescriptions/RedundantNewCaseClass.html
@@ -1,2 +1,2 @@
-<html><body>'new' modifier is redundant for instantiation of case classes since an apply method is automatically provided.
+<html><body>Removes 'new' since an apply method is automatically provided on case classes.
 </body></html>

--- a/resources/org/jetbrains/plugins/scala/ScalaBundle.properties
+++ b/resources/org/jetbrains/plugins/scala/ScalaBundle.properties
@@ -320,7 +320,7 @@ implicit.usage.tooltip=<html>\
   </html>
 implicit.usage.message=Implicit conversion ''{0}({1}): {2}'' detected.
 val.on.case.class.param.redundant='val' modifier is redundant for parameter of case class primary constructor
-new.on.case.class.instantiation.redundant='new' modifier is redundant for instantiation of case class
+new.on.case.class.instantiation.redundant=remove 'new' modifier
 suspicicious.inference=Inferred type of {0} is suspicious. If you really want this, explicitly annotate the type.
 suspicicious.newline=Newline before argument list is not inferred as a semicolon. Consider using '.' before the method name.
 constructor.invocation.expected='this' expected


### PR DESCRIPTION
Fixes the language issues and issues with overloaded apply methods.

@niktrop I was able to get this to work by checking `isSyntheticApply` but the case with `implicitly` in the ticket was still failing.  Checking that `syntheticNavigationElement` mapped to `ScClass` seemed to get all the test cases passing.
