### PR TITLE
Problem with two full Scala.js cross projects

### DIFF
--- a/src/org/jetbrains/sbt/project/ExternalSourceRootResolution.scala
+++ b/src/org/jetbrains/sbt/project/ExternalSourceRootResolution.scala
@@ -185,8 +185,12 @@ trait ExternalSourceRootResolution { self: SbtProjectResolver =>
     var counter = 1
 
     def nameFor(base: Option[File]) = {
-      val namedDirectory = if (base.exists(_.getName == "shared")) base.flatMap(_.parent) else base
-      val prefix = namedDirectory.map(_.getName + "-sources").getOrElse("shared-sources")
+      val namedDirectory = {
+        var d = base
+        while (d.exists(_.getName == "shared")) d = d.flatMap(_.parent)
+        d
+      }
+      val prefix = namedDirectory.map(_.getName + "-shared-sources").getOrElse("shared-sources")
       if (usedNames.contains(prefix)) {
         val result = prefix + counter
         counter += 1


### PR DESCRIPTION
Lets assume that we've got a config like:

``` scala
val `A-shared` = crossProject.crossType(CrossType.Full).in(file("A/shared"))
val `B-shared` = crossProject.crossType(CrossType.Full).in(file("B/shared"))
```

The folders structure looks like:

```
/
|- A
|  |- shared
|  |  |- js
|  |  |  |- src
|  |  |- jvm
|  |  |  |- src
|  |  |- shared
|  |  |  |- src
|  |- ...
|- B
|  |- shared
|  |  |- js
|  |  |  |- src
|  |  |- jvm
|  |  |  |- src
|  |  |- shared
|  |  |  |- src
|  |- ...
```

Finally I have got two modules named `shared-sources` by IntelliJ.
