### PR TITLE
Auto convert to infix when converting from .equals() to ==

### DIFF
--- a/src/org/jetbrains/plugins/scala/codeInsight/intention/booleans/ReplaceEqualsOrEqualityInMethodCallExprIntention.scala
+++ b/src/org/jetbrains/plugins/scala/codeInsight/intention/booleans/ReplaceEqualsOrEqualityInMethodCallExprIntention.scala
@@ -8,13 +8,15 @@ import com.intellij.openapi.util.TextRange
 import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.psi.{PsiDocumentManager, PsiElement}
 import org.jetbrains.plugins.scala.extensions._
-import org.jetbrains.plugins.scala.lang.psi.api.expr.{ScMethodCall, ScReferenceExpression}
+import org.jetbrains.plugins.scala.lang.psi.api.expr.{ScInfixExpr, ScMethodCall, ScReferenceExpression}
 import org.jetbrains.plugins.scala.lang.psi.impl.ScalaPsiElementFactory
+import org.jetbrains.plugins.scala.lang.psi.impl.expr.ScInfixExprImpl
+import org.jetbrains.plugins.scala.util.IntentionUtils
 
 /**
- * @author Ksenia.Sautina
- * @since 4/23/12
- */
+  * @author Ksenia.Sautina
+  * @since 4/23/12
+  */
 
 object ReplaceEqualsOrEqualityInMethodCallExprIntention {
   def familyName = "Replace equals or equality in method call expression"
@@ -44,7 +46,12 @@ class ReplaceEqualsOrEqualityInMethodCallExprIntention extends PsiElementBaseInt
     false
   }
 
-  override def invoke(project: Project, editor: Editor, element: PsiElement) {
+  override def invoke(project: Project, editor: Editor, element: PsiElement): Unit = {
+    invoke_method_one(project, editor, element)
+    //invoke_method_two(project, editor, element)
+  }
+
+  def orig_invoke(project: Project, editor: Editor, element: PsiElement) {
     val methodCallExpr: ScMethodCall = PsiTreeUtil.getParentOfType(element, classOf[ScMethodCall], false)
     if (methodCallExpr == null || !methodCallExpr.isValid) return
 
@@ -55,12 +62,100 @@ class ReplaceEqualsOrEqualityInMethodCallExprIntention extends PsiElementBaseInt
     val oper = methodCallExpr.getInvokedExpr.asInstanceOf[ScReferenceExpression].nameId.getText
 
     expr.append(methodCallExpr.getInvokedExpr.asInstanceOf[ScReferenceExpression].
-            qualifier.get.getText).append(".").append(replaceOper(oper)).append(methodCallExpr.args.getText)
+      qualifier.get.getText).append(".").append(replaceOper(oper)).append(methodCallExpr.args.getText)
 
     val newMethodCallExpr = ScalaPsiElementFactory.createExpressionFromText(expr.toString(), element.getManager)
 
     val size = newMethodCallExpr.asInstanceOf[ScMethodCall].getInvokedExpr.asInstanceOf[ScReferenceExpression].nameId.
+      getTextRange.getStartOffset - newMethodCallExpr.getTextRange.getStartOffset
+
+    inWriteAction {
+      methodCallExpr.replace(newMethodCallExpr)
+      editor.getCaretModel.moveToOffset(start + size)
+      PsiDocumentManager.getInstance(project).commitDocument(editor.getDocument)
+    }
+  }
+
+  def invoke_method_one(project: Project, editor: Editor, element: PsiElement) {
+    val methodCallExpr: ScMethodCall = PsiTreeUtil.getParentOfType(element, classOf[ScMethodCall], false)
+    if (methodCallExpr == null || !methodCallExpr.isValid) return
+
+    val start = methodCallExpr.getTextRange.getStartOffset
+
+    val replaceOper = Map("equals" -> "==", "==" -> "equals")
+
+    val args = new StringBuilder().append(methodCallExpr.args.getText)
+
+    val oper = methodCallExpr.getInvokedExpr.asInstanceOf[ScReferenceExpression].nameId.getText
+    val desiredOper: String = replaceOper(oper)
+
+    val expr = new StringBuilder()
+      .append(methodCallExpr.getInvokedExpr.asInstanceOf[ScReferenceExpression].qualifier.get.getText)
+
+    if (desiredOper == "==") {
+      expr.append(" ")
+      IntentionUtils.analyzeMethodCallArgs(methodCallExpr.args, args)
+      expr.append(desiredOper).append(" ").append(args)
+    } else {
+      expr.append(".")
+      expr.append(desiredOper).append(args)
+    }
+
+    print(expr.toString())
+    val newMethodCallExpr = ScalaPsiElementFactory.createExpressionFromText(expr.toString(), element.getManager)
+
+    val size = {
+      newMethodCallExpr match {
+        case scMethodCall: ScMethodCall =>
+          newMethodCallExpr.asInstanceOf[ScMethodCall].getInvokedExpr.asInstanceOf[ScReferenceExpression].nameId.
             getTextRange.getStartOffset - newMethodCallExpr.getTextRange.getStartOffset
+        case scInfixExpr: ScInfixExpr =>
+          newMethodCallExpr.asInstanceOf[ScInfixExpr].operation.nameId.getTextRange.getStartOffset - newMethodCallExpr.getTextRange.getStartOffset
+      }
+    }
+
+    inWriteAction {
+      methodCallExpr.replace(newMethodCallExpr)
+      methodCallExpr.replaceExpression(newMethodCallExpr, removeParenthesis = true)
+      editor.getCaretModel.moveToOffset(start + size)
+      PsiDocumentManager.getInstance(project).commitDocument(editor.getDocument)
+    }
+  }
+
+  def invoke_method_two(project: Project, editor: Editor, element: PsiElement) {
+    val methodCallExpr: ScMethodCall = PsiTreeUtil.getParentOfType(element, classOf[ScMethodCall], false)
+    if (methodCallExpr == null || !methodCallExpr.isValid) return
+
+    val start = methodCallExpr.getTextRange.getStartOffset
+
+    val expr = new StringBuilder().append(methodCallExpr.getInvokedExpr.asInstanceOf[ScReferenceExpression].qualifier.get.getText)
+
+    val replaceOper = Map("equals" -> "==", "==" -> "equals")
+    val oper = methodCallExpr.getInvokedExpr.asInstanceOf[ScReferenceExpression].nameId.getText
+
+    val desiredOper: String = replaceOper(oper)
+    if (desiredOper == "==") {
+
+      expr.append(" ").append(desiredOper).append(" ")
+      //accounts for tuples
+      if (methodCallExpr.args.getChildren.length == 1)
+        expr.append(methodCallExpr.args.getText.drop(1).dropRight(1))
+      else
+        expr.append(methodCallExpr.args.getText)
+    } else {
+      expr.append(".").append(desiredOper).append(methodCallExpr.args.getText)
+    }
+
+    val newMethodCallExpr = ScalaPsiElementFactory.createExpressionFromText(expr.toString(), element.getManager)
+
+    val size = {
+      if (desiredOper == "==") {
+        newMethodCallExpr.asInstanceOf[ScInfixExprImpl].operation.nameId.getTextRange.getStartOffset - newMethodCallExpr.getTextRange.getStartOffset
+      } else {
+        newMethodCallExpr.asInstanceOf[ScMethodCall].getInvokedExpr.asInstanceOf[ScReferenceExpression].nameId.
+          getTextRange.getStartOffset - newMethodCallExpr.getTextRange.getStartOffset
+      }
+    }
 
     inWriteAction {
       methodCallExpr.replace(newMethodCallExpr)

--- a/test/org/jetbrains/plugins/scala/codeInsight/intentions/booleans/ReplaceEqualsOrEqualityInMethodCallExprIntentionTest.scala
+++ b/test/org/jetbrains/plugins/scala/codeInsight/intentions/booleans/ReplaceEqualsOrEqualityInMethodCallExprIntentionTest.scala
@@ -21,8 +21,34 @@ class ReplaceEqualsOrEqualityInMethodCallExprIntentionTest extends ScalaIntentio
 
   def testReplaceQuality2() {
     val text = "if (a.eq<caret>uals(false)) return"
-    val resultText = "if (a.<caret>==(false)) return"
+    val resultText = "if (a <caret>== false) return"
 
     doTest(text, resultText)
   }
+
+  def testReplaceQuality2_withSpace() {
+    val text = "if (a.eq<caret>uals( false  )) return"
+    val resultText = "if (a <caret>== false) return"
+
+    doTest(text, resultText)
+  }
+
+  def testReplaceTuple(): Unit = {
+    (true, false).equals(false, false)
+    val text = "(true, false).equ<caret>als  (false, false)"
+    //TODO desired (true, false) <caret>== (false, false)
+    val resultText = "(true, false) <caret>==(false, false)"
+
+    doTest(text, resultText)
+  }
+
+  def testReplaceTuple_2(): Unit = {
+    (true, false).equals(false, false)
+    val text = "if((true, false).equ<caret>als  (false, false)) return "
+    //TODO desired (true, false) <caret>== (false, false)
+    val resultText = "if ((true, false) <caret>==(false, false)) return"
+
+    doTest(text, resultText)
+  }
+
 }


### PR DESCRIPTION
Providing an intermediate commit for feedback only.
1. There are two implementations - both work but I am not sure which one is desirable. Added a comment in the code.
2. One of the test cases does not insert a space. I have added a comment in the code as well.
