### PR TITLE
Convert to SAM inspection should check arg conformance to function param

### DIFF
--- a/src/org/jetbrains/plugins/scala/codeInspection/SAM/ConvertExpressionToSAMInspection.scala
+++ b/src/org/jetbrains/plugins/scala/codeInspection/SAM/ConvertExpressionToSAMInspection.scala
@@ -33,7 +33,7 @@ class ConvertExpressionToSAMInspection extends AbstractInspection(inspectionId, 
         definition.members match {
           case Seq(fun: ScFunctionDefinition) =>
             fun.body match {
-              case Some(funBody) if expectedMethodType.conforms(fun.getType().getOrNothing) =>
+              case Some(funBody) if fun.getType().getOrAny.conforms(expectedMethodType) =>
                 lazy val replacement: String = {
                   val res = new StringBuilder
                   fun.effectiveParameterClauses.headOption match {


### PR DESCRIPTION
Convert to SAM inspection should check arg conformance to function param, not the other way around
