### PR TITLE
MethodHandle's methods have magic return type

### DIFF
--- a/src/org/jetbrains/plugins/scala/lang/psi/ScalaPsiUtil.scala
+++ b/src/org/jetbrains/plugins/scala/lang/psi/ScalaPsiUtil.scala
@@ -2,6 +2,7 @@ package org.jetbrains.plugins.scala
 package lang
 package psi
 
+import com.intellij.codeInsight.AnnotationUtil
 import com.intellij.lang.java.JavaLanguage
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.module.{JavaModuleType, Module, ModuleUtil}
@@ -68,6 +69,17 @@ import scala.reflect.NameTransformer
  * User: Alexander Podkhalyuzin
  */
 object ScalaPsiUtil {
+
+  //java has magic @PolymorphicSignature annotation in java.lang.invoke.MethodHandle
+  def isJavaReflectPolymorphicSignature(expression: ScExpression): Boolean = expression match {
+    case ScMethodCall(invoked, _) => Option(invoked.getReference) match {
+      case Some(ResolvesTo(method: PsiMethod)) =>
+        AnnotationUtil.isAnnotated(method, CommonClassNames.JAVA_LANG_INVOKE_MH_POLYMORPHIC, false, true)
+      case _ => false
+    }
+    case _ => false
+  }
+
   def nameWithPrefixIfNeeded(c: PsiClass): String = {
     val qName = c.qualifiedName
     if (ScalaCodeStyleSettings.getInstance(c.getProject).hasImportWithPrefix(qName)) qName.split('.').takeRight(2).mkString(".")

--- a/src/org/jetbrains/plugins/scala/lang/psi/api/expr/ScExpression.scala
+++ b/src/org/jetbrains/plugins/scala/lang/psi/api/expr/ScExpression.scala
@@ -25,6 +25,8 @@ import org.jetbrains.plugins.scala.lang.psi.types.{api, _}
 import org.jetbrains.plugins.scala.lang.resolve.processor.MethodResolveProcessor
 import org.jetbrains.plugins.scala.lang.resolve.{ScalaResolveResult, StdKinds}
 import org.jetbrains.plugins.scala.macroAnnotations.{CachedMappedWithRecursionGuard, ModCount}
+import org.jetbrains.plugins.scala.project.ProjectPsiElementExt
+import org.jetbrains.plugins.scala.project.ScalaLanguageLevel.Scala_2_11
 
 import scala.annotation.tailrec
 import scala.collection.mutable.ArrayBuffer
@@ -77,6 +79,11 @@ trait ScExpression extends ScBlockStatement with PsiAnnotationMemberValue with I
               tryConvertToSAM(fromUnderscore, expected, tp) match {
                 case Some(r) => return r
                 case _ =>
+              }
+
+              val scalaVersion = ScExpression.this.scalaLanguageLevelOrDefault
+              if (scalaVersion >= Scala_2_11 && ScalaPsiUtil.isJavaReflectPolymorphicSignature(ScExpression.this)) {
+                return ExpressionTypeResult(Success(expected, Some(ScExpression.this)), Set.empty, None)
               }
 
               val functionType = FunctionType(expected, Seq(tp))(getProject, getResolveScope)

--- a/test/org/jetbrains/plugins/scala/failed/annotator/JavaHighlightingTest.scala
+++ b/test/org/jetbrains/plugins/scala/failed/annotator/JavaHighlightingTest.scala
@@ -73,34 +73,6 @@ class JavaHighlightingTest extends JavaHighlitghtingTestBase {
 
     assertNothing(errorsFromScalaCode(scala, java))
   }
-
-  def testSCL9029() = {
-    val scala =
-      """
-        |package scl9029
-        |import java.lang.invoke.{MethodHandles, MethodType}
-        |
-        |class SCL9029 {
-        |  def a: Int = 5
-        |
-        |  def b = {
-        |    val mh = MethodHandles.publicLookup().findVirtual(
-        |      classOf[A], "a", MethodType.methodType(classOf[Int])
-        |    )
-        |    val z: Int = mh.invokeExact(this)
-        |  }
-        |}
-      """.stripMargin
-
-    val java =
-      """
-        |package scl9029;
-        |public class Foo {
-        |}
-      """.stripMargin
-
-    assertNothing(errorsFromScalaCode(scala, java))
-  }
   
   def testSCL6409() = {
     val java =

--- a/test/org/jetbrains/plugins/scala/javaHighlighting/JavaHighlightingTest.scala
+++ b/test/org/jetbrains/plugins/scala/javaHighlighting/JavaHighlightingTest.scala
@@ -115,6 +115,34 @@ class JavaHighlightingTest extends JavaHighlitghtingTestBase {
     }
   }
 
+  def testSCL9029() = {
+    val scala =
+      """
+        |package scl9029
+        |import java.lang.invoke.{MethodHandles, MethodType}
+        |
+        |class SCL9029 {
+        |  def a: Int = 5
+        |
+        |  def b = {
+        |    val mh = MethodHandles.publicLookup().findVirtual(
+        |      classOf[SCL9029], "a", MethodType.methodType(classOf[Int])
+        |    )
+        |    val z: Int = mh.invokeExact(this)
+        |  }
+        |}
+      """.stripMargin
+
+    val java =
+      """
+        |package scl9029;
+        |public class Foo {
+        |}
+      """.stripMargin
+
+    assertNothing(errorsFromScalaCode(scala, java))
+  }
+
   def testAccessBacktick(): Unit = {
     val scala =
       """

--- a/test/org/jetbrains/plugins/scala/javaHighlighting/JavaHighlitghtingTestBase.scala
+++ b/test/org/jetbrains/plugins/scala/javaHighlighting/JavaHighlitghtingTestBase.scala
@@ -2,18 +2,17 @@ package org.jetbrains.plugins.scala.javaHighlighting
 
 import com.intellij.ide.highlighter.JavaFileType
 import com.intellij.lang.annotation.HighlightSeverity
-import com.intellij.pom.java.LanguageLevel
 import com.intellij.psi.{PsiDocumentManager, PsiFile}
 import org.jetbrains.plugins.scala.annotator.{AnnotatorHolderMock, Error, Message, ScalaAnnotator}
-import org.jetbrains.plugins.scala.base.{AssertMatches, ScalaFixtureTestCase, ScalaLibraryLoader}
+import org.jetbrains.plugins.scala.base.{AssertMatches, ScalaFixtureTestCase}
 import org.jetbrains.plugins.scala.extensions.PsiElementExt
-import org.jetbrains.plugins.scala.util.TestUtils
+import org.jetbrains.plugins.scala.util.TestUtils.ScalaSdkVersion
 
 /**
   * @author Alefas
   * @since 23/03/16
   */
-abstract class JavaHighlitghtingTestBase extends ScalaFixtureTestCase with AssertMatches {
+abstract class JavaHighlitghtingTestBase extends ScalaFixtureTestCase(scalaVersion = ScalaSdkVersion._2_11) with AssertMatches {
   private var filesCreated: Boolean = false
 
   def errorsFromJavaCode(scalaFileText: String, javaFileText: String, javaClassName: String): List[Message] = {
@@ -60,20 +59,5 @@ abstract class JavaHighlitghtingTestBase extends ScalaFixtureTestCase with Asser
 
   case class ContainsPattern(fragment: String) {
     def unapply(s: String) = s.contains(fragment)
-  }
-
-  private var scalaLibraryLoader: ScalaLibraryLoader = null
-
-  override def setUp() = {
-    super.setUp()
-
-    TestUtils.setLanguageLevel(getProject, LanguageLevel.JDK_1_8)
-    scalaLibraryLoader = new ScalaLibraryLoader(getProject, myFixture.getModule, null)
-    scalaLibraryLoader.loadScala(TestUtils.DEFAULT_SCALA_SDK_VERSION)
-  }
-
-  override def tearDown(): Unit = {
-    scalaLibraryLoader.clean()
-    super.tearDown()
   }
 }


### PR DESCRIPTION
java.lang.invoke.MethodHandle's methods have magic return type
Set the type of the expression be the expected type, so it isn't highlighted

Also, cleanup JavaHighlightingTestBase
