### PR TITLE
Java/Scala interop: convert upper and lower bounds correctly

### DIFF
--- a/src/org/jetbrains/plugins/scala/lang/psi/impl/ScalaPsiManager.scala
+++ b/src/org/jetbrains/plugins/scala/lang/psi/impl/ScalaPsiManager.scala
@@ -292,18 +292,11 @@ class ScalaPsiManager(val project: Project) {
   }
 
   @CachedWithoutModificationCount(synchronized = false, ValueWrapper.SofterReference, clearCacheOnChange)
-  def psiTypeParameterUpperType(typeParameter: PsiTypeParameter): ScType = {
-    typeParameter.getSuperTypes match {
-      case Array(scType) => scType.toScType(project)
-      case types => andType(types)
-    }
-  }
-
-  def psiTypeParameterLowerType(typeParameter: PsiTypeParameter): ScType = {
+  def javaPsiTypeParameterUpperType(typeParameter: PsiTypeParameter): ScType = {
     andType(typeParameter.getExtendsListTypes ++ typeParameter.getImplementsListTypes)
   }
 
-  private def andType(psiTypes: Seq[PsiType]) = {
+  private def andType(psiTypes: Seq[PsiType]): ScType = {
     project.typeSystem.andType(psiTypes.map(_.toScType(project)))
   }
 

--- a/src/org/jetbrains/plugins/scala/lang/psi/types/api/TypeParameterType.scala
+++ b/src/org/jetbrains/plugins/scala/lang/psi/types/api/TypeParameterType.scala
@@ -68,7 +68,9 @@ object TypeParameter {
       case typeParam: ScTypeParam =>
         (typeParam.typeParameters, typeParam.lowerBound.toOption, typeParam.upperBound.toOption)
       case _ =>
-        (Seq.empty, None, None)
+        val manager = ScalaPsiManager.instance(typeParameter.getProject)
+        val upper = manager.javaPsiTypeParameterUpperType(typeParameter)
+        (Seq.empty, None, Some(upper))
     }
     TypeParameter(
       typeParameters.map(TypeParameter(_)),
@@ -129,8 +131,8 @@ object TypeParameterType {
           case Some(_) => typeParameter.getTypeParameters.toSeq
           case _ => Seq.empty
         },
-          () => manager.psiTypeParameterLowerType(typeParameter),
-          () => manager.psiTypeParameterUpperType(typeParameter))
+          () => Nothing,
+          () => manager.javaPsiTypeParameterUpperType(typeParameter))
     }
     TypeParameterType(
       arguments.map(TypeParameterType(_, maybeSubstitutor)),

--- a/test/org/jetbrains/plugins/scala/failed/annotator/JavaHighlightingTest.scala
+++ b/test/org/jetbrains/plugins/scala/failed/annotator/JavaHighlightingTest.scala
@@ -198,30 +198,6 @@ class JavaHighlightingTest extends JavaHighlitghtingTestBase {
     assertNothing(errorsFromScalaCode(scala, java))
   }
 
-  def testSCL8759(): Unit = {
-    val java =
-      """
-        |public class Foobar {
-        |    public static void foo(Object something) {
-        |    }
-        |    public static <T extends Number> void foo(T something) {
-        |    }
-        |}
-      """.stripMargin
-
-    val scala =
-      """
-        |class ScClass {
-        |  def method = {
-        |    Foobar.foo("")
-        |    Foobar.foo(java.lang.Integer.valueOf(1))
-        |  }
-        |}
-      """.stripMargin
-
-    assertNothing(errorsFromScalaCode(scala, java))
-  }
-
   def testSCL8666(): Unit = {
     val java =
       """

--- a/test/org/jetbrains/plugins/scala/javaHighlighting/JavaHighlightingTest.scala
+++ b/test/org/jetbrains/plugins/scala/javaHighlighting/JavaHighlightingTest.scala
@@ -693,5 +693,29 @@ class JavaHighlightingTest extends JavaHighlitghtingTestBase {
 
     assertNothing(errorsFromJavaCode(scalaFileText = "", java, javaClassName = "OptionApply"))
   }
+
+  def testSCL8759(): Unit = {
+    val java =
+      """
+        |public class Foobar {
+        |    public static void foo(Object something) {
+        |    }
+        |    public static <T extends Number> void foo(T something) {
+        |    }
+        |}
+      """.stripMargin
+
+    val scala =
+      """
+        |class ScClass {
+        |  def method = {
+        |    Foobar.foo("")
+        |    Foobar.foo(java.lang.Integer.valueOf(1))
+        |  }
+        |}
+      """.stripMargin
+
+    assertNothing(errorsFromScalaCode(scala, java))
+  }
 }
 


### PR DESCRIPTION
Named type parameters in java cannot have 'super' bounds
 #SCL-8759 Fixed
