### PR TITLE
Fix error in intention examples

### DIFF
--- a/resources/intentionDescriptions/ConvertToCurlyBracesIntention/after.scala.template
+++ b/resources/intentionDescriptions/ConvertToCurlyBracesIntention/after.scala.template
@@ -1,4 +1,4 @@
 for {
   x <- List(1, 2, 3)
-  y <- List(x, x))
+  y <- List(x, x)
 } yield x

--- a/resources/intentionDescriptions/ConvertToCurlyBracesIntention/before.scala.template
+++ b/resources/intentionDescriptions/ConvertToCurlyBracesIntention/before.scala.template
@@ -1,1 +1,1 @@
-for <spot>(x <- List(1, 2, 3), y <- List(x, x))</spot> yield x
+for <spot>(x <- List(1, 2, 3); y <- List(x, x))</spot> yield x

--- a/resources/intentionDescriptions/ConvertToCurlyBracesIntention/description.html
+++ b/resources/intentionDescriptions/ConvertToCurlyBracesIntention/description.html
@@ -1,5 +1,5 @@
 <html>
 <body>
-Use curly braces around the generators of a for-comprenhension.
+Use curly braces around the generators of a for-comprehension.
 </body>
 </html>

--- a/resources/intentionDescriptions/ConvertToParenthesesIntention/after.scala.template
+++ b/resources/intentionDescriptions/ConvertToParenthesesIntention/after.scala.template
@@ -1,1 +1,1 @@
-for (x <- List(1, 2, 3); y <- List(x, x))) yield x
+for (x <- List(1, 2, 3); y <- List(x, x)) yield x

--- a/resources/intentionDescriptions/ConvertToParenthesesIntention/before.scala.template
+++ b/resources/intentionDescriptions/ConvertToParenthesesIntention/before.scala.template
@@ -1,4 +1,4 @@
 for <spot>{
    x <- List(1, 2, 3)
-   y <- List(x, x))
+   y <- List(x, x)
 }</spot> yield x

--- a/resources/intentionDescriptions/ConvertToParenthesesIntention/description.html
+++ b/resources/intentionDescriptions/ConvertToParenthesesIntention/description.html
@@ -1,5 +1,5 @@
 <html>
 <body>
-Use parentheses around the generators of a for-comprenhension.
+Use parentheses around the generators of a for-comprehension.
 </body>
 </html>


### PR DESCRIPTION
There's a simple syntax error in before/after examples for `ConvertToCurlyBracesIntention` and `ConvertToParenthesesIntention`.
