### PR TITLE
Fix for setting breakpoints in async code.

### DIFF
--- a/src/org/jetbrains/plugins/scala/debugger/ScalaPositionManager.scala
+++ b/src/org/jetbrains/plugins/scala/debugger/ScalaPositionManager.scala
@@ -125,8 +125,7 @@ class ScalaPositionManager(val debugProcess: DebugProcess) extends PositionManag
           val delayedBodyName = if (isDelayedInit(td)) Seq(s"$qName$delayedInitBody") else Nil
           (qName +: delayedBodyName).foreach(addExactClasses)
         case elem =>
-          val namePattern = NamePattern.forElement(elem)
-          namePatterns ++= Option(namePattern)
+          namePatterns ++= Option(NamePattern.forElement(elem)).orElse(Some(new NamePattern(elem)))
       }
     }
     val packageName: Option[String] = Option(inReadAction(file.asInstanceOf[ScalaFile].getPackageName))


### PR DESCRIPTION
this fixes long standing issues with stepping through and setting breakpoints in the scala/async async code.

bug happens because NamePattern.forElement(elem) returns nothing for async psi elements, and as a result method returns zero candidate classes for given SourcePosition.

nothing in NamePattern.forElement(elem) is returned because it doesn't know that async methods generate classes (in our case, classes generated are named Basename$statemachine$...). I think the logic that filters out our case in NamePattern.forElement(elem) should be improved but I don't know how.

but creating NamePattern directly helps. Although filter is more loose and may falsely accept more cases, hasLocations(refType: ReferenceType, position: SourcePosition) seems to be strict enough to filter out the only one correct class from generated statemachine. I wonder what could be the cases that are falsely accepted.

Environment for which it fixes bug:

scala-async_2.11 0.9.6-RC2
idea162.x branch as of today
scala 2.11.7

maybe fix for https://github.com/scala/async/issues/136
and for https://youtrack.jetbrains.com/issue/SCL-4935

best regards.
