### PR TITLE
SCL-10573  Convert anonymous function parameter of foreach call to function value

### DIFF
--- a/resources/META-INF/scala-plugin-common.xml
+++ b/resources/META-INF/scala-plugin-common.xml
@@ -1092,6 +1092,10 @@
                          shortName="FilterOtherContains" level="WARNING"
                          enabledByDefault="true" language="Scala"/>
         <!--simplifications: other-->
+        <localInspection implementationClass="org.jetbrains.plugins.scala.codeInspection.collections.SimplifiableForeachInspection"
+                         displayName="Simplifiable foreach method parameter" groupPath="Scala, Collections" groupName="Simplifications: other"
+                         shortName="SimplifiableForeach" level="WARNING"
+                         enabledByDefault="true" language="Scala"/>
         <localInspection implementationClass="org.jetbrains.plugins.scala.codeInspection.collections.SimplifiableFoldOrReduceInspection"
                          displayName="Simplifiable fold or reduce method" groupPath="Scala, Collections" groupName="Simplifications: other"
                          shortName="SimplifiableFoldOrReduce" level="WARNING"

--- a/resources/inspectionDescriptions/SimplifiableForeach.html
+++ b/resources/inspectionDescriptions/SimplifiableForeach.html
@@ -1,0 +1,19 @@
+<html>
+<body>
+Replaces anonymous function to a method value as parameter of <code>foreach</code> function.
+
+<p>
+Before:
+<pre>
+Seq("1", "2").foreach(s => foo(s))
+</pre>
+
+<br>
+After:
+<pre>
+Seq("1", "2").foreach(foo)
+</pre>
+</p>
+
+</body>
+</html>

--- a/src/org/jetbrains/plugins/scala/codeInspection/collections/SimplifiableForeachInspection.scala
+++ b/src/org/jetbrains/plugins/scala/codeInspection/collections/SimplifiableForeachInspection.scala
@@ -1,0 +1,35 @@
+package org.jetbrains.plugins.scala
+package codeInspection.collections
+
+import org.jetbrains.plugins.scala.codeInspection.InspectionBundle
+import org.jetbrains.plugins.scala.extensions.ResolvesTo
+import org.jetbrains.plugins.scala.lang.psi.api.expr.{ScExpression, ScFunctionExpr, ScMethodCall}
+
+/**
+  * @author Victor Malov
+  * 2016-08-16
+  */
+class SimplifiableForeachInspection extends OperationOnCollectionInspection {
+  override def possibleSimplificationTypes: Array[SimplificationType] = Array(SimplifiableForeach)
+}
+
+object SimplifiableForeach extends SimplificationType {
+  override def hint: String = InspectionBundle.message("convertible.to.method.value.name")
+
+  override def getSimplification(expr: ScExpression): Option[Simplification] = {
+    expr match {
+      case qual`.foreach`(methodCall(name)) =>
+        Some(replace(expr).withText(invocationText(qual, "foreach", name)))
+      case _ => None
+    }
+  }
+
+  private object methodCall {
+    def unapply(expr: ScExpression) = stripped(expr) match {
+      case ScFunctionExpr(Seq(s), Some(ScMethodCall(name, Seq(ResolvesTo(param))))) if s == param => {
+        Some(name)
+      }
+      case _ => None
+    }
+  }
+}

--- a/src/org/jetbrains/plugins/scala/codeInspection/collections/package.scala
+++ b/src/org/jetbrains/plugins/scala/codeInspection/collections/package.scala
@@ -43,6 +43,7 @@ package object collections {
 
   private[collections] val `.exists` = invocation("exists").from(likeCollectionClasses)
   private[collections] val `.forall` = invocation("forall").from(likeCollectionClasses)
+  private[collections] val `.foreach` = invocation("foreach").from(likeCollectionClasses)
   private[collections] val `.filter` = invocation("filter").from(likeCollectionClasses)
   private[collections] val `.filterNot` = invocation("filterNot").from(likeCollectionClasses)
   private[collections] val `.map` = invocation("map").from(likeCollectionClasses)

--- a/test/org/jetbrains/plugins/scala/codeInspection/collections/SimplifiableForeachInspectionTest.scala
+++ b/test/org/jetbrains/plugins/scala/codeInspection/collections/SimplifiableForeachInspectionTest.scala
@@ -1,0 +1,30 @@
+package org.jetbrains.plugins.scala
+package codeInspection.collections
+
+import org.jetbrains.plugins.scala.codeInspection.InspectionBundle
+
+/**
+  * @author Victor Malov
+  * 2016-08-16
+  */
+class ForeachAnonFunctionParameterTest extends OperationsOnCollectionInspectionTest {
+
+  val hint = InspectionBundle.message("convertible.to.method.value.name")
+  override val inspectionClass = classOf[SimplifiableForeachInspection]
+
+  def test_1() {
+    val selected = s"""Seq("1", "2").${START}foreach(s => foo(s))$END"""
+    check(selected)
+    val text = """Seq("1", "2").foreach(s => foo(s))"""
+    val result = """Seq("1", "2").foreach(foo)"""
+    testFix(text, result, hint)
+  }
+
+  def test_2() {
+    val selected = s"""Seq("1", "2").${START}foreach((s) => foo(s))$END"""
+    check(selected)
+    val text = """Seq("1", "2").foreach((s) => foo(s))"""
+    val result = """Seq("1", "2").foreach(foo)"""
+    testFix(text, result, hint)
+  }
+}


### PR DESCRIPTION
Hello, guys! I've been waiting for any feedback.
Am I correct that inspections only analyze "feel and look" of expression, but not real environment.
I mean in `Seq("1", "2", "3").foreach(s => foo(s))` inspection doesn't analyze (or depends on another analyzer) whether `foo` really  exists and is really function in this _context_. It only analyzes only that `foo` looks like function call. Am I correct?
