### PR TITLE
Fix problems with modifying ScalaTest options in plugins

### DIFF
--- a/src/org/jetbrains/plugins/scala/testingSupport/test/AbstractTestRunConfiguration.scala
+++ b/src/org/jetbrains/plugins/scala/testingSupport/test/AbstractTestRunConfiguration.scala
@@ -388,7 +388,8 @@ abstract class AbstractTestRunConfiguration(val project: Project,
           vmParams = PathMacroManager.getInstance(module).expandPath(vmParams)
         }
 
-        params.setEnv(getEnvVariables)
+        val mutableEnvVariables = new mutable.HashMap[String, String]() ++ getEnvVariables
+        params.setEnv(mutableEnvVariables)
 
         //expand environment variables in vmParams
         for (entry <- params.getEnv.entrySet) {


### PR DESCRIPTION
Previously, when modifying env variables in JavaParameters via the extension point, one could get the error that one tries to modify the immutable map.

From now on this map is mutable, what makes ScalaTest and other configuration types using AbstractTestRunConfiguration consistent with JUnit, ApplicationConfiguration etc.

For certain reasons I have to attach the below disclaimer:

THIS PROGRAM IS SUBJECT TO THE TERMS OF THE APACHE LICENSE VERSION 2.0.
THE FOLLOWING DISCLAIMER APPLIES TO ALL SOFTWARE CODE AND OTHER MATERIALS CONTRIBUTED IN CONNECTION WITH THIS SOFTWARE:
THIS SOFTWARE IS LICENSED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE AND ANY WARRANTY OF NON-INFRINGEMENT, ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. THIS SOFTWARE MAY BE REDISTRIBUTED TO OTHERS ONLY BY EFFECTIVELY USING THIS OR ANOTHER EQUIVALENT DISCLAIMER IN ADDITION TO ANY OTHER REQUIRED LICENSE TERMS.
ONLY THE SOFTWARE CODE AND OTHER MATERIALS CONTRIBUTED IN CONNECTION WITH THIS SOFTWARE, IF ANY, THAT ARE ATTACHED TO (OR OTHERWISE ACCOMPANY) THIS SUBMISSION (AND ORDINARY COURSE CONTRIBUTIONS OF FUTURES PATCHES THERETO) ARE TO BE CONSIDERED A CONTRIBUTION. NO OTHER SOFTWARE CODE OR MATERIALS ARE A CONTRIBUTION.
