### PR TITLE
SCL-11148: Inspections for sort{ed,By} with {head,last}

### DIFF
--- a/resources/META-INF/scala-plugin-common.xml
+++ b/resources/META-INF/scala-plugin-common.xml
@@ -1255,7 +1255,13 @@
         <localInspection implementationClass="org.jetbrains.plugins.scala.codeInspection.scaladoc.ScalaDocMissingParameterDescriptionInspection"
                          displayName="Missing tag parameter description" groupPath="Scala" groupName="Scaladoc" shortName="ScalaDocMissingParameterDescription"
                          level="WARNING" enabledByDefault="true" language="Scala" />
-        <!-- end of scaladoc inspections -->
+        <!--simplifications: sorted and head/last -->
+        <localInspection implementationClass="org.jetbrains.plugins.scala.codeInspection.collections.SortedMaxMinInspection"
+                       displayName="Sorted and head/last to max/min" groupPath="Scala, Collections" groupName="Simplifications: sorted and head/last"
+                       shortName="SortedHeadLast" level="WARNING"
+                       enabledByDefault="true" language="Scala"/>
+
+      <!-- end of scaladoc inspections -->
         <!-- end of inspections -->
 
         <library.type implementation="org.jetbrains.plugins.scala.project.ScalaLibraryType" />

--- a/resources/org/jetbrains/plugins/scala/codeInspection/InspectionBundle.properties
+++ b/resources/org/jetbrains/plugins/scala/codeInspection/InspectionBundle.properties
@@ -130,3 +130,8 @@ convert.null.initializer.to.underscore=Convert null initializer to _
 unnecessary.partial.function=Unnecessary partial function
 convert.to.anonymous.function=Convert to anonymous function
 replace.with.ampersand=Replace with ampersand
+
+replace.sorted.head.with.min=Replace with .min
+replace.sorted.last.with.max=Replace with .max
+replace.sortBy.head.with.minBy=Replace with .minBy
+replace.sortBy.last.with.maxBy=Replace with .maxBy

--- a/src/org/jetbrains/plugins/scala/codeInspection/collections/SortedMaxMinInspection.scala
+++ b/src/org/jetbrains/plugins/scala/codeInspection/collections/SortedMaxMinInspection.scala
@@ -1,0 +1,52 @@
+package org.jetbrains.plugins.scala.codeInspection.collections
+
+import org.jetbrains.plugins.scala.codeInspection.InspectionBundle
+import org.jetbrains.plugins.scala.lang.psi.api.expr.ScExpression
+
+/**
+ * @author Markus.Hauck
+ */
+class SortedMaxMinInspection extends OperationOnCollectionInspection {
+  override def possibleSimplificationTypes: Array[SimplificationType] =
+    Array(SortedHeadIsMin, SortedLastIsMax, SortByHeadIsMinBy, SortByLastIsMaxBy)
+}
+
+object SortedHeadIsMin extends SimplificationType {
+  override def hint: String = InspectionBundle.message("replace.sorted.head.with.min")
+
+  override def getSimplification(expr: ScExpression): Option[Simplification] = expr match {
+    case qual`.sorted`()`.head`() =>
+      Some(replace(expr).withText(invocationText(qual, "min")).highlightFrom(qual))
+    case _ => None
+  }
+}
+
+object SortedLastIsMax extends SimplificationType {
+  override def hint: String = InspectionBundle.message("replace.sorted.last.with.max")
+
+  override def getSimplification(expr: ScExpression): Option[Simplification] = expr match {
+    case qual`.sorted`()`.last`() =>
+      Some(replace(expr).withText(invocationText(qual, "max")).highlightFrom(qual))
+    case _ => None
+  }
+}
+
+object SortByHeadIsMinBy extends SimplificationType {
+  override def hint: String = InspectionBundle.message("replace.sortBy.head.with.minBy")
+
+  override def getSimplification(expr: ScExpression): Option[Simplification] = expr match {
+    case qual`.sortBy`(f)`.head`() =>
+      Some(replace(expr).withText(invocationText(qual, "minBy", f)).highlightFrom(qual))
+    case _ => None
+  }
+}
+
+object SortByLastIsMaxBy extends SimplificationType {
+  override def hint: String = InspectionBundle.message("replace.sortBy.last.with.maxBy")
+
+  override def getSimplification(expr: ScExpression): Option[Simplification] = expr match {
+    case qual`.sortBy`(f)`.last`() =>
+      Some(replace(expr).withText(invocationText(qual, "maxBy", f)).highlightFrom(qual))
+    case _ => None
+  }
+}

--- a/src/org/jetbrains/plugins/scala/codeInspection/collections/package.scala
+++ b/src/org/jetbrains/plugins/scala/codeInspection/collections/package.scala
@@ -69,6 +69,8 @@ package object collections {
   private[collections] val `.getOnMap` = invocation("get").from(likeCollectionClasses).ref(checkResolveToMap)
   private[collections] val `.mapOnOption` = invocation("map").from(likeOptionClasses).ref(checkScalaVersion)
   private[collections] val `.sort` = invocation(Set("sortWith", "sortBy", "sorted")).from(likeCollectionClasses)
+  private[collections] val `.sorted` = invocation("sorted").from(likeCollectionClasses)
+  private[collections] val `.sortBy` = invocation("sortBy").from(likeCollectionClasses)
   private[collections] val `.reverse` = invocation("reverse").from(likeCollectionClasses)
   private[collections] val `.iterator` = invocation("iterator").from(likeCollectionClasses)
   private[collections] val `.apply` = invocation("apply")

--- a/test/org/jetbrains/plugins/scala/codeInspection/collections/SortedMaxMinInspectionTest.scala
+++ b/test/org/jetbrains/plugins/scala/codeInspection/collections/SortedMaxMinInspectionTest.scala
@@ -1,0 +1,62 @@
+package org.jetbrains.plugins.scala.codeInspection.collections
+
+import org.jetbrains.plugins.scala.codeInspection.InspectionBundle
+
+/**
+ * @author Markus.Hauck
+ */
+class SortedMaxInspectionTest extends OperationsOnCollectionInspectionTest {
+  override val inspectionClass: Class[_ <: OperationOnCollectionInspection] = classOf[SortedMaxMinInspection]
+
+  override def hint: String = InspectionBundle.message("replace.sorted.head.with.min")
+
+  def test(): Unit = {
+    doTest(
+      s"Seq(1,2,3).${START}sorted.head$END",
+      "Seq(1,2,3).sorted.head",
+      "Seq(1, 2, 3).min"
+    )
+  }
+}
+
+class SortedMinInspectionTest extends OperationsOnCollectionInspectionTest {
+  override val inspectionClass: Class[_ <: OperationOnCollectionInspection] = classOf[SortedMaxMinInspection]
+
+  override def hint: String = InspectionBundle.message("replace.sorted.last.with.max")
+
+  def test(): Unit = {
+    doTest(
+      s"Seq(1,2,3).${START}sorted.last$END",
+      "Seq(1,2,3).sorted.last",
+      "Seq(1, 2, 3).max"
+    )
+  }
+}
+
+class SortByMaxInspectionTest extends OperationsOnCollectionInspectionTest {
+  override val inspectionClass: Class[_ <: OperationOnCollectionInspection] = classOf[SortedMaxMinInspection]
+
+  override def hint: String = InspectionBundle.message("replace.sortBy.head.with.minBy")
+
+  def test(): Unit = {
+    doTest(
+      s"Seq(1,2,3).${START}sortBy(_.toString).head$END",
+      "Seq(1,2,3).sortBy(_.toString).head",
+      "Seq(1, 2, 3).minBy(_.toString)"
+    )
+  }
+}
+
+class SortByMinInspectionTest extends OperationsOnCollectionInspectionTest {
+  override val inspectionClass: Class[_ <: OperationOnCollectionInspection] = classOf[SortedMaxMinInspection]
+
+  override def hint: String = InspectionBundle.message("replace.sortBy.last.with.maxBy")
+
+  def test(): Unit = {
+    doTest(
+      s"Seq(1,2,3).${START}sortBy(_.toString).last$END",
+      "Seq(1,2,3).sortBy(_.toString).last",
+      "Seq(1, 2, 3).maxBy(_.toString)"
+    )
+  }
+}


### PR DESCRIPTION
Adds some inspection to simplify combinations of `sorted`/`sortBy` and `head`/`last`.

For example, we can convert `sorted.head` to `max`, improving performance while still having the same semantics.

Adds the following inspections:

```
- sorted.head    => min
- sorted.last    => max
- sortBy(f).head => minBy(f)
- sortBy(f).last => maxBy(f)
```

Relevant issue: https://youtrack.jetbrains.com/issue/SCL-11148