### PR TITLE
specs2 matcher inspection

### DIFF
--- a/resources/META-INF/scala-plugin-common.xml
+++ b/resources/META-INF/scala-plugin-common.xml
@@ -1262,6 +1262,10 @@
                          displayName="Missing tag parameter description" groupPath="Scala" groupName="Scaladoc" shortName="ScalaDocMissingParameterDescription"
                          level="WARNING" enabledByDefault="true" language="Scala" />
       <!-- end of scaladoc inspections -->
+
+        <localInspection implementationClass="org.jetbrains.plugins.scala.codeInspection.specs2.BuiltinMatcherExistsInspection"
+                         displayName="Specs2 Matchers" shortName="Specs2Matchers" groupName="Specs2" groupPath="Scala,Specs2"
+                         level="WARNING" enabledByDefault="true" language="Scala" />
         <!-- end of inspections -->
 
         <library.type implementation="org.jetbrains.plugins.scala.project.ScalaLibraryType" />

--- a/resources/org/jetbrains/plugins/scala/codeInspection/InspectionBundle.properties
+++ b/resources/org/jetbrains/plugins/scala/codeInspection/InspectionBundle.properties
@@ -135,3 +135,6 @@ replace.sorted.head.with.min=Replace with .min
 replace.sorted.last.with.max=Replace with .max
 replace.sortBy.head.with.minBy=Replace with .minBy
 replace.sortBy.last.with.maxBy=Replace with .maxBy
+
+specs2.builtin.matcher.alternative.exists=Available matcher exists
+specs2.use.builtin.matcher=Replace with builtin matcher

--- a/src/org/jetbrains/plugins/scala/codeInspection/specs2/BuiltinMatcherExistsInspection.scala
+++ b/src/org/jetbrains/plugins/scala/codeInspection/specs2/BuiltinMatcherExistsInspection.scala
@@ -1,0 +1,116 @@
+package org.jetbrains.plugins.scala.codeInspection.specs2
+
+import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import org.jetbrains.plugins.scala.codeInspection.{AbstractFixOnPsiElement, AbstractInspection, InspectionBundle}
+import org.jetbrains.plugins.scala.lang.psi.api.expr.{ScExpression, ScInfixExpr, ScMethodCall}
+import org.jetbrains.plugins.scala.lang.psi.impl.ScalaPsiElementFactory.createExpressionWithContextFromText
+import org.jetbrains.plugins.scala.lang.psi.types.ScType
+import org.jetbrains.plugins.scala.lang.psi.types.api.designator.ScDesignatorType
+import org.jetbrains.plugins.scala.lang.psi.types.result.Success
+
+class BuiltinMatcherExistsInspection
+  extends AbstractInspection("Specs2Matchers",
+                             InspectionBundle.message("specs2.builtin.matcher.alternative.exists")) {
+
+  def actionFor(holder: ProblemsHolder) = {
+    case elem @ ScMethodCall(matcher, Seq(ScMethodCall(inner, _))) if equalToMatcher(matcher) && optional(inner) =>
+      suggestFixForOptional(elem, holder)
+    case elem @ ScMethodCall(matcher, Seq(inner: ScExpression)) if equalToMatcher(matcher) && optional(inner) =>
+      suggestFixForOptional(elem, holder)
+    case elem @ ScMethodCall(matcher, Seq(ScMethodCall(inner, _))) if equalToMatcher(matcher) && either(inner) =>
+      suggestFixForEither(elem, holder)
+    case elem @ ScInfixExpr(_, op, ScMethodCall(inner, _)) if equalToOperator(op) && optional(inner) =>
+      suggestFixForMustOptional(elem, holder)
+    case elem @ ScInfixExpr(_, op, ScMethodCall(inner, _)) if equalToOperator(op) && either(inner) =>
+      suggestFixForMustEither(elem, holder)
+    case elem @ ScInfixExpr(_, op, inner: ScExpression) if equalToOperator(op) && optional(inner) =>
+      suggestFixForMustOptional(elem, holder)
+  }
+
+  private def suggestFixForOptional(elem: PsiElement, holder: ProblemsHolder) =
+    holder.registerProblem(elem, InspectionBundle.message("specs2.use.builtin.matcher"),
+                           new ReplaceWithBeSomeOrNoneQuickFix(elem))
+
+  private def suggestFixForMustOptional(elem: PsiElement, holder: ProblemsHolder) =
+    holder.registerProblem(elem, InspectionBundle.message("specs2.use.builtin.matcher"),
+                           new ReplaceMustWithBeSomeOrNoneQuickFix(elem))
+
+  private def suggestFixForEither(elem: PsiElement, holder: ProblemsHolder) =
+    holder.registerProblem(elem, InspectionBundle.message("specs2.use.builtin.matcher"),
+                           new ReplaceWithBeLeftOrRightQuickFix(elem))
+
+  private def suggestFixForMustEither(elem: PsiElement, holder: ProblemsHolder) =
+    holder.registerProblem(elem, InspectionBundle.message("specs2.use.builtin.matcher"),
+                           new ReplaceWithMustBeLeftOrRightQuickFix(elem))
+
+  private val EqualToMatchers = Seq("be_===", "be_==", "beEqualTo", "equalTo", "beTypedEqualTo", "typedEqualTo")
+  private val EqualToOperators = Seq("must_===", "must_==", "mustEqual")
+
+  private def equalToMatcher(expr: ScExpression) = EqualToMatchers.contains(expr.getText)
+  private def equalToOperator(expr: ScExpression) = EqualToOperators.contains(expr.getText)
+
+  private def optional(expr: ScExpression) = expr.getText == "Some" || expr.getText == "None"
+  private def either(expr: ScExpression) = expr.getText == "Left" || expr.getText == "Right"
+
+  private class ReplaceWithBeSomeOrNoneQuickFix(element: PsiElement)
+    extends AbstractFixOnPsiElement(InspectionBundle.message("specs2.builtin.matcher.alternative.exists"), element) {
+
+    def doApplyFix(project: Project): Unit = {
+      val expr = getElement
+      expr match {
+        case ScMethodCall(_, Seq(ScMethodCall(option , Seq(value)))) if option.getText == "Some" =>
+          repair(s"beSome(${value.getText})", expr)
+        case ScMethodCall(_, Seq(inner: ScExpression)) if inner.getText == "None" =>
+          repair(s"beNone", expr)
+      }
+    }
+  }
+
+  private class ReplaceMustWithBeSomeOrNoneQuickFix(element: PsiElement)
+    extends AbstractFixOnPsiElement(InspectionBundle.message("specs2.builtin.matcher.alternative.exists"), element) {
+
+    def doApplyFix(project: Project): Unit = {
+      val expr = getElement
+      expr match {
+        case ScInfixExpr(bexpr, op, ScMethodCall(option, Seq(value))) if option.getText == "Some" =>
+          repair(s"${bexpr.getText} must beSome(${value.getText})", expr)
+        case ScInfixExpr(bexpr, op, inner: ScExpression) if inner.getText == "None" =>
+          repair(s"${bexpr.getText} must beNone", expr)
+      }
+    }
+  }
+
+  private class ReplaceWithBeLeftOrRightQuickFix(element: PsiElement)
+    extends AbstractFixOnPsiElement(InspectionBundle.message("specs2.builtin.matcher.alternative.exists"), element) {
+
+    def doApplyFix(project: Project): Unit =
+      getElement match {
+        case expr @ ScMethodCall(_, Seq(ScMethodCall(option , Seq(value)))) =>
+          if (option.getText == "Left")
+            repair(s"beLeft(${value.getText})", expr)
+          if (option.getText == "Right")
+            repair(s"beRight(${value.getText})", expr)
+      }
+  }
+
+  private class ReplaceWithMustBeLeftOrRightQuickFix(element: PsiElement)
+    extends AbstractFixOnPsiElement(InspectionBundle.message("specs2.builtin.matcher.alternative.exists"), element) {
+
+    def doApplyFix(project: Project): Unit = {
+      val expr = getElement
+      expr match {
+        case ScInfixExpr(bexpr, op, ScMethodCall(option, Seq(value))) if option.getText == "Left" =>
+          repair(s"${bexpr.getText} must beLeft(${value.getText})", expr)
+        case ScInfixExpr(bexpr, op, ScMethodCall(option, Seq(value))) if option.getText == "Right" =>
+          repair(s"${bexpr.getText} must beRight(${value.getText})", expr)
+      }
+    }
+  }
+
+  private def repair(fixed: String, expr: PsiElement) = {
+    val retStmt = createExpressionWithContextFromText(fixed, expr.getContext, expr)
+    expr.replace(retStmt)
+  }
+}

--- a/test/org/jetbrains/plugins/scala/codeInspection/specs2/BuiltinMatcherExistsInspectionTest.scala
+++ b/test/org/jetbrains/plugins/scala/codeInspection/specs2/BuiltinMatcherExistsInspectionTest.scala
@@ -1,0 +1,133 @@
+package org.jetbrains.plugins.scala.codeInspection.specs2
+
+import com.intellij.testFramework.EditorTestUtil.{SELECTION_END_TAG => END, SELECTION_START_TAG => START}
+import org.jetbrains.plugins.scala.codeInspection.{InspectionBundle, ScalaLightInspectionFixtureTestAdapter}
+
+class BuiltinMatcherExistsInspectionTest extends ScalaLightInspectionFixtureTestAdapter {
+
+  protected val annotation = InspectionBundle.message("specs2.use.builtin.matcher")
+  private val hint = InspectionBundle.message("specs2.builtin.matcher.alternative.exists")
+  protected val classOfInspection = classOf[BuiltinMatcherExistsInspection]
+
+  //OperationOnCollectionInspectionBase
+  def testMustBeSomeSimplification(): Unit = {
+    Seq("be_===", "be_==", "beEqualTo", "equalTo", "beTypedEqualTo", "typedEqualTo").foreach { matcher =>
+      val code =
+        s"""
+          |expr must $START$matcher(Some("123"))$END
+        """.stripMargin
+      val expected =
+        """
+          |expr must beSome("123")
+        """.stripMargin
+
+      check(code)
+
+      testFix(code, expected, hint)
+    }
+  }
+
+  def testMustBeNoneSimplification(): Unit = {
+    Seq("be_===", "be_==", "beEqualTo", "equalTo", "beTypedEqualTo", "typedEqualTo").foreach { matcher =>
+      val code =
+        s"""
+          |expr must $START$matcher(None)$END
+        """.stripMargin
+      val expected =
+        """
+          |expr must beNone
+        """.stripMargin
+
+      check(code)
+
+      testFix(code, expected, hint)
+    }
+  }
+
+  def testMustBeLeftSimplification(): Unit = {
+    Seq("be_===", "be_==", "beEqualTo", "equalTo", "beTypedEqualTo", "typedEqualTo").foreach { matcher =>
+      val code =
+        s"""
+           |expr must $START$matcher(Left("123"))$END
+        """.stripMargin
+      val expected =
+        """
+          |expr must beLeft("123")
+        """.stripMargin
+
+      check(code)
+
+      testFix(code, expected, hint)
+    }
+  }
+
+  def testMustBeRightSimplification(): Unit = {
+    Seq("be_===", "be_==", "beEqualTo", "equalTo", "beTypedEqualTo", "typedEqualTo").foreach { matcher =>
+      val code =
+        s"""
+           |expr must $START$matcher(Right("123"))$END
+        """.stripMargin
+      val expected =
+        """
+          |expr must beRight("123")
+        """.stripMargin
+
+      check(code)
+
+      testFix(code, expected, hint)
+    }
+  }
+
+  def testMustEqualBeSomeSimplification(): Unit = {
+    Seq("must_===", "must_==", "mustEqual").foreach { matcher =>
+      val code =
+        s"""
+           |${START}expr must_=== Some("123")$END
+        """.stripMargin
+      val expected =
+        """
+          |expr must beSome("123")
+        """.stripMargin
+
+      check(code)
+
+      testFix(code, expected, hint)
+    }
+  }
+
+  def testMustEqualBeNoneSimplification(): Unit = {
+    Seq("must_===", "must_==", "mustEqual").foreach { matcher =>
+      val code =
+        s"""
+           |${START}expr must_=== None$END
+        """.stripMargin
+      val expected =
+        """
+          |expr must beNone
+        """.stripMargin
+
+      check(code)
+
+      testFix(code, expected, hint)
+    }
+  }
+
+  def testMustEqualBeEitherSimplification(): Unit = {
+    Seq("must_===", "must_==", "mustEqual").foreach { matcher =>
+      Seq("Left", "Right").foreach { either =>
+        val code =
+          s"""
+             |${START}expr must_=== $either("123")$END
+          """.stripMargin
+        val expected =
+          s"""
+            |expr must be$either("123")
+          """.stripMargin
+
+        check(code)
+
+        testFix(code, expected, hint)
+      }
+    }
+  }
+}


### PR DESCRIPTION
Created a specs2 matchers inspection, in cases when developer is using equal to matchers in stead of using the builtin matcher
``` xxx must be_===( Some(x) ) => xxx must beSome( x ) ```

Added for two cases for now, Option and Either.