### PR TITLE
Displaying package names in "Change Type Fix" when needed.

### DIFF
--- a/src/org/jetbrains/plugins/scala/annotator/quickfix/ChangeTypeFix.scala
+++ b/src/org/jetbrains/plugins/scala/annotator/quickfix/ChangeTypeFix.scala
@@ -12,9 +12,11 @@ import org.jetbrains.plugins.scala.lang.psi.ScalaPsiUtil
 import org.jetbrains.plugins.scala.lang.psi.api.base.types.ScTypeElement
 import org.jetbrains.plugins.scala.lang.psi.impl.ScalaPsiElementFactory.createTypeElementFromText
 import org.jetbrains.plugins.scala.lang.psi.types.ScType
+import org.jetbrains.plugins.scala.lang.psi.types.api.ScTypePresentation
 
 class ChangeTypeFix(typeElement: ScTypeElement, newType: ScType) extends IntentionAction {
-  val getText: String = "Change type '%s' to '%s'".format(typeElement.getText, newType.presentableText)
+  val (oldTypeDescripton, newTypeDescription) = ScTypePresentation.different(typeElement.calcType, newType)
+  val getText: String = "Change type '%s' to '%s'".format(oldTypeDescripton, newTypeDescription)
 
   def getFamilyName: String = "Change Type"
 


### PR DESCRIPTION
The text looked bad if class names were the same, now the package names are displayed in that case.
