### PR TITLE
Don't mark final modifier on constant expressions as redundant

### DIFF
--- a/src/org/jetbrains/plugins/scala/annotator/modifiers/ModifierChecker.scala
+++ b/src/org/jetbrains/plugins/scala/annotator/modifiers/ModifierChecker.scala
@@ -93,8 +93,8 @@ private[annotator] object ModifierChecker {
                   }
                 case e: ScMember if e.getParent.isInstanceOf[ScTemplateBody] || e.getParent.isInstanceOf[ScEarlyDefinitions] =>
                   val redundant = (e.containingClass, e) match {
-                    case (_: ScObject, valMember: ScPatternDefinition) if valMember.typeElement.isEmpty &&
-                      valMember.pList.simplePatterns => false // SCL-899
+                    case (_, valMember: ScPatternDefinition) if valMember.typeElement.isEmpty &&
+                      valMember.pList.simplePatterns => false // SCL-899, SCL-11500
                     case (cls, _) if cls.hasFinalModifier => true
                     case _ => false
                   }

--- a/test/org/jetbrains/plugins/scala/annotator/AnnotatorHolderMock.scala
+++ b/test/org/jetbrains/plugins/scala/annotator/AnnotatorHolderMock.scala
@@ -18,6 +18,7 @@ class AnnotatorHolderMock(file: PsiFile) extends AnnotationHolder {
     case error: Error => true
     case _ => false
   }
+  def warningAnnotations = annotations.collect { case e: Warning => e }
 
   private var myAnnotations = List[Message]()
 
@@ -42,7 +43,10 @@ class AnnotatorHolderMock(file: PsiFile) extends AnnotationHolder {
 
   def createInformationAnnotation(elt: PsiElement, message: String) = FakeAnnotation
 
-  def createWarningAnnotation(range: TextRange, message: String) = FakeAnnotation
+  def createWarningAnnotation(range: TextRange, message: String) = {
+    myAnnotations ::= WarningWithRange(range, message)
+    FakeAnnotation
+  }
 
   def createWarningAnnotation(node: ASTNode, message: String) = FakeAnnotation
 

--- a/test/org/jetbrains/plugins/scala/annotator/Message.scala
+++ b/test/org/jetbrains/plugins/scala/annotator/Message.scala
@@ -9,5 +9,6 @@ import com.intellij.openapi.util.TextRange
 sealed class Message
 case class Info(element: String, message: String) extends Message
 case class Warning(element: String, message: String) extends Message
+case class WarningWithRange(range: TextRange, message: String) extends Message
 case class Error(element: String, message: String) extends Message
 case class ErrorWithRange(range: TextRange, message: String) extends Message

--- a/test/org/jetbrains/plugins/scala/annotator/modifiers/ModifierCheckerTest.scala
+++ b/test/org/jetbrains/plugins/scala/annotator/modifiers/ModifierCheckerTest.scala
@@ -1,0 +1,60 @@
+package org.jetbrains.plugins.scala
+package annotator.modifiers
+
+import org.intellij.lang.annotations.Language
+import org.jetbrains.plugins.scala.annotator._
+import org.jetbrains.plugins.scala.base.SimpleTestCase
+import org.jetbrains.plugins.scala.extensions._
+import org.jetbrains.plugins.scala.lang.psi.api.base.ScModifierList
+
+class ModifierCheckerTest extends SimpleTestCase {
+  def testToplevelObject(): Unit = {
+    assertMatches(messages("final object A")) {
+      case List(WarningWithRange(_,RedundantFinal())) =>
+    }
+  }
+
+  def testInnerObject(): Unit = {
+    assertMatches(messages("object A { final object B }")) {
+      case Nil => // SCL-10420
+    }
+  }
+
+  def testFinalValConstant(): Unit = {
+    assertMatches(messages(
+      """
+        |final class Foo {
+        |  final val constant = "This is a constant string that will be inlined"
+        |}
+      """.stripMargin)) {
+      case Nil => // SCL-11500
+    }
+  }
+
+  def testFinalValConstantAnnotated(): Unit = {
+    assertMatches(messages(
+      """
+        |final class Foo {
+        |  final val constant: String = "With annotation there is no inlining"
+        |}
+      """.stripMargin)) {
+      case List(WarningWithRange(_,RedundantFinal())) => // SCL-11500
+    }
+  }
+
+  def messages(@Language(value = "Scala") code: String): List[Message] = {
+    val file = code.parse
+    val modifiers = file.depthFirst().filterByType(classOf[ScModifierList])
+
+    val mock = new AnnotatorHolderMock(file)
+
+    modifiers.foreach(ModifierChecker.checkModifiers(_,mock))
+    mock.annotations
+  }
+
+  val RedundantFinal = StartWith("'final' modifier is redundant")
+
+  case class StartWith(fragment: String) {
+    def unapply(s: String): Boolean = s.startsWith(fragment)
+  }
+}


### PR DESCRIPTION
YouTrack Issue: https://youtrack.jetbrains.com/issue/SCL-11500
Consider the following code:

```
final class Foo {
  final val x = "" // final is NOT redundant
}
```

Currently Intellij marks the val `x` as `'final' is redundant for objects and final class members`.
This is wrong however because according to the Scala Language Specification 4.1 (http://www.scala-lang.org/files/archive/spec/2.12/04-basic-declarations-and-definitions.html):

> A constant value definition is of the form
> ```
> final val x = e
> ```
> where e is a constant expression. The final modifier must be present and no type annotation may be given. References to the constant value x are themselves treated as constant expressions; in the generated code they are replaced by the definition's right-hand side e.

So in the above code example the `final` modifier is not redundant on `x`, as long as there is no type annotation.

This removes the warning iff it is a `final val` without type annotations and adds a test suite for `ModifierChecker`.