### PR TITLE
Displaying type names in ComparingUnrelatedTypesInspection.

### DIFF
--- a/src/org/jetbrains/plugins/scala/codeInspection/typeChecking/ComparingUnrelatedTypesInspection.scala
+++ b/src/org/jetbrains/plugins/scala/codeInspection/typeChecking/ComparingUnrelatedTypesInspection.scala
@@ -85,7 +85,8 @@ class ComparingUnrelatedTypesInspection extends AbstractInspection(inspectionId,
         val leftOnTheRight = ScalaPsiElementFactory.createExpressionWithContextFromText(left.getText, right.getParent, right)
         Seq(leftOnTheRight, right) map (_.getType()) match {
           case Seq(Success(leftType, _), Success(rightType, _)) if cannotBeCompared(leftType, rightType) =>
-            holder.registerProblem(expr, inspectionName, ProblemHighlightType.GENERIC_ERROR_OR_WARNING)
+            val message = generateComparingUnrelatedTypesMsg(leftType, rightType)
+            holder.registerProblem(expr, message, ProblemHighlightType.GENERIC_ERROR_OR_WARNING)
           case _ =>
         }
       }
@@ -96,8 +97,7 @@ class ComparingUnrelatedTypesInspection extends AbstractInspection(inspectionId,
         argType <- arg.getType()
         if cannotBeCompared(elemType, argType)
       } {
-        val (elemTypeText, argTypeText) = ScTypePresentation.different(elemType, argType)
-        val message = InspectionBundle.message("comparing.unrelated.types.hint", elemTypeText, argTypeText)
+        val message = generateComparingUnrelatedTypesMsg(elemType, argType)
         holder.registerProblem(arg, message, ProblemHighlightType.GENERIC_ERROR_OR_WARNING)
       }
     case IsInstanceOfCall(call) =>
@@ -112,8 +112,14 @@ class ComparingUnrelatedTypesInspection extends AbstractInspection(inspectionId,
         t2 <- argType
         if cannotBeCompared(t1, t2)
       } {
-        holder.registerProblem(call, inspectionName, ProblemHighlightType.GENERIC_ERROR_OR_WARNING)
+        val message = generateComparingUnrelatedTypesMsg(t1, t2)
+        holder.registerProblem(call, message, ProblemHighlightType.GENERIC_ERROR_OR_WARNING)
       }
+  }
+
+  private def generateComparingUnrelatedTypesMsg(firstType: ScType, secondType: ScType): String = {
+    val (firstTypeText, secondTypeText) = ScTypePresentation.different(firstType, secondType)
+    InspectionBundle.message("comparing.unrelated.types.hint", firstTypeText, secondTypeText)
   }
 
   private def holderTypeSystem(holder: ProblemsHolder) = holder.getProject.typeSystem

--- a/test/org/jetbrains/plugins/scala/codeInspection/ScalaInspectionTestBase.scala
+++ b/test/org/jetbrains/plugins/scala/codeInspection/ScalaInspectionTestBase.scala
@@ -22,20 +22,27 @@ abstract class ScalaInspectionTestBase extends ScalaLightCodeInsightFixtureTestA
   protected val classOfInspection: Class[_ <: LocalInspectionTool]
   protected val description: String
 
-  override protected final def checkTextHasNoErrors(text: String): Unit = {
-    val ranges = configureByText(text).map(_._2)
+  override protected final def checkTextHasNoErrors(text: String): Unit = checkTextHasNoErrors(text, _ == normalize(description))
+
+  protected final def checkTextHasError(text: String): Unit = checkTextHasError(text, description)
+
+  protected final def checkTextHasNoErrors(text: String, descriptionMatcher: String => Boolean): Unit = {
+    val ranges = configureByText(text, descriptionMatcher).map(_._2)
     assertTrue(s"Highlights found at: ${ranges.mkString(", ")}.", ranges.isEmpty)
   }
 
-  protected final def checkTextHasError(text: String): Unit = {
-    val ranges = configureByText(text).map(_._2)
-    assertTrue(s"Highlights not found: $description", ranges.nonEmpty)
+  protected final def checkTextHasError(text: String, errorDescription : String): Unit = {
+    val ranges = configureByText(text, _ == normalize(errorDescription)).map(_._2)
+
+    def allHintsDescriptions = configureByText(text, _ => true).map(_._1).map(_.getDescription).filter(_ != null)
+
+    assertTrue(s"Highlights not found: $errorDescription, found hints: $allHintsDescriptions", ranges.nonEmpty)
 
     val range = selectedRange(getEditor.getSelectionModel)
     assertTrue(s"Highlights found at: ${ranges.mkString(", ")}, not found: $range", ranges.contains(range))
   }
 
-  protected final def configureByText(text: String): Seq[(HighlightInfo, TextRange)] = {
+  protected final def configureByText(text: String, descriptionMatcher: String => Boolean): Seq[(HighlightInfo, TextRange)] = {
     val (normalizedText, offset) = findCaretOffset(text, stripTrailingSpaces = true)
 
     val fixture = getFixture
@@ -44,7 +51,7 @@ abstract class ScalaInspectionTestBase extends ScalaLightCodeInsightFixtureTestA
 
     import scala.collection.JavaConversions._
     fixture.doHighlighting()
-      .filter(_.getDescription == normalize(description))
+      .filter(highlightInfo => descriptionMatcher(highlightInfo.getDescription))
       .map(info => (info, highlightedRange(info)))
       .filter(checkOffset(_, offset))
   }
@@ -66,7 +73,7 @@ object ScalaInspectionTestBase {
 abstract class ScalaQuickFixTestBase extends ScalaInspectionTestBase {
 
   protected final def testQuickFix(text: String, expected: String, hint: String): Unit = {
-    val highlights = configureByText(text).map(_._1)
+    val highlights = configureByText(text, _ == normalize(description)).map(_._1)
 
     import ScalaQuickFixTestBase._
     val actions = highlights.flatMap(quickFixes)


### PR DESCRIPTION
The inspection description now says which types cannot be compared so that it's easier to find an error, especially when comparing two types with same name but different packages.
ScalaInspectionTestBase methods that check if there are errors are slightly changed so that it is possible to test for inspections with non-constant description.

It looks like in some cases from tests the type description looks a bit strange (`B.type` when B is an object or `a.type` when comparing with `isInstanceOf`) but I believe it is still much better than not having types in descriptions at all. 