### PR TITLE
Fix for SCL-11344 (apply inherited from generic trait)

### DIFF
--- a/src/org/jetbrains/plugins/scala/lang/psi/impl/toplevel/imports/ScImportStmtImpl.scala
+++ b/src/org/jetbrains/plugins/scala/lang/psi/impl/toplevel/imports/ScImportStmtImpl.scala
@@ -9,7 +9,6 @@ import com.intellij.lang.ASTNode
 import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.util.Key
 import com.intellij.psi._
-import com.intellij.psi.stubs.StubElement
 import com.intellij.psi.util.PsiTreeUtil
 import org.jetbrains.plugins.scala.caches.ScalaShortNamesCacheManager
 import org.jetbrains.plugins.scala.extensions._
@@ -71,11 +70,12 @@ class ScImportStmtImpl private (stub: ScImportStmtStub, node: ASTNode)
         if (name != "" && !importExpr.isSingleWildcard) {
           val decodedName = ScalaNamesUtil.clean(name)
           importExpr.selectorSet match {
-            case Some(set) => set.selectors.flatMap {
-              _.reference
-            }.exists {
-              reference => ScalaNamesUtil.clean(reference.refName) == decodedName
-            }
+            case Some(set) =>
+              val containsImportWithDifferentName =
+                set.selectors
+                  .flatMap(_.reference)
+                  .exists(selectorReference => ScalaNamesUtil.clean(selectorReference.refName) != decodedName)
+              if (containsImportWithDifferentName) return true
             case None => if (ScalaNamesUtil.clean(ref.refName) != decodedName) return true
           }
         }

--- a/test/org/jetbrains/plugins/scala/annotator/ApplyTest.scala
+++ b/test/org/jetbrains/plugins/scala/annotator/ApplyTest.scala
@@ -2,8 +2,6 @@ package org.jetbrains.plugins.scala.annotator
 
 import org.jetbrains.plugins.scala.base.ScalaLightCodeInsightFixtureTestAdapter
 
-import scala.concurrent.Future
-
 /**
   * Created by kate on 6/7/16.
   */
@@ -27,6 +25,25 @@ class ApplyTest extends ScalaLightCodeInsightFixtureTestAdapter {
         |}""".stripMargin
 
     checkTextHasNoErrors(code)
+  }
+
+  def testSCL11344(): Unit = {
+    checkTextHasNoErrors(
+      """
+        |import ObjectInt.{CaseClassInObjectInt}
+        |
+        |
+        |trait CommonObjectTraitWithApply[T] {
+        |  def apply(arg: T): T = arg
+        |
+        |}
+        |
+        |object ObjectInt extends CommonObjectTraitWithApply[Int]{
+        |  ObjectInt(123)
+        |  case class CaseClassInObjectInt()
+        |}
+        |
+    """.stripMargin)
   }
 
   def testApplyFromImplicitConversion(): Unit = {


### PR DESCRIPTION
* I modified lines that handled curly brace imports in ScImportStmtImpl but appeared to have completely no effect (boolean result was ignored) - I believe I made the behavior similar to singular imports
* Added test for SCL-11344 in ApplyTest.scala

I've spent a few days trying to find the source of this bug and I am still not sure whether it is a good way to fix it and if there might be negative performance implications. I don't think I can do any better though so I thought it might be a good idea to just create a pull request and find out if the change makes any sense :-) The lines I changed in ScImportStmtImpl seemed really suspicious, so even if the fix is not appropriate I believe it's worth to take a look at the code there :-) 
