### PR TITLE
Fix run icon for tests with no state.

### DIFF
--- a/src/org/jetbrains/plugins/scala/testingSupport/test/ScalaTestRunLineMarkerProvider.scala
+++ b/src/org/jetbrains/plugins/scala/testingSupport/test/ScalaTestRunLineMarkerProvider.scala
@@ -66,16 +66,17 @@ class ScalaTestRunLineMarkerProvider extends TestRunLineMarkerProvider {
 
   private def getInfo(url: String, project: Project, isClass: Boolean) = {
     import com.intellij.execution.testframework.sm.runner.states.TestStateInfo.Magnitude._
-    Option(TestStateStorage.getInstance(project).getState(url)).
-      map(state => TestIconMapper.getMagnitude(state.magnitude)).map {
-      case ERROR_INDEX | FAILED_INDEX => AllIcons.RunConfigurations.TestState.Red2
-      case PASSED_INDEX | COMPLETE_INDEX => AllIcons.RunConfigurations.TestState.Green2
-      case _ => if (isClass) AllIcons.RunConfigurations.TestState.Run_run else AllIcons.RunConfigurations.TestState.Run
-    }.map {
-      icon =>
-        new RunLineMarkerContributor.Info(icon, ScalaTestRunLineMarkerProvider.TOOLTIP_PROVIDER,
-          ExecutorAction.getActions(1): _*)
-    }.orNull
+    val icon = Option(TestStateStorage.getInstance(project).getState(url))
+      .map(state => TestIconMapper.getMagnitude(state.magnitude))
+      .map {
+        case ERROR_INDEX | FAILED_INDEX => AllIcons.RunConfigurations.TestState.Red2
+        case PASSED_INDEX | COMPLETE_INDEX => AllIcons.RunConfigurations.TestState.Green2
+      }.getOrElse(
+        if (isClass) AllIcons.RunConfigurations.TestState.Run_run
+        else AllIcons.RunConfigurations.TestState.Run
+      )
+    new RunLineMarkerContributor.Info(icon, ScalaTestRunLineMarkerProvider.TOOLTIP_PROVIDER,
+      ExecutorAction.getActions(1): _*)
   }
 }
 


### PR DESCRIPTION
A test with no state (i.e., never been run) will return a null state, which causes `getInfo` to return a null info, which is a different behavior from [`TestRunLineMarkerProvider#getInfo`](https://github.com/JetBrains/intellij-community/blob/17524f2daad119a134a2c9052c5977d940432f25/java/java-impl/src/com/intellij/testIntegration/TestRunLineMarkerProvider.java#L68), which never returns null.