### PR TITLE
Macro support for scalaz-deriving

### DIFF
--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -187,6 +187,7 @@ object DependencyGroups {
     "com.github.julien-truffaut"  %%  "monocle-core"    % "1.2.0",
     "com.github.julien-truffaut"  %%  "monocle-generic" % "1.2.0",
     "com.github.julien-truffaut"  %%  "monocle-macro"   % "1.2.0",
+    "com.fommil" %% "stalactite" % "0.0.2",
     "io.spray" %% "spray-routing" % "1.3.1",
     "com.typesafe.slick" %% "slick" % "3.2.0",
     "org.scala-lang.modules" % "scala-async_2.11" % "0.9.5",

--- a/resources/META-INF/scala-plugin-common.xml
+++ b/resources/META-INF/scala-plugin-common.xml
@@ -23,6 +23,7 @@
     <extensions defaultExtensionNs="org.intellij.scala">
         <!--<syntheticMemberInjector implementation="scala.meta.MetaAnnotationInjector"/>-->
         <syntheticMemberInjector implementation="org.jetbrains.plugins.scala.lang.psi.impl.toplevel.typedef.MonocleInjector"/>
+        <syntheticMemberInjector implementation="org.jetbrains.plugins.scala.lang.psi.impl.toplevel.typedef.StalactiteInjector"/>
         <syntheticMemberInjector implementation="scala.meta.intellij.MetaSupportInjector"/>
         <syntheticMemberInjector implementation="org.jetbrains.plugins.scala.lang.psi.impl.toplevel.typedef.QuasiQuotesInjector"/>
         <syntheticMemberInjector implementation="org.jetbrains.plugins.scala.lang.psi.impl.toplevel.typedef.simulacrum.SimulacrumInjection"/>

--- a/src/org/jetbrains/plugins/scala/lang/psi/impl/toplevel/typedef/StalactiteInjector.scala
+++ b/src/org/jetbrains/plugins/scala/lang/psi/impl/toplevel/typedef/StalactiteInjector.scala
@@ -1,0 +1,57 @@
+package org.jetbrains.plugins.scala.lang.psi.impl.toplevel.typedef
+
+import org.jetbrains.plugins.scala.lang.psi.api.toplevel.typedef._
+import org.jetbrains.plugins.scala.lang.psi.api.expr.ScAnnotation
+
+/**
+ * Support for https://github.com/fommil/stalactite
+ *
+ * Chooses to skip typeclass derivation (and requirements) in order to
+ * provide a much faster editing experience. Users may experience
+ * deriving failures when they run the real compiler.
+ *
+ * @author Sam Halliday
+ * @since  24/08/2017
+ */
+class StalactiteInjector extends SyntheticMembersInjector {
+  // fast check
+  def hasStalactite(source: ScTypeDefinition): Boolean =
+    source.findAnnotationNoAliases("stalactite.deriving") != null
+
+  // slower, more correct
+  def stalactite(source: ScTypeDefinition): ScAnnotation = {
+    val candidates = source.annotations("stalactite.deriving")
+    if (candidates.size != 1)
+      throw new IllegalArgumentException("expected a single @deriving annotation")
+    candidates.head
+  }
+
+  // so annotated sealed traits will generate a companion
+  override def needsCompanionObject(source: ScTypeDefinition): Boolean =
+    hasStalactite(source)
+
+  // add implicits to case object / case class companions
+  override def injectFunctions(source: ScTypeDefinition): Seq[String] =
+    source match {
+      case cob: ScObject if hasStalactite(cob) =>
+        genImplicits(cob.name + ".type", stalactite(cob))
+      case obj: ScObject =>
+        obj.fakeCompanionClassOrCompanionClass match {
+          case clazz: ScTypeDefinition if hasStalactite(clazz) =>
+            genImplicits(clazz.name, stalactite(clazz))
+          case _ => Nil
+        }
+      case _ => Nil
+    }
+
+  def genImplicits(clazz: String, stalactite: ScAnnotation) = {
+    stalactite
+      .annotationExpr
+      .getAnnotationParameters
+      .map { param =>
+        val typeclass = param.getText
+        val gen = param.getText // would be more correct to use the FQN
+        s"implicit def `$gen`: $typeclass[${clazz}] = _root_.scala.Predef.???"
+      }
+  }
+}

--- a/src/org/jetbrains/plugins/scala/lang/psi/impl/toplevel/typedef/StalactiteInjector.scala
+++ b/src/org/jetbrains/plugins/scala/lang/psi/impl/toplevel/typedef/StalactiteInjector.scala
@@ -19,12 +19,8 @@ class StalactiteInjector extends SyntheticMembersInjector {
     source.findAnnotationNoAliases("stalactite.deriving") != null
 
   // slower, more correct
-  def stalactite(source: ScTypeDefinition): ScAnnotation = {
-    val candidates = source.annotations("stalactite.deriving")
-    if (candidates.size != 1)
-      throw new IllegalArgumentException("expected a single @deriving annotation")
-    candidates.head
-  }
+  def stalactite(source: ScTypeDefinition): ScAnnotation =
+    source.annotations("stalactite.deriving").head
 
   // so annotated sealed traits will generate a companion
   override def needsCompanionObject(source: ScTypeDefinition): Boolean =

--- a/src/org/jetbrains/plugins/scala/statistics/ScalaApplicationUsagesCollector.scala
+++ b/src/org/jetbrains/plugins/scala/statistics/ScalaApplicationUsagesCollector.scala
@@ -97,6 +97,7 @@ class ScalaApplicationUsagesCollector extends AbstractApplicationUsagesCollector
         checkLibrary("net.liftweb", "Lift Framework")
         checkLibrary("spray", "Spray")
         checkLibrary("monocle", "Monocle")
+        checkLibrary("stalactite", "Stalactite")
 
         java_version.foreach {
           case version: String => set += new UsageDescriptor(s"Java version: $version", 1)

--- a/test/org/jetbrains/plugins/scala/lang/macros/StalactiteTest.scala
+++ b/test/org/jetbrains/plugins/scala/lang/macros/StalactiteTest.scala
@@ -1,0 +1,130 @@
+package org.jetbrains.plugins.scala.lang.macros
+
+import com.intellij.openapi.module.Module
+import com.intellij.psi.util.PsiTreeUtil
+import org.jetbrains.plugins.scala.base.ScalaLightPlatformCodeInsightTestCaseAdapter
+import org.jetbrains.plugins.scala.base.libraryLoaders.{ IvyLibraryLoaderAdapter, ThirdPartyLibraryLoader }
+import org.jetbrains.plugins.scala.debugger.{ ScalaVersion, Scala_2_11 }
+import org.jetbrains.plugins.scala.lang.psi.ScalaPsiElement
+import org.jetbrains.plugins.scala.lang.psi.api.statements.ScFunctionDefinition
+import org.jetbrains.plugins.scala.lang.psi.api.toplevel.typedef._
+import org.jetbrains.plugins.scala.lang.psi.types.result.{ Failure, Success }
+import org.jetbrains.plugins.scala.util.TestUtils
+import org.junit.Assert._
+
+/**
+ * IntelliJ's equivalent of stalactite's built-in PresentationCompilerTest
+ *
+ * @author Sam Halliday
+ * @since  24/08/2017
+ */
+class StalactiteTest extends ScalaLightPlatformCodeInsightTestCaseAdapter {
+
+  override implicit val version: ScalaVersion = Scala_2_11
+
+  override protected def additionalLibraries(): Array[ThirdPartyLibraryLoader] = {
+    implicit val module = getModuleAdapter
+    Array(StalactiteTest.StalactiteLoader())
+  }
+
+  protected def folderPath: String = TestUtils.getTestDataPath
+
+  def doTest(text: String, expectedType: String) = {
+    val caretPos = text.indexOf("<caret>")
+    configureFromFileTextAdapter("dummy.scala", text.replace("<caret>", ""))
+
+    val clazz = PsiTreeUtil
+      .findElementOfClassAtOffset(
+        getFileAdapter,
+        caretPos,
+        classOf[ScalaPsiElement],
+        false)
+      .asInstanceOf[ScTypeDefinition]
+
+    clazz
+      .fakeCompanionModule
+      .getOrElse(clazz.asInstanceOf[ScObject])
+      .allMethods
+      .collect {
+        case sig if sig.method.isInstanceOf[ScFunctionDefinition] => sig.method.asInstanceOf[ScFunctionDefinition]
+      }
+      .filter(_.getText.contains("implicit def")) // hacky
+      .headOption match {
+        case Some(method) =>
+          method.returnType match {
+            case Success(t, _) => assertEquals(s"${t.toString} != $expectedType", expectedType, t.toString)
+            case Failure(cause, _) => fail(cause)
+          }
+
+        case None =>
+          fail("no implicit def was generated")
+      }
+  }
+
+  def testClass = {
+    val fileText: String = """
+package wibble
+
+import stalactite._
+
+@typeclass trait Wibble[T] {}
+object DerivedWibble {
+  def gen[T]: Wibble[T] = new Wibble[T] {}
+}
+
+@deriving(Wibble)
+final case class <caret>Foo(string: String, int: Int)
+"""
+
+    doTest(fileText, "Wibble[Foo]")
+  }
+
+  def testTrait = {
+    val fileText: String = """
+package wibble
+
+import stalactite._
+
+@typeclass trait Wibble[T] {}
+object DerivedWibble {
+  def gen[T]: Wibble[T] = new Wibble[T] {}
+}
+
+@deriving(Wibble)
+sealed trait <caret>Baz
+
+@deriving(Wibble)
+final case class Foo(string: String, int: Int) extends Baz
+"""
+
+    doTest(fileText, "Wibble[Baz]")
+  }
+
+  def testObject = {
+    val fileText: String = """
+package wibble
+
+import stalactite._
+
+@typeclass trait Wibble[T] {}
+object DerivedWibble {
+  def gen[T]: Wibble[T] = new Wibble[T] {}
+}
+
+@deriving(Wibble)
+case object <caret>Caz
+"""
+
+    doTest(fileText, "Wibble[Caz.type]")
+  }
+
+}
+
+object StalactiteTest {
+
+  case class StalactiteLoader(
+    version: String = "0.0.2",
+    vendor: String = "com.fommil",
+    name: String = "stalactite")(implicit val module: Module) extends IvyLibraryLoaderAdapter
+
+}


### PR DESCRIPTION
Will close https://github.com/fommil/stalactite/issues/1

This adds IntelliJ support for the `@deriving` macro https://github.com/fommil/stalactite/blob/30156ed07a9b0441b884edfbbd696092008830c2/src/main/scala/stalagtite/deriving.scala

I have created the boilerplate but I have a few questions where I'd really appreciate some help:

- [x] how do I get the list of parameters of the annotation?
- [x] can I get the resolved FQNs of those parameters?
- [x] how can I write a test? (e.g. a file doesn't have red squigglies)
- [x] `updateClassifiers` is not attaching the `intellij-community` sources or javadocs. These would be extremely useful.
- [ ] is there a way to detect if a method has been declared `implicit`?
- [x] I have had to parse the annotation manually with `.getText` because the parameters are not showing up when I use `.getParameterList` and look at the attributes. Is this a bug or am I just not using it correctly?
- [ ] how do I get the FQN of a `ScExpression` on a `ScAnnotation.annotationExpr.getAnnotationParameters` ?

BTW, anyone using ensime to hack on this repo can use this setup in `ensime.sbt`

```
// ;packagePluginCommunity ;testOnly *Stalactite*
// packagePluginCommunityZip
scalacOptions += "-Ywarn-unused-import"
ensimeIgnoreScalaMismatch in ThisBuild := true
ensimeScalaVersion in ThisBuild := "2.11.11"
// https://github.com/ensime/ensime-sbt/issues/353
ensimeUnmanagedSourceArchives in LocalProject("scalaCommunity") :=
   Seq(file(s"./SDK/ideaSDK/${ideaBuild.value}/sources.zip"))
```

I've made a prerelease of this plugin available at https://github.com/fommil/stalactite/releases/tag/v0.0.2