### PR TITLE
Remove dependency on DatatypeConverter

### DIFF
--- a/compiler-settings/src/org/jetbrains/jps/incremental/scala/data/SbtData.scala
+++ b/compiler-settings/src/org/jetbrains/jps/incremental/scala/data/SbtData.scala
@@ -3,7 +3,6 @@ package data
 
 import java.io._
 import java.security.MessageDigest
-import javax.xml.bind.DatatypeConverter
 
 import com.intellij.openapi.util.io.FileUtil
 import org.jetbrains.jps.incremental.scala._
@@ -17,6 +16,9 @@ case class SbtData(interfaceJar: File,
                    javaClassVersion: String)
 
 object SbtData {
+
+  private val HexChars = Array('0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F')
+
   val compilerInterfacesKey = "scala.compiler.interfaces.dir"
 
   private def compilerInterfacesDir = {
@@ -46,7 +48,7 @@ object SbtData {
               .toRight("Unable to read SBT version from JVM classpath")
               .map { sbtVersion =>
 
-              val checksum = DatatypeConverter.printHexBinary(md5(sourceJar))
+              val checksum = encodeHex(md5(sourceJar))
               val interfacesHome = new File(compilerInterfacesDir, sbtVersion + "-idea-" + checksum)
 
               new SbtData(interfaceJar, sourceJar, interfacesHome, javaClassVersion)
@@ -78,6 +80,18 @@ object SbtData {
     } else {
       md.digest(FileUtil.loadBytes(new FileInputStream(file)))
     }
+  }
+
+  private def encodeHex(bytes: Array[Byte]): String = {
+    val out = new StringBuilder(bytes.length * 2)
+    var i = 0
+    while (i < bytes.length) {
+      val b = bytes(i)
+      out.append(HexChars((b >> 4) & 0xF))
+      out.append(HexChars(b & 0xF))
+      i += 1
+    }
+    out.toString()
   }
 
 }


### PR DESCRIPTION
It's not available in Java 9's base module.