### PR TITLE
#SCL-11156 fixed

### DIFF
--- a/scala/scala-impl/test/org/jetbrains/plugins/scala/annotator/SingleAbstractMethodTest.scala
+++ b/scala/scala-impl/test/org/jetbrains/plugins/scala/annotator/SingleAbstractMethodTest.scala
@@ -302,6 +302,21 @@ abstract class SingleAbstractMethodTestBase extends ScalaFixtureTestCase with As
     checkCodeHasNoErrors(code)
   }
 
+  def testSCL11156(): Unit = {
+    val code =
+      """
+        |trait F[T, R] {
+        |  def apply(a: T): R
+        |}
+        |
+        |trait Specific extends F[String, Int]
+        |
+        |val ok: F[Int, Int] = _ => 1
+        |val error: Specific = _ => 1
+      """.stripMargin
+    checkCodeHasNoErrors(code)
+  }
+
   def testOverload(): Unit = {
     val code =
       """


### PR DESCRIPTION
See fix and provided SingleAbstractMethodTestBase.testSCL11156
after some research I came to conclusion there is no correct ScSubstitutor for ScDesignatorType's. No substitutor is provided, but it has to be provided. (for example, for ScDesignatorType Specific)