### PR TITLE
prepare for new scalaz-deriving update

### DIFF
--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -161,11 +161,11 @@ object DependencyGroups {
   val testDownloader = Seq(
 
     "com.chuusai" % "shapeless_2.11" % "2.0.0",
-    "com.fommil" % "stalactite_2.11" % "0.0.3",
+    "com.fommil" % "stalactite_2.11" % "0.0.5",
     "com.github.julien-truffaut" %% "monocle-core" % monocleVersion,
     "com.github.julien-truffaut" %% "monocle-generic" % monocleVersion,
     "com.github.julien-truffaut" %% "monocle-macro" % monocleVersion,
-    "com.github.mpilquist" % "simulacrum_2.11" % "0.10.0",
+    "com.github.mpilquist" % "simulacrum_2.11" % "0.11.0",
     "com.lihaoyi" % "utest_2.10" % "0.3.1" % "provided",
     "com.lihaoyi" % "utest_2.10" % "0.4.3" % "provided",
     "com.lihaoyi" % "utest_2.11" % "0.3.1" % "provided",

--- a/scala/scala-impl/resources/META-INF/scala-plugin-common.xml
+++ b/scala/scala-impl/resources/META-INF/scala-plugin-common.xml
@@ -24,7 +24,7 @@
     <extensions defaultExtensionNs="org.intellij.scala">
         <!--<syntheticMemberInjector implementation="scala.meta.MetaAnnotationInjector"/>-->
         <syntheticMemberInjector implementation="org.jetbrains.plugins.scala.lang.psi.impl.toplevel.typedef.MonocleInjector"/>
-        <syntheticMemberInjector implementation="org.jetbrains.plugins.scala.lang.psi.impl.toplevel.typedef.StalactiteInjector"/>
+        <syntheticMemberInjector implementation="org.jetbrains.plugins.scala.lang.psi.impl.toplevel.typedef.ScalazDerivingInjector"/>
         <syntheticMemberInjector implementation="scala.meta.intellij.MetaSupportInjector"/>
         <syntheticMemberInjector implementation="org.jetbrains.plugins.scala.lang.psi.impl.toplevel.typedef.QuasiQuotesInjector"/>
         <syntheticMemberInjector implementation="org.jetbrains.plugins.scala.lang.psi.impl.toplevel.typedef.simulacrum.SimulacrumInjection"/>

--- a/scala/scala-impl/src/org/jetbrains/plugins/scala/lang/psi/impl/toplevel/typedef/ScalazDerivingInjector.scala
+++ b/scala/scala-impl/src/org/jetbrains/plugins/scala/lang/psi/impl/toplevel/typedef/ScalazDerivingInjector.scala
@@ -6,7 +6,7 @@ import org.jetbrains.plugins.scala.lang.psi.api.expr.{ScAnnotation, ScExpression
 import org.jetbrains.plugins.scala.lang.psi.api.toplevel.typedef._
 
 /**
- * Support for https://github.com/fommil/stalactite
+ * Support for https://gitlab.com/fommil/scalaz-deriving
  *
  * Chooses to skip typeclass derivation (and requirements) in order to
  * provide a much faster editing experience. Users may experience
@@ -15,37 +15,41 @@ import org.jetbrains.plugins.scala.lang.psi.api.toplevel.typedef._
  * @author Sam Halliday
  * @since  24/08/2017
  */
-class StalactiteInjector extends SyntheticMembersInjector {
+class ScalazDerivingInjector extends SyntheticMembersInjector {
   // fast check
-  def hasStalactite(source: ScTypeDefinition): Boolean =
-    source.findAnnotationNoAliases("stalactite.deriving") != null
+  private def hasDeriving(source: ScTypeDefinition): Boolean =
+    (source.findAnnotationNoAliases("deriving") != null) ||
+    (source.findAnnotationNoAliases("scalaz.deriving") != null) ||
+    (source.findAnnotationNoAliases("stalactite.deriving") != null)
 
   // slower, more correct
-  def stalactite(source: ScTypeDefinition): Option[ScAnnotation] =
+  private def getDeriving(source: ScTypeDefinition): Option[ScAnnotation] =
+    source.annotations("deriving").headOption orElse
+    source.annotations("scalaz.deriving").headOption orElse
     source.annotations("stalactite.deriving").headOption
 
   // so annotated sealed traits will generate a companion
   override def needsCompanionObject(source: ScTypeDefinition): Boolean =
-    hasStalactite(source)
+    hasDeriving(source)
 
   // add implicits to case object / case class companions
   override def injectFunctions(source: ScTypeDefinition): Seq[String] =
     source match {
-      case cob: ScObject if hasStalactite(cob) =>
-        genImplicits(cob.name + ".type", stalactite(cob))
+      case cob: ScObject if hasDeriving(cob) =>
+        genImplicits(cob.name + ".type", getDeriving(cob))
       case obj: ScObject =>
         obj.fakeCompanionClassOrCompanionClass match {
-          case clazz: ScTypeDefinition if hasStalactite(clazz) =>
-            genImplicits(clazz.name, stalactite(clazz))
+          case clazz: ScTypeDefinition if hasDeriving(clazz) =>
+            genImplicits(clazz.name, getDeriving(clazz))
           case _ => Nil
         }
       case _ => Nil
     }
 
-  private def genImplicits(clazz: String, stalactite: Option[ScAnnotation]): Seq[String] = {
+  private def genImplicits(clazz: String, ann: Option[ScAnnotation]): Seq[String] = {
     for {
-      stalactiteAnnotation <- stalactite.toSeq
-      param <- stalactiteAnnotation.annotationExpr.getAnnotationParameters
+      derivingAnn <- ann.toSeq
+      param <- derivingAnn.annotationExpr.getAnnotationParameters
       typeClassFqn <- fqn(param)
     } yield {
       s"implicit def `$typeClassFqn`: $typeClassFqn[$clazz] = _root_.scala.Predef.???"

--- a/scala/scala-impl/src/org/jetbrains/plugins/scala/statistics/ScalaApplicationUsagesCollector.scala
+++ b/scala/scala-impl/src/org/jetbrains/plugins/scala/statistics/ScalaApplicationUsagesCollector.scala
@@ -96,7 +96,6 @@ class ScalaApplicationUsagesCollector extends AbstractProjectsUsagesCollector {
         checkLibrary("net.liftweb", "Lift Framework")
         checkLibrary("spray", "Spray")
         checkLibrary("monocle", "Monocle")
-        checkLibrary("stalactite", "Stalactite")
 
         java_version.foreach {
           version: String => set += new UsageDescriptor(s"Java version: $version", 1)

--- a/scala/scala-impl/test/org/jetbrains/plugins/scala/lang/macros/ScalazDerivingTest.scala
+++ b/scala/scala-impl/test/org/jetbrains/plugins/scala/lang/macros/ScalazDerivingTest.scala
@@ -16,20 +16,20 @@ import org.junit.Assert._
 import org.junit.experimental.categories.Category
 
 /**
- * IntelliJ's equivalent of stalactite's built-in PresentationCompilerTest
+ * IntelliJ's equivalent of scalaz-deriving's built-in PresentationCompilerTest
  *
  * @author Sam Halliday
  * @since  24/08/2017
  */
 @Category(Array(classOf[SlowTests]))
-class StalactiteTest extends ScalaLightCodeInsightFixtureTestAdapter {
+class ScalazDerivingTest extends ScalaLightCodeInsightFixtureTestAdapter {
 
   override implicit val version: ScalaVersion = Scala_2_11
 
   override def librariesLoaders =
     super.librariesLoaders :+
-      StalactiteTest.StalactiteLoader() :+
-      StalactiteTest.SimulacrumLoader()
+      ScalazDerivingTest.ScalazDerivingLoader() :+
+      ScalazDerivingTest.SimulacrumLoader()
 
 
   protected def folderPath: String = TestUtils.getTestDataPath
@@ -68,7 +68,7 @@ class StalactiteTest extends ScalaLightCodeInsightFixtureTestAdapter {
     val fileText: String = """
 package wibble
 
-import stalactite._
+import stalactite.deriving
 import simulacrum.typeclass
 
 @typeclass trait Wibble[T] {}
@@ -87,7 +87,7 @@ final case class <caret>Foo(string: String, int: Int)
     val fileText: String = """
 package wibble
 
-import stalactite._
+import stalactite.deriving
 import simulacrum.typeclass
 
 @typeclass trait Wibble[T] {}
@@ -109,7 +109,7 @@ final case class Foo(string: String, int: Int) extends Baz
     val fileText: String = """
 package wibble
 
-import stalactite._
+import stalactite.deriving
 import simulacrum.typeclass
 
 @typeclass trait Wibble[T] {}
@@ -126,17 +126,17 @@ case object <caret>Caz
 
 }
 
-object StalactiteTest {
+object ScalazDerivingTest {
 
-  case class StalactiteLoader() extends IvyLibraryLoaderAdapter {
+  case class ScalazDerivingLoader() extends IvyLibraryLoaderAdapter {
     val vendor: String = "com.fommil"
     val name: String = "stalactite"
-    val version: String = "0.0.3"
+    val version: String = "0.0.5"
   }
 
   case class SimulacrumLoader() extends IvyLibraryLoaderAdapter {
     val vendor: String = "com.github.mpilquist"
     val name: String = "simulacrum"
-    val version: String = "0.10.0"
+    val version: String = "0.11.0"
   }
 }


### PR DESCRIPTION
I am planning a large update to `scalaz-deriving` (formerly known as `stalactite`) and this adds support for both the legacy annotation `@stalactite.deriving`, the new annotation `@scalaz.deriving`, and the upcoming compiler plugin annotation `@deriving` (I would rather use `@scalaz.deriving` but as you may know, compiler plugins do not perform naming of annotations until rather late in the game so such plugins tend to use annotations as keywords. *sigh*)

FYI, hacking on this codebase was again a pleasure and made easier with the following `ensime.sbt` config

```
// ;packagePluginCommunity ;testOnly *ScalazDeriving*
// packagePluginCommunityZip
scalacOptions += "-Ywarn-unused-import"
ensimeIgnoreScalaMismatch in ThisBuild := true
ensimeScalaVersion in ThisBuild := (scalaVersion in LocalProject("scalaCommunity")).value
ensimeUnmanagedSourceArchives in LocalProject("scalaCommunity") :=
   Seq(file(s"./SDK/ideaSDK/${ideaBuild.value}/sources.zip"))
```