### PR TITLE
SCL-9972: Add inspection for typical incorrect usages of Source

### DIFF
--- a/scala/scala-impl/resources/META-INF/scala-plugin-common.xml
+++ b/scala/scala-impl/resources/META-INF/scala-plugin-common.xml
@@ -1335,7 +1335,13 @@
                        displayName="Ammonite unresolved import" groupPath="Scala" shortName="AmmoniteUnresolvedLibraryInspection" 
                        level="WARNING" enabledByDefault="true" language="Scala" groupName="Other"/>
       <!---->
-      
+
+        <!-- resource leak inspections -->
+        <localInspection implementationClass="org.jetbrains.plugins.scala.codeInspection.resourceLeaks.SourceNotClosedInspection"
+                         displayName="Source not closed" groupPath="Scala" shortName="SourceNotClosed"
+                         level="WARNING" enabledByDefault="true" language="Scala" groupName="Resource leaks"/>
+        <!-- end of resource leak inspections -->
+
         <localInspection implementationClass="org.jetbrains.plugins.scala.codeInspection.specs2.BuiltinMatcherExistsInspection"
                          displayName="Specs2 Matchers" shortName="Specs2Matchers" groupName="Specs2" groupPath="Scala,Specs2"
                          level="WARNING" enabledByDefault="true" language="Scala" />

--- a/scala/scala-impl/resources/inspectionDescriptions/SourceNotClosed.html
+++ b/scala/scala-impl/resources/inspectionDescriptions/SourceNotClosed.html
@@ -1,0 +1,8 @@
+<html>
+<body>
+<p>Using <code>.mkString</code> or <code>.getLines</code> directly on a <code>Source</code> opened by
+<code>fromFile</code>, <code>fromURL</code>, <code>fromURI</code> will leak the underlying file handle.</p>
+
+<p>Consider using <code>try</code> / <code>finally</code> to manage the resource lifetime.</p>
+</body>
+</html>

--- a/scala/scala-impl/resources/org/jetbrains/plugins/scala/codeInspection/InspectionBundle.properties
+++ b/scala/scala-impl/resources/org/jetbrains/plugins/scala/codeInspection/InspectionBundle.properties
@@ -145,3 +145,5 @@ replace.sortBy.last.with.maxBy=Replace with .maxBy
 
 specs2.builtin.matcher.alternative.exists=Available matcher exists
 specs2.use.builtin.matcher=Replace with builtin matcher
+
+source.not.closed=Source is not closed

--- a/scala/scala-impl/src/org/jetbrains/plugins/scala/codeInspection/resourceLeaks/SourceNotClosedInspection.scala
+++ b/scala/scala-impl/src/org/jetbrains/plugins/scala/codeInspection/resourceLeaks/SourceNotClosedInspection.scala
@@ -1,0 +1,51 @@
+package org.jetbrains.plugins.scala.codeInspection.resourceLeaks
+
+import com.intellij.codeInspection.{ProblemHighlightType, ProblemsHolder}
+import com.intellij.psi.PsiElement
+import org.jetbrains.plugins.scala.codeInspection.collections.{invocation, unqualifed}
+import org.jetbrains.plugins.scala.codeInspection.{AbstractInspection, InspectionBundle}
+import org.jetbrains.plugins.scala.lang.psi.api.expr.{ScExpression, ScMethodCall, ScReferenceExpression}
+import org.jetbrains.plugins.scala.lang.psi.api.statements.ScFunctionDefinition
+
+
+class SourceNotClosedInspection extends AbstractInspection("SourceNotClosed", "Source not closed") {
+  override protected def actionFor(implicit holder: ProblemsHolder): PartialFunction[PsiElement, Any] = {
+    case ref @ ScReferenceExpression.withQualifier(scalaIoFromPathLike()) =>
+      val problemElement = ref.getParent match {
+        case call @ ScMethodCall(r, _) if r eq ref => call
+        case _ => ref.getOriginalElement
+      }
+
+      markProblems(ref, problemElement)
+  }
+
+  private[this] def markProblems(ref: ScReferenceExpression, problemElement: PsiElement)(implicit holder: ProblemsHolder): Unit = {
+    ref.resolve() match {
+      case funDef: ScFunctionDefinition if nonClosingMethods contains funDef.name =>
+        holder.registerProblem(problemElement, InspectionBundle.message("source.not.closed"),
+          ProblemHighlightType.GENERIC_ERROR_OR_WARNING)
+      case _ =>
+    }
+  }
+
+  private[this] val nonClosingMethods = Set("mkString", "getLines")
+
+  private[this] val qualFromFile = invocation("fromFile").from(Array("scala.io.Source"))
+  private[this] val unqualFromFile = unqualifed("fromFile").from(Array("scala.io.Source"))
+  private[this] val qualFromURL = invocation("fromURL").from(Array("scala.io.Source"))
+  private[this] val unqualFromURL = unqualifed("fromURL").from(Array("scala.io.Source"))
+  private[this] val qualFromURI = invocation("fromURI").from(Array("scala.io.Source"))
+  private[this] val unqualFromURI = unqualifed("fromURI").from(Array("scala.io.Source"))
+
+  private[this] object scalaIoFromPathLike {
+    def unapply(expr: ScExpression): Boolean = expr match {
+      case _ qualFromFile(_) => true
+      case unqualFromFile(_) => true
+      case _ qualFromURI(_) => true
+      case unqualFromURI(_) => true
+      case _ qualFromURL(_) => true
+      case unqualFromURL(_) => true
+      case _ => false
+    }
+  }
+}

--- a/scala/scala-impl/test/org/jetbrains/plugins/scala/codeInspection/resourceLeaks/SourceNotClosedInspectionTest.scala
+++ b/scala/scala-impl/test/org/jetbrains/plugins/scala/codeInspection/resourceLeaks/SourceNotClosedInspectionTest.scala
@@ -1,0 +1,69 @@
+package org.jetbrains.plugins.scala.codeInspection.resourceLeaks
+
+import com.intellij.codeInspection.LocalInspectionTool
+import com.intellij.testFramework.EditorTestUtil
+import org.jetbrains.plugins.scala.ScalaBundle
+import org.jetbrains.plugins.scala.codeInspection.ScalaQuickFixTestBase
+
+class SourceNotClosedInspectionTest extends ScalaQuickFixTestBase {
+
+  import EditorTestUtil.{SELECTION_END_TAG => END, SELECTION_START_TAG => START}
+
+  override protected val classOfInspection: Class[_ <: LocalInspectionTool] = classOf[SourceNotClosedInspection]
+
+  override protected val description: String = ScalaBundle.message("source.not.closed")
+
+  def testFullyQualifiedFromFileMkString(): Unit =
+    checkTextHasError(s"""${START}scala.io.Source.fromFile(new java.io.File("test")).mkString$END""")
+  def testFullyQualifiedFromURIMkString(): Unit =
+    checkTextHasError(s"""${START}scala.io.Source.fromURI(new java.net.URI("test")).mkString$END""")
+  def testFullyQualifiedFromURLMkString(): Unit =
+    checkTextHasError(s"""${START}scala.io.Source.fromURL(new java.net.URL("test")).mkString$END""")
+
+  def testFullyQualifiedFromFileMkStringSep(): Unit =
+    checkTextHasError(s"""${START}scala.io.Source.fromFile(new java.io.File("test")).mkString(",")$END""")
+  def testFullyQualifiedFromURIMkStringSep(): Unit =
+    checkTextHasError(s"""${START}scala.io.Source.fromURI(new java.net.URI("test")).mkString(",")$END""")
+  def testFullyQualifiedFromURLMkStringSep(): Unit =
+    checkTextHasError(s"""${START}scala.io.Source.fromURL(new java.net.URL("test")).mkString(",")$END""")
+
+  def testFullyQualifiedFromFileGetLines(): Unit =
+    checkTextHasError(s"""${START}scala.io.Source.fromFile(new java.io.File("test")).getLines()$END""")
+  def testFullyQualifiedFromURIGetLines(): Unit =
+    checkTextHasError(s"""${START}scala.io.Source.fromURI(new java.net.URI("test")).getLines()$END""")
+  def testFullyQualifiedFromURLGetLines(): Unit =
+    checkTextHasError(s"""${START}scala.io.Source.fromURL(new java.net.URL("test")).getLines()$END""")
+
+  def testSourceFromFileMkString(): Unit =
+    checkTextHasError(
+      s"""import scala.io.Source
+         |import java.io.File
+         |
+         |val file = new File("test")
+         |
+         |${START}Source.fromFile(file).mkString$END
+         |""".stripMargin)
+
+  def testUnqualifiedFromFileMkString(): Unit =
+    checkTextHasError(
+      s"""import scala.io.Source.fromFile
+         |import java.io.File
+         |
+         |val file = new File("test")
+         |
+         |${START}fromFile(file).mkString$END
+         |""".stripMargin)
+
+  def testQualifiedRenamedFromFileMkString(): Unit =
+    checkTextHasError(
+      s"""import scala.io.{Source => S}
+         |${START}S.fromFile(new java.io.File("test")).mkString$END
+         |""".stripMargin)
+
+  // TODO: this is currently pending because the InvocationTemplate tests do not check for renames
+  def pendingUnqualifiedRenamedFromFileMkString(): Unit =
+    checkTextHasError(
+      s"""import scala.io.Source.{fromFile => gotcha}
+         |${START}gotcha(new java.io.File("test")).mkString$END
+         |""".stripMargin)
+}


### PR DESCRIPTION
Missing features:

 1. `Source.fromInputStream(new FooInputStream(???)).getLines()`,
 2. quick fix / conversion to `try`/`finally` and
 3. cannot handle renamed method (as in `import scala.io.Source.{fromFile => problemSolved}`.

For 1, what kinds of sources of `InputStream` should be marked? New instances created explicitly with `new` and functions/methods returning an `InputStream`?

2 can perhaps be added later?

3 could maybe be solved by adding a case for renamed methods to `org.jetbrains.plugins.scala.codeInspection.collections.{Qualified, Unqualified}` but perhaps such a case is intentionally left out?