### PR TITLE
SCL-13264: Improved ammonite resolving logic

### DIFF
--- a/scala/scala-impl/src/org/jetbrains/plugins/scala/worksheet/ammonite/AmmoniteUtil.scala
+++ b/scala/scala-impl/src/org/jetbrains/plugins/scala/worksheet/ammonite/AmmoniteUtil.scala
@@ -21,6 +21,7 @@ import org.jetbrains.plugins.scala.settings.ScalaProjectSettings
 import org.jetbrains.plugins.scala.util.ScalaUtil
 import org.jetbrains.sbt.project.SbtProjectSystem
 
+import scala.annotation.tailrec
 import scala.collection.mutable.ArrayBuffer
 
 /**
@@ -29,16 +30,16 @@ import scala.collection.mutable.ArrayBuffer
   */
 object AmmoniteUtil {
   val AMMONITE_EXTENSION = "sc"
-  
+
   private val DEFAULT_VERSION = "2.12"
   private val ROOT_FILE = "$file"
   private val ROOT_EXEC = "$exec"
   private val ROOT_IVY = "$ivy"
   private val ROOT_PLUGIN = "$plugin"
-  
+
   private val PARENT_FILE = "^"
-  
-  private val DEFAULT_IMPORTS = Seq("ammonite.main.Router._", "ammonite.runtime.tools.grep", "ammonite.runtime.tools.browse", 
+
+  private val DEFAULT_IMPORTS = Seq("ammonite.main.Router._", "ammonite.runtime.tools.grep", "ammonite.runtime.tools.browse",
     "ammonite.runtime.tools.time", "ammonite.repl.tools.desugar", "ammonite.repl.tools.source") //todo more default imports ?
   private val DEFAULT_BUILTINS = Seq(("repl", "ammonite.repl.ReplAPI"), ("interp", "ammonite.runtime.Interpreter with ammonite.interp.Interpreter"))
 
@@ -48,12 +49,12 @@ object AmmoniteUtil {
       case _ => false
     }
   }
-  
+
   def isAmmoniteFile(virtualFile: VirtualFile, project: Project): Boolean = {
     virtualFile.getExtension == AMMONITE_EXTENSION && (ScalaProjectSettings.getInstance(project).getScFileMode match {
       case ScalaProjectSettings.ScFileMode.Ammonite => true
       case ScalaProjectSettings.ScFileMode.Worksheet => false
-      case ScalaProjectSettings.ScFileMode.Auto => 
+      case ScalaProjectSettings.ScFileMode.Auto =>
         ProjectRootManager.getInstance(project).getFileIndex.isUnderSourceRootOfType(virtualFile, ContainerUtilRt.newHashSet(JavaSourceRootType.TEST_SOURCE))
       case _ => false
     })
@@ -71,7 +72,7 @@ object AmmoniteUtil {
     case scalaFile: ScalaFile => AmmoniteScriptWrappersHolder.getInstance(file.getProject).findWrapper(scalaFile)
     case _ => None
   }
-  
+
   def executeImplicitImportsDeclarations(processor: PsiScopeProcessor, file: FileDeclarationsHolder, state: ResolveState): Boolean = {
     file match {
       case ammoniteFile: ScalaFile if isAmmoniteFile(ammoniteFile) =>
@@ -79,7 +80,7 @@ object AmmoniteUtil {
           case (name, txt) =>
             ScalaPsiElementFactory.createElementFromText(s"class A { val $name: $txt = ??? }")(ammoniteFile.projectContext).processDeclarations(processor, state, null, ammoniteFile)
         }
-        
+
         DEFAULT_IMPORTS.foreach {
           imp =>
             val importStmt = ScalaPsiElementFactory.createImportFromText(s"import $imp")(ammoniteFile.projectContext)
@@ -87,7 +88,7 @@ object AmmoniteUtil {
         }
       case _ =>
     }
-    
+
     true
   }
 
@@ -133,16 +134,16 @@ object AmmoniteUtil {
 
     def qual(scRef: ScStableCodeReferenceElement) = {
       scRef.getParent match {
-        case selector: ScImportSelector => 
+        case selector: ScImportSelector =>
           new ParentsIterator(selector).collectFirst {
-            case expr: ScImportExpr => expr.qualifier 
+            case expr: ScImportExpr => expr.qualifier
           }
         case _ => scRef.qualifier
       }
     }
-    
+
     qual(refElement) match {
-      case Some(q) if scriptResolvePlugin(q) && refElement.getReference.getCanonicalText == ROOT_IVY => 
+      case Some(q) if scriptResolvePlugin(q) && refElement.getReference.getCanonicalText == ROOT_IVY =>
         Option(refElement.getContainingFile.getContainingDirectory)
       case Some(q) if scriptResolveIvy(q) || scriptResolvePlugin(q) || q.getReference.refName == ROOT_IVY =>
         findLibrary(refElement) flatMap {
@@ -158,145 +159,104 @@ object AmmoniteUtil {
     AmmoniteUtil.extractLibInfo(refElement).flatMap {
       case LibInfo(group, name, version, scalaVersion) =>
         val existsPredicate = (f: File) => f.exists()
-        
-        val nv = s"${name}_$scalaVersion"
-        val fullVersion = s"$nv|$nv.${ScalaUtil.getScalaVersion(refElement.getContainingFile).flatMap(_.split('.').lastOption).getOrElse("0")}"
-        
-        val ivyPath = s"$group/$fullVersion/jars|bundles"
-        val mavenPath = s"maven2/${group.replace('.', '/')}/$nv|$name/$version"
-        
-        val prefixPatterns = Seq(name, version)
-        
-        
-        def tryIvy() = findFileByPattern(
-          s"$getDefaultCachePath/$ivyPath", 
-          existsPredicate
-        )
-        
-        def tryCoursier() = findFileByPattern(
-          s"$getCoursierCachePath/https/repo1.maven.org/$mavenPath",
-          existsPredicate
-        )
 
-        tryIvy() orElse tryCoursier() flatMap {
-          parent =>
-            parent.listFiles().find{
-              cf =>
-                val name = cf.getName
-                prefixPatterns.exists(name.startsWith) && name.endsWith(".jar")
-            } flatMap { //todo more variants? 
-              jarModuleRoot =>
-                Option(JarFileSystem.getInstance().findLocalVirtualFileByPath(jarModuleRoot.getCanonicalPath))
-            }
+        val n = name
+        val nv = s"${name}_$scalaVersion"
+        val fullVersion =
+          s"$n|$nv|$nv.${ScalaUtil.getScalaVersion(refElement.getContainingFile).flatMap(_.split('.').lastOption).getOrElse("0")}"
+
+        val ivyPath = s"$group/$fullVersion/jars|bundles"
+        val mavenPath = s"${group.replace('.', '/')}/$nv|$name/$version"
+
+        val prefixPatterns = Seq(name, version)
+
+        def tryIvy() =
+          firstFileMatchingPattern(s"/$ivyPath", new File(getDefaultCachePath))
+            .find(existsPredicate)
+
+        def tryCoursier() =
+          firstFileMatchingPattern(s"/https/*/*/$mavenPath", new File(getCoursierCachePath))
+            .find(existsPredicate)
+
+        tryIvy() orElse tryCoursier() flatMap { parent =>
+          parent.listFiles().find { cf =>
+            val name = cf.getName
+            prefixPatterns.exists(name.startsWith) &&
+            name.endsWith(".jar") &&
+            !name.endsWith("-sources.jar") &&
+            !name.endsWith("-javadoc.jar")
+          } flatMap { //todo more variants?
+            jarModuleRoot =>
+              Option(
+                JarFileSystem
+                  .getInstance()
+                  .findLocalVirtualFileByPath(jarModuleRoot.getCanonicalPath))
+          }
         }
     }
   }
-  
+
   def isAmmoniteSpecificImport(expr: ScImportExpr): Boolean = {
     val txt = expr.getText
     txt.startsWith(ROOT_EXEC) || txt.startsWith(ROOT_FILE) || txt.startsWith(ROOT_IVY) || txt.startsWith(ROOT_PLUGIN)
   }
-  
-  private def findFileByPattern(pattern: String, predicate: File => Boolean): Option[File] = {
-    abstract class PathPart[T] {
-      protected var current: Option[T] = None
-      def getCurrent: Option[T] = current
-      def hasNext: Boolean = false
 
-      def add(): Boolean
-      def reset()
-    }
+  sealed trait FileTree
+  final case class OneSegment(segment: String, next: FileTree) extends FileTree
+  final case class AlternativeSegments(segments: List[String], next: FileTree)
+      extends FileTree
+  final case class AnySegment(next: FileTree) extends FileTree
+  final case object Empty extends FileTree
 
-    case class SimplePart(p: String) extends PathPart[String] {
-      reset()
-      override def add(): Boolean = {
-        current = None
-        false
-      }
-      override def reset(): Unit = current = Option(p)
-    }
-
-    case class OrPart(ps: Iterable[String]) extends PathPart[String] {
-      private var it = ps.iterator
-      setCurrent()
-
-      override def add(): Boolean = {it.hasNext && {setCurrent(); true} || {current = None; false}}
-      override def hasNext: Boolean = it.hasNext
-      override def reset(): Unit = {
-        it = ps.iterator
-        setCurrent()
-      }
-
-      private def setCurrent() {
-        current = Option(it.next())
-      }
-    }
-
-    case class PathIterator(pathParts: Iterable[PathPart[String]]) extends Iterator[File] {
-      private var it = pathParts.iterator
-      private var currentDigit = pathParts.head
-      private var currentVal: Option[String] = Option(gluePath)
-
-      private def gluePath: String = pathParts.flatMap(_.getCurrent.toList).mkString(File.separator)
-
-      private def advance() {
-        if (!currentDigit.add()) {
-          while (!currentDigit.add() && it.hasNext) currentDigit = it.next()
-          if (currentDigit.getCurrent.isEmpty) return
-          pathParts.takeWhile(_ != currentDigit).foreach(_.reset())
-          currentDigit = pathParts.head
-          it = pathParts.iterator
-        }
-
-        currentVal = Option(gluePath)
-      }
-
-      def hasNext: Boolean = currentVal.isDefined
-
-      def next(): File = {
-        val c = currentVal.get
-        currentVal = None
-        advance()
-        new File(c)
-      }
-    }
-    
-    PathIterator {
-      pattern.split('/').map {
-        part => part.split('|') match {
-          case Array(single) => SimplePart(single)
-          case multiple => OrPart(multiple)
-        }
-      }.foldRight(List.empty[PathPart[String]]){
-        case (SimplePart(part), SimplePart(pp) :: tail) =>
-          SimplePart(part + File.separator + pp) :: tail
-        case (otherPart, list) =>
-          otherPart :: list
-      }
-    }.find(predicate)
+  private def segment(s: String, down: FileTree) = s.split('|').toList match {
+    case "*" :: Nil => AnySegment(down)
+    case str :: Nil => OneSegment(str, down)
+    case array      => AlternativeSegments(array, down)
   }
 
-  private def getResolveItem(library: Library, project: Project): Option[PsiDirectory] = getLibraryDirs(library, project).headOption
+  def patternToTree(pattern: String): FileTree =
+    pattern.split("/").filter(_.nonEmpty).foldRight[FileTree](Empty)(segment)
 
-  private def getLibraryDirs(library: Library, project: Project): Array[PsiDirectory] = {
-    library.getFiles(OrderRootType.CLASSES).flatMap {
-      root => Option(PsiManager.getInstance(project).findDirectory(root))
+  @tailrec
+  def treeToFiles(tree: FileTree, acc: List[File]): List[File] = tree match {
+    case Empty => acc
+    case OneSegment(segment, next) =>
+      treeToFiles(next, acc.filter(_.isDirectory).flatMap(_.listFiles().filter(_.getName == segment)))
+    case AlternativeSegments(segments, next) =>
+      treeToFiles(next, acc.filter(_.isDirectory).flatMap(_.listFiles().filter(f => segments.contains(f.getName))))
+    case AnySegment(next) =>
+      treeToFiles(next, acc.filter(_.isDirectory).flatMap(_.listFiles()))
+  }
+
+  def firstFileMatchingPattern(pattern: String, rootFile: File): List[File] =
+    treeToFiles(patternToTree(pattern), List(rootFile))
+
+  private def getResolveItem(library: Library,
+                             project: Project): Option[PsiDirectory] =
+    getLibraryDirs(library, project).headOption
+
+  private def getLibraryDirs(library: Library,
+                             project: Project): Array[PsiDirectory] = {
+    library.getFiles(OrderRootType.CLASSES).flatMap { root =>
+      Option(PsiManager.getInstance(project).findDirectory(root))
     }
   }
 
-  private def findLibrary(refElement: ScStableCodeReferenceElement): Option[Library] = {
-    extractLibInfo(refElement).map(convertLibName) flatMap {
-      name =>
-        Option(LibraryTablesRegistrar.getInstance() getLibraryTable refElement.getProject getLibraryByName name)
+  private def findLibrary(
+      refElement: ScStableCodeReferenceElement): Option[Library] = {
+    extractLibInfo(refElement).map(convertLibName) flatMap { name =>
+      Option(
+        LibraryTablesRegistrar
+          .getInstance() getLibraryTable refElement.getProject getLibraryByName name)
     }
   }
 
   def convertLibName(info: LibInfo): String = {
     import info._
-    
+
     List(SbtProjectSystem.Id.getId, " " + groupId, name + "_" + scalaVersion, version, "jar").mkString(":")
   }
-  
+
   private def getScalaVersion(element: ScalaPsiElement): String = {
     ScalaUtil.getScalaVersion(element.getContainingFile) map {
       version => version.lastIndexOf('.') match {
@@ -307,13 +267,13 @@ object AmmoniteUtil {
   }
 
   case class LibInfo(groupId: String, name: String, version: String, scalaVersion: String)
-  
+
   def extractLibInfo(ref: ScReferenceElement): Option[LibInfo] = {
     val name = ref.refName.stripPrefix("`").stripSuffix("`")
     val result = ArrayBuffer[String]()
 
     var scalaVersion: Option[String] = None
-    
+
     name.split(':').foreach {
       p => if (p.nonEmpty) {
         if (p contains "_") {
@@ -327,10 +287,10 @@ object AmmoniteUtil {
       }
     }
 
-    if (result.length == 3) Some(LibInfo(result.head, result(1), result(2), scalaVersion getOrElse getScalaVersion(ref))) else None 
+    if (result.length == 3) Some(LibInfo(result.head, result(1), result(2), scalaVersion getOrElse getScalaVersion(ref))) else None
   }
 
   def getDefaultCachePath: String = System.getProperty("user.home") + "/.ivy2/cache"
-  
+
   def getCoursierCachePath: String = System.getProperty("user.home") + "/.coursier/cache/v1"
 }

--- a/scala/scala-impl/src/org/jetbrains/plugins/scala/worksheet/ammonite/runconfiguration/AmmoniteRunConfiguration.scala
+++ b/scala/scala-impl/src/org/jetbrains/plugins/scala/worksheet/ammonite/runconfiguration/AmmoniteRunConfiguration.scala
@@ -27,32 +27,32 @@ import org.jetbrains.plugins.scala.worksheet.ammonite.runconfiguration.AmmoniteR
   * User: Dmitry.Naydanov
   * Date: 12.09.17.
   */
-class AmmoniteRunConfiguration(project: Project, factory: ConfigurationFactory) extends 
+class AmmoniteRunConfiguration(project: Project, factory: ConfigurationFactory) extends
   RunConfigurationBase(project, factory, AmmoniteRunConfiguration.AMMONITE_RUN_NAME) {
-  
+
   def this(project: Project, factory: ConfigurationFactory, name: String) {
     this(project, factory)
     setFilePath(name)
   }
-  
+
   private var execName: Option[String] = None
   private var fileName: Option[String] = None
   private var scriptParameters: Option[String] = None
-  
+
   def setFilePath(path: String) {
-    fileName = Option(path).filter(_ != "") 
+    fileName = Option(path).filter(_ != "")
   }
-  
+
   def setExecPath(path: String) {
     execName = Option(path)
   }
-  
+
   def setScriptParameters(params: String) {
     scriptParameters = Option(params).filter(_ != "")
   }
-  
+
   def getIOFile: Option[File] = fileName.map(new File(_)).filter(_.exists())
-  
+
   override def getConfigurationEditor: SettingsEditor[_ <: RunConfiguration] = new MyEditor
 
   override def getState(executor: Executor, environment: ExecutionEnvironment): RunProfileState = {
@@ -61,26 +61,26 @@ class AmmoniteRunConfiguration(project: Project, factory: ConfigurationFactory) 
         sdk => cmd.getEnvironment.put("JAVA_HOME", sdk.getHomePath)
       }
     }
-    
+
     val state = new CommandLineState(environment) {
       override def startProcess(): ProcessHandler = {
         val cmd = new GeneralCommandLine()
-        
+
         execName match {
           case Some(exec) =>
             val exFile = new File(exec)
             if (exFile.exists()) cmd.setExePath(exFile.getAbsolutePath) else cmd.setExePath(exec)
-          case None => 
-            cmd.setExePath("amm")
+          case None =>
+            cmd.setExePath("/usr/local/bin/amm")
         }
-        
+
         if (isRepl) {
           cmd.addParameter("--predef")
           cmd.addParameter(s"${createPredefFile(getIOFile.map(_.getName).getOrElse("AmmoniteFile.sc"))}")
         }
 
         fileName.foreach{
-          f => 
+          f =>
             cmd.addParameter(f)
             val tf = new File(f)
             if (tf.exists()) cmd.setWorkDirectory(tf.getParentFile)
@@ -88,31 +88,31 @@ class AmmoniteRunConfiguration(project: Project, factory: ConfigurationFactory) 
         scriptParameters.foreach(cmd.getParametersList.addParametersString(_))
 
         patchSdkVersion(cmd)
-        
+
         try {
           JavaCommandLineStateUtil.startProcess(cmd)
         } catch {
-          case pne: ProcessNotCreatedException => 
+          case pne: ProcessNotCreatedException =>
             pne.getCause match {
               case ioe: IOException =>
                 ioe.getCause match {
                   case ioe2: IOException if ioe2.getMessage.contains("error=2") =>
                     throw new AmmNotFoundException(
-                      s"<br>Can't find Ammonite distributive:<br> ${ioe2.getMessage} <br>" + "<br> <a href=\"azaza\">Specify amm executable path?</a>", 
-                      pne.getCommandLine, 
+                      s"<br>Can't find Ammonite distributive:<br> ${ioe2.getMessage} <br>" + "<br> <a href=\"azaza\">Specify amm executable path?</a>",
+                      pne.getCommandLine,
                       project
                     )
-                  case _ => 
+                  case _ =>
                 }
-              case _ => 
+              case _ =>
             }
-            
+
             throw pne
         }
       }
     }
     state.setConsoleBuilder(new TextConsoleBuilderImpl(project))
-    
+
     fileName.foreach {
       fn =>
         Option(LocalFileSystem.getInstance().findFileByIoFile(new File(fn))) foreach {
@@ -125,11 +125,11 @@ class AmmoniteRunConfiguration(project: Project, factory: ConfigurationFactory) 
 
   override def writeExternal(element: Element) {
     super.writeExternal(element)
-    
+
     def saveFileElement(name: String, maybeString: Option[String]) {
       JDOMExternalizer.write(element, name, maybeString.getOrElse(""))
     }
-    
+
     saveFileElement("execName", execName)
     saveFileElement("fileName", fileName)
     saveFileElement("scriptParameters", scriptParameters)
@@ -137,49 +137,49 @@ class AmmoniteRunConfiguration(project: Project, factory: ConfigurationFactory) 
 
   override def readExternal(element: Element) {
     super.readExternal(element)
-    
+
     def retrieveFileElement(name: String): Option[String] = {
       JDOMExternalizer.readString(element, name) match {
         case "" | null => None
         case other => Option(other)
       }
     }
-    
+
     execName = retrieveFileElement("execName")
     fileName = retrieveFileElement("fileName")
     scriptParameters = retrieveFileElement("scriptParameters")
   }
-  
+
   private def createPredefFile(baseName: String): String = {
     val tempDir = new File(FileUtil.getTempDirectory)
     if (tempDir.exists()) tempDir.mkdir()
-    
+
     val tempFile = new File(tempDir, s"predef$baseName")
     if (!tempFile.exists()) {
       tempFile.createNewFile()
       FileUtil.writeToFile(tempFile, s"repl.frontEnd() = ammonite.repl.FrontEnd.${if (SystemInfo.isWindows) "JLineWindows" else "JLineUnix"}")
     }
-    
+
     tempFile.getAbsolutePath
   }
-  
+
   private def isRepl = fileName.isEmpty
 }
 
 object AmmoniteRunConfiguration {
   val AMMONITE_RUN_NAME = "Ammonite script"
-  
+
   class AmmNotFoundException(message: String, commandLine: GeneralCommandLine, project: Project) extends ProcessNotCreatedException(message, commandLine) with HyperlinkListener {
     override def hyperlinkUpdate(e: HyperlinkEvent): Unit = {
-      if (e.getEventType != HyperlinkEvent.EventType.ACTIVATED) return 
-      
+      if (e.getEventType != HyperlinkEvent.EventType.ACTIVATED) return
+
       new EditConfigurationsDialog(project).show()
     }
   }
-  
+
   private class MyEditor extends SettingsEditor[AmmoniteRunConfiguration]() {
     private val form = new AmmoniteRunConfigurationForm
-    
+
     override def createEditor(): JComponent = form.panel
 
     override def applyEditorTo(s: AmmoniteRunConfiguration) {
@@ -193,40 +193,40 @@ object AmmoniteRunConfiguration {
       form(s.fileName.getOrElse(""), s.execName.getOrElse("amm"), s.scriptParameters.getOrElse(""))
     }
   }
-  
+
   private class AmmoniteRunConfigurationForm {
     val (panel, fileNameField, execNameField, scriptParameters) = initPanel()
-    
+
     def get: (String, String, String) = (fileNameField.getText, execNameField.getText, scriptParameters.getText)
-    
+
     def apply(fileName: String, execName: String, parametersRaw: String) {
       fileNameField.setText(fileName)
       execNameField.setText(execName)
       scriptParameters.setText(parametersRaw)
     }
-    
+
     private def initPanel() = {
       val panel = new JPanel()
       panel setLayout new BoxLayout(panel, BoxLayout.Y_AXIS)
-      
+
       val comp0 = createLabeledElement("Script:", createFileBrowser)
       val comp1 = createLabeledElement("Amm executable:", createFileBrowser)
       val comp2 = createLabeledElement("Script parameters:", new RawCommandLineEditor)
-      
+
       panel.add(comp0, 0)
       panel.add(comp1, 1)
       panel.add(comp2, 2)
-      
+
       (panel, comp0.getComponent, comp1.getComponent, comp2.getComponent)
     }
-    
+
     private def createLabeledElement[T <: JComponent](name: String, comp: T): LabeledComponent[T] = {
       val c = new LabeledComponent[T]
       c.setComponent(comp)
       c.setText(name)
       c
     }
-    
+
     private def createFileBrowser: TextFieldWithBrowseButton = {
       val fileBrowser = new TextFieldWithBrowseButton()
       fileBrowser.addBrowseFolderListener("Select...", "", null, new FileChooserDescriptor(true, false, true, true, false, false))


### PR DESCRIPTION
This solves a couple issues in the ammonite resolving logic. Namely : 

* Amended search logic to allow to get artifacts from coursier that might have been 
resolved from other resolvers than the Maven Central one 
* Amended search logic to avoid triggering the import of jars containing sources or javadoc 
* Changed default ammonite path to a more pragmatic one

#SCL-13264 Fixed

The logic is still lacking in the sense it doesn't recursively imports the dependencies, but I think it's still a step in the right direction and if this gets merged, I might go further and address the recursive imports 