### PR TITLE
Allow injection of custom resolvers into test framework.

### DIFF
--- a/scala/scala-impl/test/org/jetbrains/plugins/scala/DependencyManager.scala
+++ b/scala/scala-impl/test/org/jetbrains/plugins/scala/DependencyManager.scala
@@ -22,7 +22,7 @@ abstract class DependencyManagerBase {
 
   protected val artifactBlackList = Set("scala-library", "scala-reflect", "scala-compiler")
 
-  protected val resolvers = Seq(
+  protected val resolvers: Seq[Resolver] = Seq(
     MavenResolver("central", "http://repo1.maven.org/maven2"),
     MavenResolver("scalaz-releases", "http://dl.bintray.com/scalaz/releases"),
     IvyResolver("typesafe-releases",

--- a/scala/scala-impl/test/org/jetbrains/plugins/scala/base/libraryLoaders/IvyManagedLoader.scala
+++ b/scala/scala-impl/test/org/jetbrains/plugins/scala/base/libraryLoaders/IvyManagedLoader.scala
@@ -4,12 +4,14 @@ import com.intellij.openapi.module.Module
 import com.intellij.openapi.vfs.newvfs.impl.VfsRootAccess
 import com.intellij.testFramework.PsiTestUtil
 import org.jetbrains.plugins.scala.debugger.ScalaVersion
-import org.jetbrains.plugins.scala.DependencyManagerBase._
-import org.jetbrains.plugins.scala.DependencyManager
+import org.jetbrains.plugins.scala.{DependencyManager, DependencyManagerBase}
+import org.jetbrains.plugins.scala.DependencyManagerBase.DependencyDescription
 
 case class IvyManagedLoader(dependencies: DependencyDescription*) extends LibraryLoader {
+  protected lazy val dependencyManager: DependencyManagerBase = DependencyManager
+
   override def init(implicit module: Module, version: ScalaVersion): Unit = {
-    DependencyManager.resolve(dependencies: _*).foreach { resolved =>
+    dependencyManager.resolve(dependencies: _*).foreach { resolved =>
       VfsRootAccess.allowRootAccess(resolved.file.getCanonicalPath)
       PsiTestUtil.addLibrary(module, resolved.info.toString, resolved.file.getParent, resolved.file.getName)
     }

--- a/scala/scala-impl/test/org/jetbrains/plugins/scala/base/libraryLoaders/ScalaSDKLoader.scala
+++ b/scala/scala-impl/test/org/jetbrains/plugins/scala/base/libraryLoaders/ScalaSDKLoader.scala
@@ -17,6 +17,10 @@ import scala.collection.JavaConverters._
 
 
 case class ScalaSDKLoader(includeScalaReflect: Boolean = false) extends LibraryLoader {
+  protected lazy val dependencyManager: DependencyManagerBase = new DependencyManagerBase {
+    override protected val artifactBlackList: Set[String] = Set.empty
+  }
+
   override def init(implicit module: Module, version: ScalaVersion): Unit = {
 
     val deps = Seq(
@@ -25,9 +29,6 @@ case class ScalaSDKLoader(includeScalaReflect: Boolean = false) extends LibraryL
       "org.scala-lang" % "scala-reflect"  % version.minor
     ).filterNot(!includeScalaReflect && _.artId.contains("reflect"))
 
-    val dependencyManager = new DependencyManagerBase {
-      override protected val artifactBlackList: Set[String] = Set.empty
-    }
 
     val resolved = deps.flatMap(dependencyManager.resolve(_))
     val srcsResolved = dependencyManager.resolve("org.scala-lang" % "scala-library" % version.minor % Types.SRC)


### PR DESCRIPTION
First time contributor. Happy to file a YouTrack for this.

Context:

I contribute to an IntelliJ plugin which depends on the Scala plugin (to offer assistance in using a particular DSL). During tests I would like to be able to resolve libraries from alternate repositories, such as an Artifactory instance.

Notes:

1. I considered passing an entire DependencyManager rather than a Seq[Resolver], but that also encodes other aspects like a blacklist which feel best left orthogonal.
1. Parameterization vs. overrides - I've attempted to follow the localized patterns I saw, such as ScalaSdkLoader accepting arguments to control its behavior, as contrasted with DependencyManagerBase which uses subclassing+overrides to control its behavior. I don't love that resolver-mgmt is handled in different ways across these.