### PR TITLE
support a new scalaz-deriving annotation

### DIFF
--- a/scala/scala-impl/src/org/jetbrains/plugins/scala/lang/psi/impl/toplevel/typedef/ScalazDerivingInjector.scala
+++ b/scala/scala-impl/src/org/jetbrains/plugins/scala/lang/psi/impl/toplevel/typedef/ScalazDerivingInjector.scala
@@ -20,12 +20,16 @@ class ScalazDerivingInjector extends SyntheticMembersInjector {
   private def hasDeriving(source: ScTypeDefinition): Boolean =
     (source.findAnnotationNoAliases("deriving") != null) ||
     (source.findAnnotationNoAliases("scalaz.deriving") != null) ||
+    (source.findAnnotationNoAliases("xderiving") != null) ||
+    (source.findAnnotationNoAliases("scalaz.xderiving") != null) ||
     (source.findAnnotationNoAliases("stalactite.deriving") != null)
 
   // slower, more correct
   private def getDeriving(source: ScTypeDefinition): Option[ScAnnotation] =
     source.annotations("deriving").headOption orElse
     source.annotations("scalaz.deriving").headOption orElse
+    source.annotations("xderiving").headOption orElse
+    source.annotations("scalaz.xderiving").headOption orElse
     source.annotations("stalactite.deriving").headOption
 
   // so annotated sealed traits will generate a companion


### PR DESCRIPTION
v1.0 of https://gitlab.com/fommil/scalaz-deriving/ will introduce a new annotation `@xderiving` that behaves identically to `@deriving` as far as IntelliJ is concerned.

The FQN is `scalaz.xderiving` but because it is implemented as a compiler plugin, `_root_.xderiving` is equally valid (unfortunately).