### PR TITLE
Disable verbose boxing/unboxing desugaring by default

### DIFF
--- a/scala/scala-impl/src/org/jetbrains/plugins/scala/lang/transformation/SelectionDialog.scala
+++ b/scala/scala-impl/src/org/jetbrains/plugins/scala/lang/transformation/SelectionDialog.scala
@@ -60,8 +60,8 @@ class SelectionDialog {
       Entry("Inscribe implicit parameters", new InscribeImplicitParameters())
     ),
     Group("Conversion",
-      Entry("Make boxing explicit", new MakeBoxingExplicit()),
-      Entry("Make unboxing explicit"),
+      Entry("Make boxing explicit", new MakeBoxingExplicit(), enabled = false),
+      Entry("Make unboxing explicit", enabled = false),
       Entry("Make conversion to String explicit")
     ),
     Group("Functions",


### PR DESCRIPTION
When teaching new users Scala I have found the "desugar scala code" action very useful with the exception of the fact that they find the unboxing/boxing code confusing.  This pr defaults boxing desugaring to disabled as I believe by the time users need to know about boxing and unboxing they will no longer find the dialogue confusing.