### PR TITLE
Prevent module ID conflict on multi module projects

### DIFF
--- a/scala/scala-impl/src/org/jetbrains/sbt/project/ExternalSourceRootResolution.scala
+++ b/scala/scala-impl/src/org/jetbrains/sbt/project/ExternalSourceRootResolution.scala
@@ -41,7 +41,7 @@ trait ExternalSourceRootResolution { self: SbtProjectResolver =>
 
       val uniqueProjectDependencies = projects.flatMap(_.dependencies.projects).distinct
       uniqueProjectDependencies.foreach { dependencyId =>
-        val dependency = projectToModuleNode.values.find(_.getId == dependencyId.project).getOrElse(
+        val dependency = projectToModuleNode.values.find(_.getId == ModuleNode.combinedId(dependencyId.project, dependencyId.buildURI)).getOrElse(
           throw new ExternalSystemException("Cannot find project dependency: " + dependencyId.project))
 
         val dependencyNode = new ModuleDependencyNode(moduleNode, dependency)
@@ -63,7 +63,7 @@ trait ExternalSourceRootResolution { self: SbtProjectResolver =>
 
   private def createSourceModule(group: RootGroup, moduleFilesDirectory: File): ModuleNode = {
     val moduleNode = new ModuleNode(SharedSourcesModuleType.instance.getId,
-      group.name, group.name, moduleFilesDirectory.path, group.base.canonicalPath)
+      group.name, null, group.name, moduleFilesDirectory.path, group.base.canonicalPath)
 
     val contentRootNode = {
       val node = new ContentRootNode(group.base.path)

--- a/scala/scala-impl/src/org/jetbrains/sbt/project/SbtProjectResolver.scala
+++ b/scala/scala-impl/src/org/jetbrains/sbt/project/SbtProjectResolver.scala
@@ -310,7 +310,7 @@ class SbtProjectResolver extends ExternalSystemProjectResolver[SbtExecutionSetti
       moduleProject.dependencies.projects.foreach { dependencyId =>
         val dependency =
           projectToModule.values
-            .find(_.getId == dependencyId.project)
+            .find(_.getId == ModuleNode.combinedId(dependencyId.project, dependencyId.buildURI))
             .getOrElse(throw new ExternalSystemException("Cannot find project dependency: " + dependencyId.project))
         val data = new ModuleDependencyNode(moduleNode, dependency)
         data.setScope(scopeFor(dependencyId.configuration))
@@ -428,7 +428,7 @@ class SbtProjectResolver extends ExternalSystemProjectResolver[SbtExecutionSetti
   private def createModule(project: sbtStructure.ProjectData, moduleFilesDirectory: File): ModuleNode = {
     // TODO use both ID and Name when related flaws in the External System will be fixed
     // TODO explicit canonical path is needed until IDEA-126011 is fixed
-    val result = new ModuleNode(StdModuleTypes.JAVA.getId, project.id, project.id,
+    val result = new ModuleNode(StdModuleTypes.JAVA.getId, project.id, project.buildURI, project.name,
       moduleFilesDirectory.path, project.base.canonicalPath)
 
     result.setInheritProjectCompileOutputPath(false)
@@ -508,7 +508,7 @@ class SbtProjectResolver extends ExternalSystemProjectResolver[SbtExecutionSetti
 
     // TODO use both ID and Name when related flaws in the External System will be fixed
     // TODO explicit canonical path is needed until IDEA-126011 is fixed
-    val result = new ModuleNode(SbtModuleType.instance.getId, id, id, moduleFilesDirectory.path, buildRoot.canonicalPath)
+    val result = new ModuleNode(SbtModuleType.instance.getId, id, project.buildURI, project.name+Sbt.BuildModuleSuffix, moduleFilesDirectory.path, buildRoot.canonicalPath)
 
     result.setInheritProjectCompileOutputPath(false)
     result.setCompileOutputPath(ExternalSystemSourceType.SOURCE, (buildRoot / Sbt.TargetDirectory / "idea-classes").path)

--- a/scala/scala-impl/src/org/jetbrains/sbt/project/data/Nodes.scala
+++ b/scala/scala-impl/src/org/jetbrains/sbt/project/data/Nodes.scala
@@ -1,6 +1,8 @@
 package org.jetbrains.sbt
 package project.data
 
+import java.net.URI
+
 import com.intellij.openapi.externalSystem.model.project._
 import com.intellij.openapi.externalSystem.model.{DataNode, Key, ProjectKeys}
 import org.jetbrains.sbt.project.SbtProjectSystem
@@ -19,11 +21,22 @@ class ProjectNode(val data: ProjectData)
 
 class ModuleNode(val data: ModuleData)
   extends Node[ModuleData] {
-  def this(typeId: String, id: String, name: String, moduleFileDirectoryPath: String, externalConfigPath: String) {
-    this(new ModuleData(id, SbtProjectSystem.Id, typeId, name, moduleFileDirectoryPath, externalConfigPath))
+  def this(typeId: String, projectId: String, projectURI: URI, name: String, moduleFileDirectoryPath: String, externalConfigPath: String) {
+    this(new ModuleData(ModuleNode.combinedId(projectId, projectURI), SbtProjectSystem.Id, typeId, name, moduleFileDirectoryPath, externalConfigPath))
   }
 
   protected def key: Key[ModuleData] = ProjectKeys.MODULE
+}
+
+object ModuleNode {
+  /**
+    * Generate a formatted ID with project id and URI.
+    * This prevent ID conflicts on multi module projects where different modules have same value as ID
+    * @param projectId project ID
+    * @param projectURI project root path or repository url
+    * @return
+    */
+  def combinedId(projectId: String, projectURI: URI) = if (projectURI != null) f"$projectId [$projectURI]" else projectId
 }
 
 class LibraryNode(val data: LibraryData)


### PR DESCRIPTION
Combine project id and URI to use as module id, in order to guarantee uniqueness on multi module projects. #SCL-13600 fixed

These changes depends on changes made on SBT structure project. See: https://github.com/JetBrains/sbt-structure/pull/55

