### PR TITLE
Support circe JsonCodec/ConfiguredJsonCodec macro annotations

### DIFF
--- a/.idea/intellij-scala.iml
+++ b/.idea/intellij-scala.iml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<module type="JAVA_MODULE" version="4">
-  <component name="NewModuleRootManager" inherit-compiler-output="true">
-    <exclude-output />
-    <content url="file://$MODULE_DIR$" />
-    <orderEntry type="inheritedJdk" />
-    <orderEntry type="sourceFolder" forTests="false" />
-  </component>
-</module>

--- a/.idea/intellij-scala.iml
+++ b/.idea/intellij-scala.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/scala/scala-impl/resources/META-INF/scala-plugin-common.xml
+++ b/scala/scala-impl/resources/META-INF/scala-plugin-common.xml
@@ -32,6 +32,7 @@
         <!--<syntheticMemberInjector implementation="scala.meta.MetaAnnotationInjector"/>-->
         <syntheticMemberInjector implementation="org.jetbrains.plugins.scala.lang.psi.impl.toplevel.typedef.MonocleInjector"/>
         <syntheticMemberInjector implementation="org.jetbrains.plugins.scala.lang.psi.impl.toplevel.typedef.ScalazDerivingInjector"/>
+        <syntheticMemberInjector implementation="org.jetbrains.plugins.scala.lang.psi.impl.toplevel.typedef.CirceCodecInjector"/>
         <syntheticMemberInjector implementation="scala.meta.intellij.MetaSupportInjector"/>
         <syntheticMemberInjector implementation="org.jetbrains.plugins.scala.lang.psi.impl.toplevel.typedef.QuasiQuotesInjector"/>
         <syntheticMemberInjector implementation="org.jetbrains.plugins.scala.lang.psi.impl.toplevel.typedef.simulacrum.SimulacrumInjection"/>
@@ -48,7 +49,7 @@
                 implementation="org.jetbrains.plugins.scala.lang.refactoring.namesSuggester.genericTypes.FunctionTypeNamesProvider"/>
         <genericTypeNamesProvider
                 implementation="org.jetbrains.plugins.scala.lang.refactoring.namesSuggester.genericTypes.TupleTypeNamesProvider"/>
-      
+
         <fileDeclarationsContributor implementation="org.jetbrains.plugins.scala.worksheet.ui.WorksheetFileDeclarationsContributor"/>
         <fileDeclarationsContributor implementation="org.jetbrains.plugins.scala.worksheet.ammonite.AmmoniteFileDeclarationsContributor"/>
     </extensions>

--- a/scala/scala-impl/src/org/jetbrains/plugins/scala/lang/psi/impl/toplevel/typedef/CirceCodecInjector.scala
+++ b/scala/scala-impl/src/org/jetbrains/plugins/scala/lang/psi/impl/toplevel/typedef/CirceCodecInjector.scala
@@ -89,7 +89,6 @@ class CirceCodecInjector extends SyntheticMembersInjector {
       s"implicit def enc_$id$encCtxBounds: $Enc[$nme$encParams] = $Dummy",
       s"implicit def dec_$id$decCtxBounds: $Dec[$nme$decParams] = $Dummy"
     )
-    Seq.empty
   }
 
   private def join(xs: Seq[String]): String = xs.mkString(",")

--- a/scala/scala-impl/src/org/jetbrains/plugins/scala/lang/psi/impl/toplevel/typedef/CirceCodecInjector.scala
+++ b/scala/scala-impl/src/org/jetbrains/plugins/scala/lang/psi/impl/toplevel/typedef/CirceCodecInjector.scala
@@ -1,52 +1,54 @@
 package org.jetbrains.plugins.scala.lang.psi.impl.toplevel.typedef
 
 import scala.util.Random
-import com.intellij.psi.PsiClass
-import org.jetbrains.plugins.scala.extensions.{PsiClassExt, ResolvesTo}
-import org.jetbrains.plugins.scala.lang.psi.api.expr.{ScAnnotation, ScExpression}
+import org.jetbrains.plugins.scala.lang.psi.api.expr.ScAnnotation
 import org.jetbrains.plugins.scala.lang.psi.api.statements.params.ScTypeParam
 import org.jetbrains.plugins.scala.lang.psi.api.toplevel.typedef._
 import org.jetbrains.plugins.scala.lang.psi.types.ScalaTypePresentation
 
 
 /**
- * Support for https://github.com/circe/circe
- *
- * Chooses to skip encoder/decoder derivation (and requirements) in order to
- * provide a much faster editing experience. Users may experience
- * deriving failures when they run the real compiler.
- *
- * @author tkroman
- * @since  06/10/2018
- */
+  * Support for https://github.com/circe/circe
+  *
+  * Does not do typechecking etc
+  * (in particular, no implicit search for Configuration),
+  * so users may face errors when running actual compilation.
+  *
+  * @author tkroman
+  * @since  06/10/2018
+  */
 class CirceCodecInjector extends SyntheticMembersInjector {
-  private val jc: String = "JsonCodec"
-  private val cjc: String = "ConfiguredJsonCodec"
-  private val fqnJc: String = "io.circe.generic.JsonCodec"
-  private val fqnCjc: String = "io.circe.generic.extras.ConfiguredJsonCodec"
+  private val Jc: String = "JsonCodec"
+  private val Cjc: String = "ConfiguredJsonCodec"
+  private val FqnJc: String = "io.circe.generic.JsonCodec"
+  private val FqnCjc: String = "io.circe.generic.extras.ConfiguredJsonCodec"
+  private val Enc: String = "_root_.io.circe.Encoder"
+  private val Dec: String = "_root_.io.circe.Decoder"
+  private val Dummy: String = "_root_.scala.Predef.???"
 
   // fast check
   private def hasCodecs(source: ScTypeDefinition): Boolean = {
-    (source.findAnnotationNoAliases(jc) != null) ||
-      (source.findAnnotationNoAliases(fqnJc) != null) ||
-      (source.findAnnotationNoAliases(cjc) != null) ||
-      (source.findAnnotationNoAliases(fqnCjc) != null)
+    (source.findAnnotationNoAliases(Jc) != null) ||
+      (source.findAnnotationNoAliases(FqnJc) != null) ||
+      (source.findAnnotationNoAliases(Cjc) != null) ||
+      (source.findAnnotationNoAliases(FqnCjc) != null)
   }
 
   // slower, more correct
   private def getDeriving(source: ScTypeDefinition): Option[ScAnnotation] = {
-    source.annotations(jc).headOption orElse
-      source.annotations(cjc).headOption orElse
-      source.annotations(fqnJc).headOption orElse
-      source.annotations(fqnCjc).headOption
+    source.annotations(Jc).headOption orElse
+      source.annotations(Cjc).headOption orElse
+      source.annotations(FqnJc).headOption orElse
+      source.annotations(FqnCjc).headOption
   }
 
   // so annotated sealed traits will generate a companion
-  override def needsCompanionObject(source: ScTypeDefinition): Boolean =
+  override def needsCompanionObject(source: ScTypeDefinition): Boolean = {
     hasCodecs(source)
+  }
 
   // add implicits to case object / case class companions
-  override def injectFunctions(source: ScTypeDefinition): Seq[String] =
+  override def injectFunctions(source: ScTypeDefinition): Seq[String] = {
     source match {
       case cob: ScObject if hasCodecs(cob) =>
         genImplicits(cob, cob.typeParameters)
@@ -58,10 +60,7 @@ class CirceCodecInjector extends SyntheticMembersInjector {
         }
       case _ => Nil
     }
-
-  private val Enc = "_root_.io.circe.Encoder"
-  private val Dec = "_root_.io.circe.Decoder"
-  private val Dummy = "_root_.scala.Predef.???"
+  }
 
   private def genImplicits(clazz: ScTypeDefinition, typarams: Seq[ScTypeParam]): Seq[String] = {
     val tparams: Seq[String] = typarams.map(tp => tp.name)
@@ -90,6 +89,7 @@ class CirceCodecInjector extends SyntheticMembersInjector {
       s"implicit def enc_$id$encCtxBounds: $Enc[$nme$encParams] = $Dummy",
       s"implicit def dec_$id$decCtxBounds: $Dec[$nme$decParams] = $Dummy"
     )
+    Seq.empty
   }
 
   private def join(xs: Seq[String]): String = xs.mkString(",")

--- a/scala/scala-impl/src/org/jetbrains/plugins/scala/lang/psi/impl/toplevel/typedef/CirceCodecInjector.scala
+++ b/scala/scala-impl/src/org/jetbrains/plugins/scala/lang/psi/impl/toplevel/typedef/CirceCodecInjector.scala
@@ -34,14 +34,6 @@ class CirceCodecInjector extends SyntheticMembersInjector {
       (source.findAnnotationNoAliases(FqnCjc) != null)
   }
 
-  // slower, more correct
-  private def getDeriving(source: ScTypeDefinition): Option[ScAnnotation] = {
-    source.annotations(Jc).headOption orElse
-      source.annotations(Cjc).headOption orElse
-      source.annotations(FqnJc).headOption orElse
-      source.annotations(FqnCjc).headOption
-  }
-
   // so annotated sealed traits will generate a companion
   override def needsCompanionObject(source: ScTypeDefinition): Boolean = {
     hasCodecs(source)

--- a/scala/scala-impl/src/org/jetbrains/plugins/scala/lang/psi/impl/toplevel/typedef/CirceCodecInjector.scala
+++ b/scala/scala-impl/src/org/jetbrains/plugins/scala/lang/psi/impl/toplevel/typedef/CirceCodecInjector.scala
@@ -1,0 +1,96 @@
+package org.jetbrains.plugins.scala.lang.psi.impl.toplevel.typedef
+
+import scala.util.Random
+import com.intellij.psi.PsiClass
+import org.jetbrains.plugins.scala.extensions.{PsiClassExt, ResolvesTo}
+import org.jetbrains.plugins.scala.lang.psi.api.expr.{ScAnnotation, ScExpression}
+import org.jetbrains.plugins.scala.lang.psi.api.statements.params.ScTypeParam
+import org.jetbrains.plugins.scala.lang.psi.api.toplevel.typedef._
+import org.jetbrains.plugins.scala.lang.psi.types.ScalaTypePresentation
+
+
+/**
+ * Support for https://github.com/circe/circe
+ *
+ * Chooses to skip encoder/decoder derivation (and requirements) in order to
+ * provide a much faster editing experience. Users may experience
+ * deriving failures when they run the real compiler.
+ *
+ * @author tkroman
+ * @since  06/10/2018
+ */
+class CirceCodecInjector extends SyntheticMembersInjector {
+  private val jc: String = "JsonCodec"
+  private val cjc: String = "ConfiguredJsonCodec"
+  private val fqnJc: String = "io.circe.generic.JsonCodec"
+  private val fqnCjc: String = "io.circe.generic.extras.ConfiguredJsonCodec"
+
+  // fast check
+  private def hasCodecs(source: ScTypeDefinition): Boolean = {
+    (source.findAnnotationNoAliases(jc) != null) ||
+      (source.findAnnotationNoAliases(fqnJc) != null) ||
+      (source.findAnnotationNoAliases(cjc) != null) ||
+      (source.findAnnotationNoAliases(fqnCjc) != null)
+  }
+
+  // slower, more correct
+  private def getDeriving(source: ScTypeDefinition): Option[ScAnnotation] = {
+    source.annotations(jc).headOption orElse
+      source.annotations(cjc).headOption orElse
+      source.annotations(fqnJc).headOption orElse
+      source.annotations(fqnCjc).headOption
+  }
+
+  // so annotated sealed traits will generate a companion
+  override def needsCompanionObject(source: ScTypeDefinition): Boolean =
+    hasCodecs(source)
+
+  // add implicits to case object / case class companions
+  override def injectFunctions(source: ScTypeDefinition): Seq[String] =
+    source match {
+      case cob: ScObject if hasCodecs(cob) =>
+        genImplicits(cob, cob.typeParameters)
+      case obj: ScObject =>
+        obj.fakeCompanionClassOrCompanionClass match {
+          case clazz: ScTypeDefinition if hasCodecs(clazz) =>
+            genImplicits(clazz, clazz.typeParameters)
+          case _ => Nil
+        }
+      case _ => Nil
+    }
+
+  private val Enc = "_root_.io.circe.Encoder"
+  private val Dec = "_root_.io.circe.Decoder"
+  private val Dummy = "_root_.scala.Predef.???"
+
+  private def genImplicits(clazz: ScTypeDefinition, typarams: Seq[ScTypeParam]): Seq[String] = {
+    val tparams: Seq[String] = typarams.map(tp => tp.name)
+
+    val nme: String = if (clazz.isObject) {
+      clazz.name + ScalaTypePresentation.ObjectTypeSuffix
+    } else {
+      clazz.name
+    }
+
+    val ((encParams, decParams), (encCtxBounds, decCtxBounds)) = if (clazz.typeParameters.isEmpty) {
+      (("",""),("",""))
+    } else {
+      val tps: String = join(tparams)
+      (
+        (s"[$tps]", s"[$tps]"),
+        (
+          s"[${join(tparams.map(p => s"$p: $Enc"))}]",
+          s"[${join(tparams.map(p => s"$p: $Dec"))}]"
+        ),
+      )
+    }
+    val id: Int = Random.nextInt(1000000)
+
+    Seq(
+      s"implicit def enc_$id$encCtxBounds: $Enc[$nme$encParams] = $Dummy",
+      s"implicit def dec_$id$decCtxBounds: $Dec[$nme$decParams] = $Dummy"
+    )
+  }
+
+  private def join(xs: Seq[String]): String = xs.mkString(",")
+}

--- a/scala/scala-impl/test/org/jetbrains/plugins/scala/lang/macros/CirceCodecTest.scala
+++ b/scala/scala-impl/test/org/jetbrains/plugins/scala/lang/macros/CirceCodecTest.scala
@@ -1,0 +1,138 @@
+package org.jetbrains.plugins.scala.lang.macros
+
+import com.intellij.openapi.util.text.StringUtil
+import com.intellij.psi.util.PsiTreeUtil
+import org.jetbrains.plugins.scala.DependencyManagerBase._
+import org.jetbrains.plugins.scala.base.ScalaLightCodeInsightFixtureTestAdapter
+import org.jetbrains.plugins.scala.base.libraryLoaders.{IvyManagedLoader, LibraryLoader}
+import org.jetbrains.plugins.scala.debugger.{ScalaVersion, Scala_2_11}
+import org.jetbrains.plugins.scala.lang.psi.api.statements.ScFunctionDefinition
+import org.jetbrains.plugins.scala.lang.psi.api.toplevel.typedef._
+import org.jetbrains.plugins.scala.lang.psi.types.PhysicalSignature
+import org.jetbrains.plugins.scala.lang.psi.types.result._
+import org.jetbrains.plugins.scala.util.TestUtils
+import org.junit.Assert._
+
+
+class CirceCodecTest extends ScalaLightCodeInsightFixtureTestAdapter {
+
+  override implicit val version: ScalaVersion = Scala_2_11
+
+  override def librariesLoaders: Seq[LibraryLoader] = super.librariesLoaders :+ IvyManagedLoader(
+    "io.circe" %% "circe-core" % "0.9.3",
+    "io.circe" %% "circe-generic" % "0.9.3",
+    "io.circe" %% "circe-generic-extras" % "0.9.3"
+  )
+
+  protected def folderPath: String = TestUtils.getTestDataPath
+
+  def doTest(text: String, codecTypeName: String): Unit = {
+    val cleaned = StringUtil.convertLineSeparators(text)
+    val caretPos = cleaned.indexOf("<caret>")
+    getFixture.configureByText("dummy.scala", cleaned.replace("<caret>", ""))
+
+    val clazz = PsiTreeUtil.findElementOfClassAtOffset(
+      getFile,
+      caretPos,
+      classOf[ScTypeDefinition],
+      false
+    )
+
+    val implicitDefs0: Set[TypeResult] = clazz
+      .fakeCompanionModule
+      .getOrElse(clazz.asInstanceOf[ScObject])
+      .allMethods
+      .collect {
+        case PhysicalSignature(fun: ScFunctionDefinition, _) if fun.hasModifierProperty("implicit") => fun
+      }
+      .map(m => m.returnType)
+      .toSet
+
+    assertTrue("no implicit defs were generated", implicitDefs0.forall(_.isRight))
+
+    val implicitDefs: Set[String] =
+      implicitDefs0.map(_.right.get.presentableText)
+
+    assertEquals(
+      s"$implicitDefs != Set(Encoder[$codecTypeName], Decoder[$codecTypeName])",
+      implicitDefs,
+      Set(
+        s"Encoder[$codecTypeName]",
+        s"Decoder[$codecTypeName]"
+      )
+    )
+  }
+
+  def testJsonCodec(): Unit = {
+    val fileText: String = """
+package foo
+
+import io.circe.generic.JsonCodec
+
+@JsonCodec case class <caret>A(x: Int)
+"""
+
+    doTest(fileText, "A")
+  }
+
+  def testConfiguredJsonCodec(): Unit = {
+    val fileText: String = """
+package foo
+
+import io.circe.generic.extras.ConfiguredJsonCodec
+
+@ConfiguredJsonCodec case class <caret>B(x: Int)
+"""
+
+    doTest(fileText, "B")
+  }
+
+  def testGenericClasses0(): Unit = {
+    val fileText: String = """
+package foo
+
+import io.circe.generic.JsonCodec
+
+@JsonCodec case class <caret>C[A: Encoder: Decoder](x: A)
+"""
+
+    doTest(fileText, "C[A]")
+  }
+
+  def testGenericClasses1(): Unit = {
+    val fileText: String = """
+package foo
+
+import io.circe.generic.JsonCodec
+
+@JsonCodec case class <caret>D[A: Encoder: Decoder, B: Encoder: Decoder](x: A, y: B)
+"""
+
+    doTest(fileText, "D[A, B]")
+  }
+
+  def testObject(): Unit = {
+    val fileText: String = """
+package foo
+
+import io.circe.generic.JsonCodec
+
+@JsonCodec case object <caret>X
+"""
+
+    doTest(fileText, "X.type")
+  }
+
+  def testTrait(): Unit = {
+    val fileText: String = """
+package foo
+
+import io.circe.generic.JsonCodec
+
+@JsonCodec sealed trait <caret>Y
+"""
+
+    doTest(fileText, "Y")
+  }
+
+}

--- a/scala/scala-impl/test/org/jetbrains/plugins/scala/lang/macros/CirceCodecTest.scala
+++ b/scala/scala-impl/test/org/jetbrains/plugins/scala/lang/macros/CirceCodecTest.scala
@@ -134,5 +134,20 @@ import io.circe.generic.JsonCodec
 
     doTest(fileText, "Y")
   }
+  
+  def testCaseClassWithCompanion(): Unit = {
+    val fileText: String = """
+package foo
+
+import io.circe.generic.JsonCodec
+
+@JsonCodec case class Boom(i: Int)
+object Boom {
+  val something: String = ""
+}
+"""
+
+    doTest(fileText, "Boom")
+  }
 
 }


### PR DESCRIPTION
Based on @fommil's deriving plugin (same limitations apply: no implicit resolution etc => false positives happen)

Screenshots for with/without this PR.
Notice that `ConfiguredJsonCodec`-based derivation isn't red even though it should be (no implicit `Confifuration` in scope), but I would assume it's fine with most users.

<img width="223" alt="screen shot 2018-10-06 at 23 48 18" src="https://user-images.githubusercontent.com/1114784/46575760-77792080-c9c4-11e8-8cc8-41506bb5000c.png">
<img width="381" alt="screen shot 2018-10-07 at 00 00 18" src="https://user-images.githubusercontent.com/1114784/46575761-77792080-c9c4-11e8-80b4-fd74feab414e.png">
