### PR TITLE
fix escaping symbol [ in test runner

### DIFF
--- a/scala/runners/src/org/jetbrains/plugins/scala/testingSupport/TestRunnerUtil.java
+++ b/scala/runners/src/org/jetbrains/plugins/scala/testingSupport/TestRunnerUtil.java
@@ -42,7 +42,7 @@ public class TestRunnerUtil {
   private static final SimpleDateFormat TIMESTAMP_FORMAT = new SimpleDateFormat(FORMAT_WITHOUT_TZ);
 
   public static String escapeString(String s) {
-    return s.replaceAll("[|]", "||").replaceAll("[']", "|'").replaceAll("[\n]", "|n").replaceAll("[\r]", "|r").replaceAll("]","|]");
+    return s.replaceAll("[|]", "||").replaceAll("[']", "|'").replaceAll("[\n]", "|n").replaceAll("[\r]", "|r").replaceAll("]","|]").replaceAll("\\[","|[");
   }
 
   public static String formatCurrentTimestamp() {


### PR DESCRIPTION
If test message contains open square bracket then test runner show broken output.
It can't parse message and show smt like `##teamcity[testFailed...`
<img width="1163" alt="screenshot 2018-11-16 at 05 31 06" src="https://user-images.githubusercontent.com/135157/48598887-46eab600-e976-11e8-8a26-4c120ef78073.png">

It's typically happen on Doobie query check test.
I added escaping for open square bracket and now it looks great
<img width="869" alt="screenshot 2018-11-16 at 05 27 24" src="https://user-images.githubusercontent.com/135157/48598934-82858000-e976-11e8-97e3-ed6766397047.png">
