### PR TITLE
Suggest to add `override` modifier 

### DIFF
--- a/scala/scala-impl/resources/META-INF/scala-plugin-common.xml
+++ b/scala/scala-impl/resources/META-INF/scala-plugin-common.xml
@@ -1018,6 +1018,14 @@
               language="Scala" level="WARNING"
               enabledByDefault="true"/>
       <localInspection
+            implementationClass="org.jetbrains.plugins.scala.codeInspection.methodSignature.ScalaOverrideModifierMissingInspection"
+            bundle="org.jetbrains.plugins.scala.codeInspection.InspectionBundle"
+            key="method.signature.override.modifier.missing"
+            groupPath="Scala" groupName="Method signature"
+            shortName="ScalaOverrideModifierMissing"
+            language="Scala" level="WARNING"
+            enabledByDefault="true"/>
+      <localInspection
               implementationClass="org.jetbrains.plugins.scala.codeInspection.methodSignature.ApparentResultTypeRefinementInspection"
               bundle="org.jetbrains.plugins.scala.codeInspection.InspectionBundle"
               key="method.signature.result.type.refinement"

--- a/scala/scala-impl/resources/org/jetbrains/plugins/scala/codeInspection/InspectionBundle.properties
+++ b/scala/scala-impl/resources/org/jetbrains/plugins/scala/codeInspection/InspectionBundle.properties
@@ -135,6 +135,7 @@ method.signature.empty.paren.override.parameterless=Parameterless Scala member o
 method.signature.parameterless.access.java.mutator=Java mutator method accessed as parameterless
 method.signature.parameterless.access.empty.paren=Empty-paren method accessed as parameterless
 method.signature.java.accessor.empty.paren=Java accessor method called as empty-paren
+method.signature.override.modifier.missing=Add `override` modifier
 empty.parentheses=Add empty parentheses
 add.call.parentheses=Add call parentheses
 remove.call.parentheses=Remove call prentheses

--- a/scala/scala-impl/src/org/jetbrains/plugins/scala/codeInspection/methodSignature/ScalaOverrideModifierMissingInspection.scala
+++ b/scala/scala-impl/src/org/jetbrains/plugins/scala/codeInspection/methodSignature/ScalaOverrideModifierMissingInspection.scala
@@ -1,0 +1,43 @@
+package org.jetbrains.plugins.scala.codeInspection.methodSignature
+
+import com.intellij.codeInspection.{InspectionManager, LocalQuickFix, ProblemDescriptor, ProblemHighlightType}
+import com.intellij.openapi.project.Project
+import com.intellij.psi.{PsiElement, PsiNamedElement}
+import org.jetbrains.plugins.scala.codeInspection.{AbstractFixOnPsiElement, AbstractRegisteredInspection, InspectionBundle}
+import org.jetbrains.plugins.scala.lang.psi.ScalaPsiUtil.superValsSignatures
+import org.jetbrains.plugins.scala.lang.psi.api.statements._
+import org.jetbrains.plugins.scala.lang.psi.api.statements.params.ScParameter
+import org.jetbrains.plugins.scala.lang.psi.api.toplevel.ScModifierListOwner
+
+class ScalaOverrideModifierMissingInspection extends AbstractRegisteredInspection {
+
+  override protected def problemDescriptor(element: PsiElement,
+                                           maybeQuickFix: Option[LocalQuickFix],
+                                           descriptionTemplate: String,
+                                           highlightType: ProblemHighlightType)
+                                          (implicit manager: InspectionManager,
+                                           isOnTheFly: Boolean): Option[ProblemDescriptor] = {
+    def noOverrideModifier(member: ScModifierListOwner): Boolean = !member.hasModifierProperty("override")
+    val hasSuper: PsiNamedElement => Boolean = superValsSignatures(_, withSelfType = true).nonEmpty
+
+    lazy val problemDescriptor = super.problemDescriptor(element, createQuickFix(element), descriptionTemplate, ProblemHighlightType.INFORMATION)
+
+    element match {
+      case method: ScFunction if noOverrideModifier(method) && method.superMethod.isDefined => problemDescriptor
+      case param: ScParameter if noOverrideModifier(param) && hasSuper(param) => problemDescriptor
+      case expr: ScValueOrVariable if noOverrideModifier(expr) && expr.declaredElements.exists(hasSuper) => problemDescriptor
+      case _ => None
+    }
+  }
+
+  def createQuickFix(element: PsiElement): Option[LocalQuickFix] = {
+    Some(new AbstractFixOnPsiElement(InspectionBundle.message("method.signature.override.modifier.missing"), element) {
+      override protected def doApplyFix(element: PsiElement)(implicit project: Project): Unit = {
+        element match {
+          case mOwner: ScModifierListOwner => mOwner.getModifierList.setModifierProperty("override", true)
+        }
+      }
+    })
+  }
+
+}

--- a/scala/scala-impl/test/org/jetbrains/plugins/scala/codeInspection/methodSignature/ScalaOverrideModifierMissingInspectionBase.scala
+++ b/scala/scala-impl/test/org/jetbrains/plugins/scala/codeInspection/methodSignature/ScalaOverrideModifierMissingInspectionBase.scala
@@ -1,0 +1,47 @@
+package org.jetbrains.plugins.scala.codeInspection.methodSignature
+
+import com.intellij.testFramework.EditorTestUtil
+import org.jetbrains.plugins.scala.codeInspection.{InspectionBundle, ScalaQuickFixTestBase}
+
+abstract class ScalaOverrideModifierMissingInspectionBase(keyword: String) extends ScalaQuickFixTestBase {
+  import EditorTestUtil.{SELECTION_END_TAG => END, SELECTION_START_TAG => START}
+
+  override protected val classOfInspection =
+    classOf[ScalaOverrideModifierMissingInspection]
+  override protected val description =
+    InspectionBundle.message("method.signature.override.modifier.missing")
+  private val hint = "Add `override` modifier"
+
+  def test1(): Unit = {
+    val text =
+      s"""
+         |trait A {
+         | $keyword sample: Int
+         |}
+         |
+         |class B extends A {
+         | 1;$START$keyword sample: Int = 1$END
+         |}
+        """
+    checkTextHasError(text)
+
+    testQuickFix(text,
+      expected =
+        s"""
+           |trait A {
+           | $keyword sample: Int
+           |}
+           |
+           |class B extends A {
+           | 1;override $keyword sample: Int = 1
+           |}
+        """,
+      hint
+    )
+  }
+
+}
+
+class FunctionScalaOverrideModifierMissingInspectionTest extends ScalaOverrideModifierMissingInspectionBase("def")
+class ValueScalaOverrideModifierMissingInspectionTest extends ScalaOverrideModifierMissingInspectionBase("val")
+class VariableScalaOverrideModifierMissingInspectionTest extends ScalaOverrideModifierMissingInspectionBase("var")


### PR DESCRIPTION
Quick fix which allows to add `override` modifier 

```
trait A { def sample(): Int }
class B extends A { def sample(): Int }
```

into

```
trait A { def sample(): Int }
class B extends A { **override** def sample(): Int }
```