### PR TITLE
use current document version when formatting with scalafmt

### DIFF
--- a/scala/scala-impl/src/org/jetbrains/plugins/scala/lang/formatting/ReformatOnFileSaveTask.scala
+++ b/scala/scala-impl/src/org/jetbrains/plugins/scala/lang/formatting/ReformatOnFileSaveTask.scala
@@ -35,7 +35,7 @@ class ReformatOnFileSaveTask(project: Project) extends ProjectComponent {
       psiFile <- PsiDocumentManager.getInstance(project).getPsiFile(document).nullSafe
       if isFileSupported(psiFile) && isInProjectSources(psiFile, vFile)
     } CommandProcessor.runUndoTransparentAction {
-      ScalaFmtPreFormatProcessor.formatWithoutCommit(psiFile, respectProjectMatcher = true)
+      ScalaFmtPreFormatProcessor.formatWithoutCommit(psiFile, document, respectProjectMatcher = true)
     }
   }
 

--- a/scala/scala-impl/src/org/jetbrains/plugins/scala/lang/formatting/processors/ScalaFmtPreFormatProcessor.scala
+++ b/scala/scala-impl/src/org/jetbrains/plugins/scala/lang/formatting/processors/ScalaFmtPreFormatProcessor.scala
@@ -307,17 +307,16 @@ object ScalaFmtPreFormatProcessor {
     if (config == null || respectProjectMatcher && !configManager.isIncludedInProject(file, config))
       return
 
-    formatWithoutCommit(file, Some(document), config) match {
+    formatWithoutCommit(document, config) match {
       case Left(error: ScalafmtFormatError) =>
         reportInvalidCodeFailure(file, Some(error))(file.getProject)
       case _ =>
     }
   }
 
-  private def formatWithoutCommit(file: PsiFile, optDocument: Option[Document], config: ScalafmtDynamicConfig): Either[FormattingError, Unit] = {
+  private def formatWithoutCommit(document: Document, config: ScalafmtDynamicConfig): Either[FormattingError, Unit] = {
     val scalaFmt: ScalafmtReflect = config.fmtReflect
     for {
-      document <- optDocument.orElse(Option(PsiDocumentManager.getInstance(file.getProject).getDocument(file))).toRight(DocumentNotFoundError)
       formattedText <- scalaFmt.tryFormat(document.getText, config)
     } yield {
       inWriteAction(document.setText(formattedText))
@@ -335,7 +334,7 @@ object ScalaFmtPreFormatProcessor {
 
     var wholeFileFormatError: Option[ScalafmtFormatError] = None
     if (rangeIncludesWholeFile) {
-      formatWithoutCommit(file, None, config) match {
+      formatWithoutCommit(document, config) match {
         case Right(_) =>
           manager.commitDocument(document)
           return None

--- a/scala/scala-impl/src/org/jetbrains/plugins/scala/lang/formatting/processors/ScalaFmtPreFormatProcessor.scala
+++ b/scala/scala-impl/src/org/jetbrains/plugins/scala/lang/formatting/processors/ScalaFmtPreFormatProcessor.scala
@@ -4,6 +4,7 @@ import com.intellij.application.options.CodeStyle
 import com.intellij.lang.ASTNode
 import com.intellij.notification._
 import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.editor.Document
 import com.intellij.openapi.fileEditor.OpenFileDescriptor
 import com.intellij.openapi.progress.ProgressIndicatorProvider
 import com.intellij.openapi.project.Project
@@ -300,24 +301,24 @@ object ScalaFmtPreFormatProcessor {
     elementsFormatted.collect { case (el, Some(code)) => (el, code) }
   }
 
-  def formatWithoutCommit(file: PsiFile, respectProjectMatcher: Boolean): Unit = {
+  def formatWithoutCommit(file: PsiFile, document: Document, respectProjectMatcher: Boolean): Unit = {
     val configManager = ScalafmtDynamicConfigManager.instanceIn(file.getProject)
     val config = configManager.configForFile(file).orNull
     if (config == null || respectProjectMatcher && !configManager.isIncludedInProject(file, config))
       return
 
-    formatWithoutCommit(file, config) match {
+    formatWithoutCommit(file, Some(document), config) match {
       case Left(error: ScalafmtFormatError) =>
         reportInvalidCodeFailure(file, Some(error))(file.getProject)
       case _ =>
     }
   }
 
-  private def formatWithoutCommit(file: PsiFile, config: ScalafmtDynamicConfig): Either[FormattingError, Unit] = {
+  private def formatWithoutCommit(file: PsiFile, optDocument: Option[Document], config: ScalafmtDynamicConfig): Either[FormattingError, Unit] = {
     val scalaFmt: ScalafmtReflect = config.fmtReflect
     for {
-      document <- Option(PsiDocumentManager.getInstance(file.getProject).getDocument(file)).toRight(DocumentNotFoundError)
-      formattedText <- scalaFmt.tryFormat(file.getText, config)
+      document <- optDocument.orElse(Option(PsiDocumentManager.getInstance(file.getProject).getDocument(file))).toRight(DocumentNotFoundError)
+      formattedText <- scalaFmt.tryFormat(document.getText, config)
     } yield {
       inWriteAction(document.setText(formattedText))
     }
@@ -334,7 +335,7 @@ object ScalaFmtPreFormatProcessor {
 
     var wholeFileFormatError: Option[ScalafmtFormatError] = None
     if (rangeIncludesWholeFile) {
-      formatWithoutCommit(file, config) match {
+      formatWithoutCommit(file, None, config) match {
         case Right(_) =>
           manager.commitDocument(document)
           return None


### PR DESCRIPTION
The reformat on save reads the content from the source file
when it should have used the current document that's in memory.

SCL-15402 fixed