### PR TITLE
SCL-16179 Support for switch expressions (no yield yet)

### DIFF
--- a/scala/conversion/src/org/jetbrains/plugins/scala/conversion/ast/Statements.scala
+++ b/scala/conversion/src/org/jetbrains/plugins/scala/conversion/ast/Statements.scala
@@ -31,9 +31,10 @@ case class ExpressionListStatement(exprs: Seq[IntermediateNode]) extends Interme
 
 case class SynchronizedStatement(lock: Option[IntermediateNode], body: Option[IntermediateNode]) extends IntermediateNode
 
-case class SwitchLabelStatement(caseValue: Option[IntermediateNode], arrow: String) extends IntermediateNode
+case class SwitchLabelStatement(caseValues: Seq[IntermediateNode], arrow: String,
+                                body: Option[IntermediateNode] = None) extends IntermediateNode
 
-case class SwitchStatemtnt(expession: Option[IntermediateNode], body: Option[IntermediateNode]) extends IntermediateNode
+case class SwitchBlock(expession: Option[IntermediateNode], body: Option[IntermediateNode]) extends IntermediateNode
 
 case class TryCatchStatement(resourcesList: Seq[(String, IntermediateNode)], tryBlock: Seq[IntermediateNode],
                              catchStatements: Seq[(IntermediateNode, IntermediateNode)],

--- a/scala/conversion/src/org/jetbrains/plugins/scala/conversion/visitors/SimplePrintVisitor.scala
+++ b/scala/conversion/src/org/jetbrains/plugins/scala/conversion/visitors/SimplePrintVisitor.scala
@@ -101,8 +101,8 @@ class SimplePrintVisitor protected() {
       visitWhile(w, initialization, condition, body, update, whileType)
     case TryCatchStatement(resourcesList, tryBlock, catchStatements, finallyStatements, arrow) =>
       visitTryCatch(resourcesList, tryBlock, catchStatements, finallyStatements, arrow)
-    case SwitchStatemtnt(expression, body) => visitSwitchStatement(expression, body)
-    case SwitchLabelStatement(caseValue, arrow) => visitSwitchLabelStatement(caseValue, arrow)
+    case SwitchBlock(expression, body) => visitSwitchStatement(expression, body)
+    case SwitchLabelStatement(caseValues, arrow, body) => visitSwitchLabelStatement(caseValues, arrow, body)
     case SynchronizedStatement(lock, body) => visitSynchronizedStatement(lock, body)
     case ExpressionListStatement(exprs) => visitExpressionListStatement(exprs)
     case EnumConstruction(name) => visit(name)
@@ -790,10 +790,17 @@ class SimplePrintVisitor protected() {
     }
   }
 
-  protected def visitSwitchLabelStatement(caseValue: Option[IntermediateNode], arrow: String): Unit = {
+  protected def visitSwitchLabelStatement(caseValues: Seq[IntermediateNode], arrow: String,
+                                          body: Option[IntermediateNode]): Unit = {
     printer.append("case ")
-    if (caseValue.isDefined) visit(caseValue.get)
+    var first = true
+    caseValues.foreach(e => {
+      if (first) first = false
+      else printer.append(" | ")
+      visit(e)
+    })
     printer.append(s" $arrow ")
+    body.foreach(visit)
   }
 
   protected def visitNotSupported(iNode: Option[IntermediateNode], msg: String): Unit = {

--- a/scala/conversion/test/org/jetbrains/plugins/scala/conversion/generated/JavaToScalaConversionExamplesTest.scala
+++ b/scala/conversion/test/org/jetbrains/plugins/scala/conversion/generated/JavaToScalaConversionExamplesTest.scala
@@ -77,4 +77,6 @@ class JavaToScalaConversionExamplesTest extends JavaToScalaConversionTestBase {
   def testImports(): Unit = doTest()
 
   def testLambdaExpr(): Unit = doTest()
+
+  def testSwitchExpression(): Unit = doTest()
 }

--- a/scala/scala-impl/testdata/conversion/examples/SwitchExpression.java
+++ b/scala/scala-impl/testdata/conversion/examples/SwitchExpression.java
@@ -1,0 +1,23 @@
+/*start*/
+class SwitchExpression {
+    public void main(String[] args) {
+        int x = switch (args.length) {
+            case 1 -> 3;
+            case 2 -> 4;
+            case 3, 4 -> 5;
+            default -> args.length * 2;
+        };
+    }
+}/*end*/
+
+/*
+class SwitchExpression {
+  def main(args: Array[String]): Unit = {
+    val x: Int = args.length match {
+      case 1 => 3
+      case 2 => 4
+      case 3 | 4 => 5
+      case _ => args.length * 2
+    }
+  }
+}*/


### PR DESCRIPTION
Just some contribution in the known-to-me area to warm up.

A yield statement could be supported to some extent if it's the last statement in the top-level block inside the `case`. In other cases, the conversion seems non-trivial (though I'm a complete newbie in Scala, probably I just don't know something). Also to test the yield it will be necessary to set language level to 13-preview. Otherwise, the `yield` keyword is tokenized as an identifier. I can do these if there are no objections.