### PR TITLE
parseExtendsBlock: do not add " extends " if nothing is displayed after it

### DIFF
--- a/scala/scala-impl/src/org/jetbrains/plugins/scala/editor/documentationProvider/ScalaDocumentationProvider.scala
+++ b/scala/scala-impl/src/org/jetbrains/plugins/scala/editor/documentationProvider/ScalaDocumentationProvider.scala
@@ -721,7 +721,7 @@ object ScalaDocumentationProvider {
 
   private def parseExtendsBlock(elem: ScExtendsBlock)
                                (implicit typeToString: ScType => String): String = {
-    val buffer: StringBuilder = new StringBuilder(" extends ")
+    val buffer: StringBuilder = new StringBuilder()
     elem.templateParents match {
       case Some(x: ScTemplateParents) =>
         val seq = x.allTypeElements
@@ -734,7 +734,7 @@ object ScalaDocumentationProvider {
         }
     }
 
-    buffer.toString()
+    if (buffer.isEmpty) "" else " extends " + buffer
   }
 
   private def parseModifiers(elem: ScModifierListOwner): String = {

--- a/scala/scala-impl/test/org/jetbrains/plugins/scala/lang/scaladoc/quickdoc/QuickDocTest.scala
+++ b/scala/scala-impl/test/org/jetbrains/plugins/scala/lang/scaladoc/quickdoc/QuickDocTest.scala
@@ -55,7 +55,22 @@ class QuickDocTest extends ScalaLightPlatformCodeInsightTestCaseAdapter {
     generateSimpleByText(fileText, testText)
   }
 
-   def testSimpleTags() {
+  def testSimpleClass(): Unit = {
+    val fileText =
+      """package foo
+        |
+        |class A"""
+    val expected =
+      """<html><body><div class="definition"><font size="-1"><b>foo</b></font><pre>class <b>A</b>
+        |</pre></div></body></html>""".stripMargin.replaceAll("\r", "")
+
+    configureFromFileTextAdapter("dummy.scala", fileText.stripMargin('|').replaceAll("\r", "").trim())
+    val element = getFileAdapter.getLastChild.getLastChild
+    val generated = QuickDocTest.quickDocGenerator.generateDoc(element, element)
+    Assert.assertEquals(expected, generated)
+  }
+
+  def testSimpleTags() {
     val fileText =
       """
       | /**


### PR DESCRIPTION
#SCL-15751 fixed