### PR TITLE
ScalaTypedHandler: hasPrefix method fixed

### DIFF
--- a/scala/scala-impl/src/org/jetbrains/plugins/scala/editor/typedHandler/ScalaTypedHandler.scala
+++ b/scala/scala-impl/src/org/jetbrains/plugins/scala/editor/typedHandler/ScalaTypedHandler.scala
@@ -70,7 +70,7 @@ class ScalaTypedHandler extends TypedHandlerDelegate {
     @inline
     def hasPrefix(prefix: String): Boolean =
       prefix.length <= offset && offset < text.length &&
-        text.substring(offset - prefix.length, offset) == " case "
+        text.substring(offset - prefix.length, offset) == prefix
 
     val myTask: Task = if (isInDocComment(element)) { //we don't have to check offset >= 3 because "/**" is already has 3 characters
       getScaladocTask(text, offset)

--- a/scala/scala-impl/test/org/jetbrains/plugins/scala/lang/actions/editor/SpaceInsertTest.scala
+++ b/scala/scala-impl/test/org/jetbrains/plugins/scala/lang/actions/editor/SpaceInsertTest.scala
@@ -1,0 +1,40 @@
+package org.jetbrains.plugins.scala.lang.actions.editor
+
+import org.jetbrains.plugins.scala.base.EditorActionTestBase
+import org.jetbrains.plugins.scala.settings.ScalaApplicationSettings
+
+class SpaceInsertTest extends EditorActionTestBase {
+
+  private def doTest(before: String, after: String): Unit = {
+    checkGeneratedTextAfterTyping(before, after, ' ')
+  }
+
+  def testIfElse(): Unit = {
+    getScalaSettings.ALIGN_IF_ELSE = true
+    val before =
+      s"""def test = {
+         |  val x = if (true) 8
+         |  else$CARET
+         |}""".stripMargin
+    val after =
+      s"""def test = {
+         |  val x = if (true) 8
+         |          else $CARET
+         |}""".stripMargin
+    doTest(before, after)
+  }
+
+  def testMatchCase(): Unit = {
+    val before =
+      s"""val x = 5 match {
+         |  case 1 => 2
+         |    case$CARET
+         |}""".stripMargin
+    val after =
+      s"""val x = 5 match {
+         |  case 1 => 2
+         |  case $CARET
+         |}""".stripMargin
+    doTest(before, after)
+  }
+}


### PR DESCRIPTION
#SCL-15468 fixed

When the "Align if-else statements" option is switched on, the explicit formatting action works correctly. The only problem is that indent is not adjusted automatically during the typing. We cannot indent initially (before `else` is typed), because `val x = if (true) 8` is a complete declaration in Scala, so it's possible that the user starts typing a new expression like

```scala
val x = if (true) 8
elseSomething(x)
```

And new expression should be aligned with `val`, not `if`. So we should realign only when `else` and subsequent space is typed. And this was already implemented! But due to a small bug, this feature wasn't working. And it appears it wasn't tested. I fixed the small bug and wrote a test (also for `match-case` which is handled nearby).

Btw I suggest to switch "Align if-else statements" on by default. I think the code looks better this way.