### PR TITLE
projectionTypeText: decorate element via nameFun

### DIFF
--- a/scala/scala-impl/src/org/jetbrains/plugins/scala/lang/psi/types/ScalaTypePresentation.scala
+++ b/scala/scala-impl/src/org/jetbrains/plugins/scala/lang/psi/types/ScalaTypePresentation.scala
@@ -89,27 +89,29 @@ trait ScalaTypePresentation extends api.TypePresentation {
         }
       }
 
-      if (context.nameResolvesTo(refName, e)) refName
+      val decoratedName = nameFun(e)
+
+      if (context.nameResolvesTo(refName, e)) decoratedName
       else
         projType.projected match {
           case ScDesignatorType(pack: PsiPackage) =>
-            nameWithPointFun(pack) + refName
+            nameWithPointFun(pack) + decoratedName
           case ScDesignatorType(named) if checkIfStable(named) =>
-            nameWithPointFun(named) + refName + typeTailForProjection
+            nameWithPointFun(named) + decoratedName + typeTailForProjection
           case ScThisType(obj: ScObject) =>
-            nameWithPointFun(obj) + refName + typeTailForProjection
+            nameWithPointFun(obj) + decoratedName + typeTailForProjection
           case p@ScThisType(_: ScTypeDefinition) if checkIfStable(e) =>
-            s"${innerTypeText(p, needDotType = false)}.$refName$typeTailForProjection"
+            s"${innerTypeText(p, needDotType = false)}.$decoratedName$typeTailForProjection"
           case p: ScProjectionType if checkIfStable(p.actualElement) =>
-            s"${projectionTypeText(p, needDotType = false)}.$refName$typeTailForProjection"
+            s"${projectionTypeText(p, needDotType = false)}.$decoratedName$typeTailForProjection"
           case StaticJavaClassHolder(clazz) if isStaticJavaClass =>
-            nameWithPointFun(clazz) + refName
+            nameWithPointFun(clazz) + decoratedName
           case p@(_: ScCompoundType | _: ScExistentialType) =>
-            s"(${innerTypeText(p)})#$refName"
+            s"(${innerTypeText(p)})#$decoratedName"
           case p =>
             val innerText = innerTypeText(p)
-            if (innerText.endsWith(ObjectTypeSuffix)) innerText.stripSuffix("type") + refName
-            else s"$innerText#$refName"
+            if (innerText.endsWith(ObjectTypeSuffix)) innerText.stripSuffix("type") + decoratedName
+            else s"$innerText#$decoratedName"
         }
     }
 

--- a/scala/scala-impl/src/org/jetbrains/plugins/scala/lang/psi/types/api/ScTypePresentation.scala
+++ b/scala/scala-impl/src/org/jetbrains/plugins/scala/lang/psi/types/api/ScTypePresentation.scala
@@ -33,11 +33,11 @@ trait TypePresentation {
     def nameFun(e: PsiNamedElement, withPoint: Boolean): String = {
       e match {
         case o: ScObject if withPoint && o.qualifiedName == "scala.Predef" => ""
-        case e: PsiClass => "<a href=\"psi_element://" + e.qualifiedName + "\"><code>" +
+        case e: PsiClass => "<a href=\"psi_element://" + StringEscapeUtils.escapeHtml(e.qualifiedName) + "\"><code>" +
           StringEscapeUtils.escapeHtml(e.name) +
           "</code></a>" + (if (withPoint) "." else "")
         case _: PsiPackage if withPoint => ""
-        case _ => StringEscapeUtils.escapeHtml(e.name) + "."
+        case _ => StringEscapeUtils.escapeHtml(e.name) + (if (withPoint) "." else "")
       }
     }
     typeText(`type`, nameFun(_, withPoint = false), nameFun(_, withPoint = true))

--- a/scala/scala-impl/test/org/jetbrains/plugins/scala/lang/scaladoc/quickdoc/QuickDocTest.scala
+++ b/scala/scala-impl/test/org/jetbrains/plugins/scala/lang/scaladoc/quickdoc/QuickDocTest.scala
@@ -7,7 +7,7 @@ import com.intellij.psi.PsiElement
 import org.jetbrains.plugins.scala.base.ScalaLightPlatformCodeInsightTestCaseAdapter
 import org.jetbrains.plugins.scala.editor.documentationProvider.ScalaDocumentationProvider
 import org.jetbrains.plugins.scala.lang.psi.api.ScalaFile
-import org.jetbrains.plugins.scala.lang.psi.api.toplevel.typedef.{ScMember, ScTemplateDefinition}
+import org.jetbrains.plugins.scala.lang.psi.api.toplevel.typedef.{ScMember, ScObject, ScTemplateDefinition}
 import org.jetbrains.plugins.scala.lang.psi.light.ScFunctionWrapper
 import org.junit.Assert
 
@@ -367,6 +367,26 @@ class QuickDocTest extends ScalaLightPlatformCodeInsightTestCaseAdapter {
 
     configureFromFileTextAdapter("dummy.scala", fileText.stripMargin('|').replaceAll("\r", "").trim())
     val element = getFileAdapter.getLastChild
+    val generated = QuickDocTest.quickDocGenerator.generateDoc(element, element)
+    Assert.assertEquals(expected, generated)
+  }
+
+  def testTraitSpecialChars() {
+    val fileText =
+      """
+        |object A {
+        |trait <:<[A,B]
+        |def f(a: Int <:< String): Unit = {}
+        |}"""
+
+    val expected =
+      """<html><body><div class="definition"><a href="psi_element://A"><code>A</code></a><pre>def <b>f</b>
+        |(a: <a href="psi_element://A"><code>A</code></a>.
+        |<a href="psi_element://A.&lt;:&lt;"><code>&lt;:&lt;</code></a>[Int, String]): Unit</pre></div></body></html>"""
+        .stripMargin.replaceAll("[\r\n]", "")
+
+    configureFromFileTextAdapter("dummy.scala", fileText.stripMargin('|').replaceAll("\r", "").trim())
+    val element = getFileAdapter.getLastChild.asInstanceOf[ScObject].getMethods.head
     val generated = QuickDocTest.quickDocGenerator.generateDoc(element, element)
     Assert.assertEquals(expected, generated)
   }


### PR DESCRIPTION
#SCL-15745 fixed

Somewhat invasive change. Hopefully, it doesn't break anything but it looks reasonable to run the whole test suite before merging (I don't know how to do this).

Note that the resulting link `<:<` is not clickable. It seems it's a separate problem, as the same problem appears even if a trait is defined separately.