### PR TITLE
SCL-16244 Breakpoints do not work in lambda functions when the classes are reload dynamically

### DIFF
--- a/scala/scala-impl/src/org/jetbrains/plugins/scala/debugger/ScalaPositionManager.scala
+++ b/scala/scala-impl/src/org/jetbrains/plugins/scala/debugger/ScalaPositionManager.scala
@@ -266,7 +266,10 @@ class ScalaPositionManager(val debugProcess: DebugProcess) extends PositionManag
 
   private def filterAllClasses(condition: ReferenceType => Boolean, packageName: Option[String]): Seq[ReferenceType] = {
     def samePackage(refType: ReferenceType) = {
-      val name = refType.name()
+      val fullName = refType.name()
+      //name can be SomeClass$$Lambda$1.1836643189
+      val lastDol = fullName.lastIndexOf('$')
+      val name  = if (lastDol < 0) fullName else fullName.substring(0, lastDol)
       val lastDot = name.lastIndexOf('.')
       val refTypePackageName = if (lastDot < 0) "" else name.substring(0, lastDot)
       packageName.isEmpty || packageName.contains(refTypePackageName)

--- a/scala/scala-impl/src/org/jetbrains/plugins/scala/debugger/ScalaPositionManager.scala
+++ b/scala/scala-impl/src/org/jetbrains/plugins/scala/debugger/ScalaPositionManager.scala
@@ -268,8 +268,8 @@ class ScalaPositionManager(val debugProcess: DebugProcess) extends PositionManag
     def samePackage(refType: ReferenceType) = {
       val fullName = refType.name()
       //name can be SomeClass$$Lambda$1.1836643189
-      val lastDol = fullName.lastIndexOf('$')
-      val name  = if (lastDol < 0) fullName else fullName.substring(0, lastDol)
+      val firstDol = fullName.indexOf('$')
+      val name  = if (firstDol < 0) fullName else fullName.substring(0, firstDol)
       val lastDot = name.lastIndexOf('.')
       val refTypePackageName = if (lastDot < 0) "" else name.substring(0, lastDot)
       packageName.isEmpty || packageName.contains(refTypePackageName)


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/SCL-16244

This partially solve the bug.
Part 1
fix: filterAllClasses, sometimes the function did not remove class name from the full name, so the package was incorrect
Part 2 (It is not implemented)
org.jetbrains.plugins.scala.debugger.ScalaPositionManager.hasLocations will not work when dynamic classes is not in dependency list of module which is used to run the program