### PR TITLE
Fix classBuffer overwriting the myExtensionInstances hashmap

### DIFF
--- a/scala/scala-impl/src/org/jetbrains/plugins/scala/components/libextensions/LibraryExtensionsManager.scala
+++ b/scala/scala-impl/src/org/jetbrains/plugins/scala/components/libextensions/LibraryExtensionsManager.scala
@@ -156,7 +156,7 @@ class LibraryExtensionsManager(project: Project) extends ProjectComponent {
   }
 
   private def loadDescriptor(descriptor: LibraryDescriptor, jarFile: File): Unit = {
-    var classBuffer = mutable.HashMap[Class[_], mutable.ArrayBuffer[Any]]()
+    val classBuffer = mutable.HashMap[Class[_], mutable.ArrayBuffer[Any]]()
     descriptor.getCurrentPluginDescriptor.foreach { currentVersion =>
       val IdeaVersionDescriptor(_, _, _, defaultPackage, extensions) = currentVersion
       val classLoader = UrlClassLoader.build()
@@ -172,7 +172,11 @@ class LibraryExtensionsManager(project: Project) extends ProjectComponent {
         classBuffer.getOrElseUpdate(myInterface, mutable.ArrayBuffer.empty) += myInstance
       }
     }
-    myExtensionInstances ++= classBuffer
+    classBuffer.foreach {
+      case (k, v) =>
+        myExtensionInstances.getOrElseUpdate(k, mutable.ArrayBuffer.empty) ++= v
+    }
+
     myLoadedLibraries    +=  ExtensionJarData(descriptor, jarFile, classBuffer.toMap)
   }
 


### PR DESCRIPTION
It looks like this function gets called N times for N bundles.  If you have two
or more bundles with the same interface implemented (SyntheticMemberInjector or friends) the last one wins.

This code merges it instead.

I tried to change as little as possible.