### PR TITLE
Do not rewrite { (a: Int) => ... } to { a: Int => ... }

### DIFF
--- a/scala/scala-impl/src/org/jetbrains/plugins/scala/codeInspection/parentheses/ScalaUnnecessaryParenthesesInspectionBase.scala
+++ b/scala/scala-impl/src/org/jetbrains/plugins/scala/codeInspection/parentheses/ScalaUnnecessaryParenthesesInspectionBase.scala
@@ -36,17 +36,12 @@ abstract class ScalaUnnecessaryParenthesesInspectionBase
   def setSettings(settings: UnnecessaryParenthesesSettings): Unit
 
   private def hasSingleParenthesizedParam(f: ScFunctionExpr): Boolean = {
-    // If an anonymous function (x: T) => e with a single typed parameter appears as the result expression of a block, it can be abbreviated to x: T => e.
-    def isBlockResultExpr: Boolean = f.getParent match {
-      case block: ScBlockExpr if block.resultExpression.contains(f) => true
-      case _ => false
-    }
     // In the case of a single untyped formal parameter, (x) => e can be abbreviated to x => e
     def hasNoParamType = f.parameters.headOption.exists(_.typeElement.isEmpty)
 
     def hasParenthesizedClause = f.params.clauses.headOption.exists(isParenthesised)
 
-    f.parameters.size == 1 && hasParenthesizedClause && (hasNoParamType || isBlockResultExpr)
+    f.parameters.size == 1 && hasParenthesizedClause && hasNoParamType
   }
 
   private def isParenthesesRedundant(elem: ScParenthesizedElement, settings: UnnecessaryParenthesesSettings): Boolean = {

--- a/scala/scala-impl/test/org/jetbrains/plugins/scala/codeInspection/parentheses/ScalaUnnecessaryParenthesesInspectionTest.scala
+++ b/scala/scala-impl/test/org/jetbrains/plugins/scala/codeInspection/parentheses/ScalaUnnecessaryParenthesesInspectionTest.scala
@@ -362,7 +362,7 @@ class ScalaUnnecessaryParenthesesInspectionTest extends ScalaQuickFixTestBase {
 
     checkTextHasNoErrors(required)
     checkTextHasErrors(r1)
-    checkTextHasErrors(r2)
+    checkTextHasNoErrors(r2)
     checkTextHasErrors(r3)
 
     withSettings(ignoreAroundFunctionExprParam) {
@@ -372,9 +372,9 @@ class ScalaUnnecessaryParenthesesInspectionTest extends ScalaQuickFixTestBase {
       checkTextHasNoErrors(r3)
     }
 
-    val text = s"Seq(1) map { (${CARET_MARKER}i: Int) => i + 1 }"
-    val result = s"Seq(1) map { i: Int => i + 1 }"
-    val hint = hintBeginning + " (i: Int)"
+    val text = s"Seq(1) map { (${CARET_MARKER}i) => i + 1 }"
+    val result = s"Seq(1) map { i => i + 1 }"
+    val hint = hintBeginning + " (i)"
     testQuickFix(text, result, hint)
   }
 


### PR DESCRIPTION
The latter syntax is removed from Dotty due to its irregularity:

```scala
scala> def foo : Int => Int = { a: Int => a }
1 |def foo : Int => Int = { a: Int => a }
  |                         ^^^^^^
  |parentheses are required around the parameter of a lambda
  |This construct can be rewritten automatically under -language:Scala2 -rewrite.
```