### PR TITLE
Fix SBT downloader hang with noexec temp dir

### DIFF
--- a/scala/scala-impl/src/org/jetbrains/plugins/scala/project/template/package.scala
+++ b/scala/scala-impl/src/org/jetbrains/plugins/scala/project/template/package.scala
@@ -136,11 +136,18 @@ package object template {
 
   private[this] def vmOptions = {
     import JavaConverters._
-    net.HttpConfigurable.getInstance
+    val proxyOpts = net.HttpConfigurable.getInstance
       .getJvmProperties(false, null)
       .asScala
+    val javaOpts = Seq(sysprop("java.io.tmpdir")).flatten
+    (proxyOpts ++ javaOpts)
       .map { pair =>
         "-D" + pair.getFirst + "=" + pair.getSecond
       }
+  }
+
+  private def sysprop(key: String) = {
+    import com.intellij.openapi.util.Pair
+    Option(System.getProperty(key)).map(value => Pair.pair(key, value))
   }
 }


### PR DESCRIPTION
On linux some choose to mount /tmp with noexec, and redirect a list of
apps known to require temporary executables onto another mount. For java
this can be done via -Djava.io.tmpdir

Forward this property to the sbt downloader process to avoid sbt hanging
when trying to use the default noexec temporary dir

Such a setup causes this error in idea.log:

```
2019-11-28 18:26:33,565 [ 167309]   WARN - n.process.BaseOSProcessHandler - Process hasn't generated any output for a long time.
If it's a long-running mostly idle daemon process, consider overriding OSProcessHandler#readerOptions with 'BaseOutputReader.Options.forMostlySilentProcess()' to reduce CPU usage.
Command line: sbt-based downloader 
java.lang.Throwable: Process creation:
        at com.intellij.execution.process.BaseOSProcessHandler.<init>(BaseOSProcessHandler.java:33)
        at com.intellij.execution.process.OSProcessHandler.<init>(OSProcessHandler.java:151)
        at org.jetbrains.plugins.scala.project.template.package$.$anonfun$createTempSbtProject$2(package.scala:58)
        at org.jetbrains.plugins.scala.project.template.package$.usingTempDirectory(package.scala:94)
        at org.jetbrains.plugins.scala.project.template.package$.$anonfun$createTempSbtProject$1(package.scala:49)
        at org.jetbrains.plugins.scala.project.template.package$.usingTempFile(package.scala:85)
        at org.jetbrains.plugins.scala.project.template.package$.createTempSbtProject(package.scala:43)
        at org.jetbrains.plugins.scala.project.template.VersionDialog.$anonfun$showAndGetSelected$1(VersionDialog.scala:35)
        at org.jetbrains.plugins.scala.project.template.VersionDialog.$anonfun$showAndGetSelected$1$adapted(VersionDialog.scala:34)
        at org.jetbrains.plugins.scala.extensions.package$$anon$4.compute(package.scala:1081)
        at com.intellij.openapi.progress.impl.CoreProgressManager$1.run(CoreProgressManager.java:225)
        at com.intellij.openapi.progress.impl.CoreProgressManager$TaskRunnable.run(CoreProgressManager.java:894)
        at com.intellij.openapi.progress.impl.CoreProgressManager$5.run(CoreProgressManager.java:447)
        at com.intellij.openapi.progress.impl.CoreProgressManager.lambda$runProcess$2(CoreProgressManager.java:169)
        at com.intellij.openapi.progress.impl.CoreProgressManager.registerIndicatorAndRun(CoreProgressManager.java:591)
        at com.intellij.openapi.progress.impl.CoreProgressManager.executeProcessUnderProgress(CoreProgressManager.java:537)
        at com.intellij.openapi.progress.impl.ProgressManagerImpl.executeProcessUnderProgress(ProgressManagerImpl.java:59)
        at com.intellij.openapi.progress.impl.CoreProgressManager.runProcess(CoreProgressManager.java:156)
        at com.intellij.openapi.application.impl.ApplicationImpl.lambda$null$9(ApplicationImpl.java:552)
        at com.intellij.openapi.application.impl.ApplicationImpl$1.run(ApplicationImpl.java:294)
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:748)
```

This causes the following