### PR TITLE
Handle space characters in Bloop binary name.

### DIFF
--- a/bsp/src/org/jetbrains/bsp/protocol/session/BloopConnector.scala
+++ b/bsp/src/org/jetbrains/bsp/protocol/session/BloopConnector.scala
@@ -59,8 +59,12 @@ class BloopConnector(bloopExecutable: File, base: File, compilerOutput: File, ca
 
   private def connectUnixSocket(socketFile: File): Either[BspErrorMessage, (Process, UnixDomainSocket)] = {
 
-    val verboseParam = if (verbose) "--verbose" else ""
-    val bloopParams = s"bsp --protocol local --socket $socketFile $verboseParam"
+    val verboseParam = if (verbose) List("--verbose") else Nil
+    val bloopParams = List[String](
+      "bsp",
+      "--protocol", "local",
+      "--socket", socketFile.toString
+    ) ++ verboseParam
     val proc = runBloop(bloopParams)
 
     if (bspReady(socketFile)) {
@@ -86,8 +90,13 @@ class BloopConnector(bloopExecutable: File, base: File, compilerOutput: File, ca
   }
 
   private def connectTcp(host: URI, port: Int): Either[BspError, java.net.Socket] = {
-    val verboseParam = if (verbose) "--verbose" else ""
-    val bloopParams = s"bsp --protocol tcp --host ${host.toString} --port $port $verboseParam"
+    val verboseParam = if (verbose) List("--verbose") else Nil
+    val bloopParams = List[String](
+      "bsp",
+      "--protocol", "tcp",
+      "--host", host.toString,
+      "--port", port.toString
+   ) ++ verboseParam
 
     runBloop(bloopParams)
     Try(new java.net.Socket(host.toString, port))
@@ -99,8 +108,8 @@ class BloopConnector(bloopExecutable: File, base: File, compilerOutput: File, ca
     err => logger.warn(s"bloop: $err")
   )
 
-  private def runBloop(params: String) = {
-    val command = s"${bloopExecutable.getCanonicalPath} $params"
+  private def runBloop(params: List[String]) = {
+    val command = bloopExecutable.getCanonicalPath.toString :: params
     Process(command, base).run(proclog)
   }
 


### PR DESCRIPTION
Previously, the `bloop` binary was launched as a single string command,
which caused errors when the path name contained a space character.

```
2019-11-29 13:00:30,242 [ 152454]   WARN - ctExternalProjectImportBuilder - java.io.IOException: Cannot run program "..." (in directory "...): error=2, No such file or directory
at java.base/java.lang.ProcessBuilder.start(ProcessBuilder.java:1128)
at java.base/java.lang.ProcessBuilder.start(ProcessBuilder.java:1071)
at scala.sys.process.ProcessBuilderImpl$Simple.run(ProcessBuilderImpl.scala:71)
at scala.sys.process.ProcessBuilderImpl$AbstractBuilder.run(ProcessBuilderImpl.scala:102)
at scala.sys.process.ProcessBuilderImpl$AbstractBuilder.run(ProcessBuilderImpl.scala:101)
at org.jetbrains.bsp.protocol.session.BloopConnector.runBloop(BloopConnector.scala:104)
```

Now, the system process command is a list of strings so that the `bloop`
binary name can contain a string.