### PR TITLE
BSP reports compilation end

### DIFF
--- a/bsp/src/org/jetbrains/bsp/protocol/session/BloopConnector.scala
+++ b/bsp/src/org/jetbrains/bsp/protocol/session/BloopConnector.scala
@@ -109,8 +109,11 @@ class BloopConnector(bloopExecutable: File, base: File, compilerOutput: File, ca
   )
 
   private def runBloop(params: List[String]) = {
-    val command = bloopExecutable.getCanonicalPath.toString :: params
-    Process(command, base).run(proclog)
+    val bloopPath = bloopExecutable.toString match {
+      case "bloop" => "bloop" // Allow to use bloop from  $PATH rather then localize it in current directory
+      case _ => bloopExecutable.getCanonicalPath
+    }
+    Process(bloopPath :: params, base).run(proclog)
   }
 
 }

--- a/scala/scala-impl/src/org/jetbrains/plugins/scala/findUsages/compilerReferences/compilation/JpsCompilationWatcher.scala
+++ b/scala/scala-impl/src/org/jetbrains/plugins/scala/findUsages/compilerReferences/compilation/JpsCompilationWatcher.scala
@@ -79,8 +79,9 @@ private[compilerReferences] class JpsCompilationWatcher(
         compileContext: CompileContext
       ): Unit = {
         val timestamp   = System.currentTimeMillis()
-        val key         = Key.findKeyByName("COMPILE_SERVER_BUILD_STATUS")
-        val wasUpToDate = compileContext.getUserData(key) == ExitStatus.UP_TO_DATE
+        val key         = Option(Key.findKeyByName("COMPILE_SERVER_BUILD_STATUS"))
+        val status      = key.flatMap(k => Option(compileContext.getUserData(k)))
+        val wasUpToDate = status.contains(ExitStatus.UP_TO_DATE)
 
         val modules =
           Option(compileContext.getCompileScope)

--- a/scala/scala-impl/src/org/jetbrains/plugins/scala/worksheet/actions/topmenu/RunWorksheetAction.scala
+++ b/scala/scala-impl/src/org/jetbrains/plugins/scala/worksheet/actions/topmenu/RunWorksheetAction.scala
@@ -131,6 +131,7 @@ object RunWorksheetAction {
                             vFile: VirtualFile, file: ScalaFile, makeBeforeRun: Boolean, module: Module)
                            (promise: Promise[RunWorksheetActionResult]): Unit = {
     val viewer = WorksheetCache.getInstance(project).getViewer(editor)
+
     if (viewer != null && !WorksheetFileSettings.isRepl(file)) {
       invokeAndWait(ModalityState.any()) {
         inWriteAction {
@@ -171,7 +172,7 @@ object RunWorksheetAction {
     if (makeBeforeRun) {
       val compilerNotification: CompileStatusNotification =
         (aborted: Boolean, errors: Int, warnings: Int, context: CompileContext) => {
-          val finishedWithError = aborted && errors != 0
+          val finishedWithError = aborted || errors != 0
           if (!finishedWithError) {
             runnable()
           } else {


### PR DESCRIPTION
Adresses  https://youtrack.jetbrains.com/issue/SCL-16630

This is really hacky implementation but I managed it to work. Not sure if this is correct direction since this is generally big hack but we can make it production-ready.

The problem was that auto-tests listen for messages on COMPILATION_STATUS topic that standard compiler produce. This PR adds skeleton implementaion for bsp to publish required messages.


![auto-test](https://user-images.githubusercontent.com/3967938/71127128-b7ec4500-21ea-11ea-9bee-ca9222a1d002.gif)
