### PR TITLE
Fix compatible runners search in isByteCodeIndexingActive

### DIFF
--- a/scala/scala-impl/src/org/jetbrains/plugins/scala/findUsages/compilerReferences/settings/CompilerIndicesSettings.scala
+++ b/scala/scala-impl/src/org/jetbrains/plugins/scala/findUsages/compilerReferences/settings/CompilerIndicesSettings.scala
@@ -43,7 +43,7 @@ class CompilerIndicesSettings(project: Project) extends PersistentStateComponent
   }
 
   private[this] def hasCompatibleRunner: Boolean =
-    runners.find { runner =>
+    runners.filter { runner =>
       val task = taskManager.createAllModulesBuildTask(true, project)
       val moduleBuildTasks = task match {
         case taskList: ProjectTaskList => taskList.asScala


### PR DESCRIPTION
While opening a project, the ScalaCompilerReferenceService
decides whether to enable bytecode indexing. It is done via
CompilerIndicesSettings::isBytecodeIndexingActive

One of the requirements is that there must exist a ProjectTaskRunner
that can run project's modules and is either an SBT runner or a JPS
runner.

Unfortunately, the `hasCompatibleRunner` indices function loooks only
for the first runner that can run all the modules and then checks if
it is ans SBT or JPS runner. If the first runner can run the modules,
or the module list is empty, the lookup will stop. Then, if it's
neither a JPS or an SBT runner, the result of `hasCompatibleRunners`
will be false, even if there is a good runner further on the list.

With this change, we search through the whole list for a good runner.

YouTrack: #SCL-16768 fixed