### PR TITLE
BSP Server status Icon in Status Bar

### DIFF
--- a/bsp/src/org/jetbrains/bsp/BspServerWidgetProvider.scala
+++ b/bsp/src/org/jetbrains/bsp/BspServerWidgetProvider.scala
@@ -1,0 +1,94 @@
+package org.jetbrains.bsp
+
+
+import com.intellij.openapi.wm.{StatusBar, StatusBarWidget, StatusBarWidgetProvider, WindowManager}
+import java.awt.Point
+import java.awt.event.{ActionEvent, ActionListener, MouseEvent}
+
+import com.intellij.icons.AllIcons
+import com.intellij.ide.DataManager
+import com.intellij.openapi.actionSystem.{AnAction, AnActionEvent, DefaultActionGroup, Separator}
+import com.intellij.openapi.project.{DumbAware, Project}
+import com.intellij.openapi.ui.popup.JBPopupFactory
+import com.intellij.openapi.util.IconLoader
+import com.intellij.openapi.wm.StatusBar.Anchors
+import com.intellij.ui.awt.RelativePoint
+import com.intellij.util.Consumer
+import javax.swing.{Icon, Timer}
+import org.jetbrains.bsp.protocol.BspCommunicationService
+
+class BspServerWidgetProvider extends StatusBarWidgetProvider{
+
+  private val IconRunning = org.jetbrains.bsp.Icons.BSP
+
+  private val IconStopped = IconLoader.getDisabledIcon(IconRunning)
+
+  private class Widget(project: Project) extends StatusBarWidget {
+
+    private val timer = new Timer(1000, TimerListener)
+
+    private def statusBar = Option(WindowManager.getInstance.getStatusBar(project))
+
+    private object TimerListener extends ActionListener {
+
+      override def actionPerformed(e: ActionEvent): Unit = {
+        statusBar.foreach(_.updateWidget(ID))
+      }
+    }
+
+    def connectionActive: Boolean = {
+      val inst = BspCommunicationService.getInstance
+      inst.communicate(project).alive
+    }
+
+    override def ID = "BSP Manager"
+
+    override def getPresentation: Presentation.type = Presentation
+
+    override def install(statusBar: StatusBar): Unit = {
+      timer.start()
+    }
+
+    override def dispose(): Unit = {
+      timer.stop()
+    }
+
+    object Presentation extends StatusBarWidget.IconPresentation {
+      override def getIcon: Icon = if (connectionActive) IconRunning else IconStopped
+
+      override def getClickConsumer: Consumer[MouseEvent] = ClickConsumer
+
+      private object ClickConsumer extends Consumer[MouseEvent] {
+        override def consume(event: MouseEvent): Unit = toggleList(event)
+      }
+
+      override def getTooltipText: String = "BSP Connection"
+    }
+
+    private object Stop extends AnAction("&Stop", "Kill BSP connection", AllIcons.Actions.Suspend) with DumbAware {
+      override def update(e: AnActionEvent): Unit = {
+        e.getPresentation.setEnabled(connectionActive)
+      }
+
+      override def actionPerformed(e: AnActionEvent): Unit = {
+        BspCommunicationService.getInstance.communicate(project).closeSession()
+      }
+    }
+
+    private def toggleList(e: MouseEvent): Unit = {
+      val mnemonics = JBPopupFactory.ActionSelectionAid.MNEMONICS
+      val group = new DefaultActionGroup(Stop, Separator.getInstance)
+      val context = DataManager.getInstance.getDataContext(e.getComponent)
+      val title =  s"BSP Connection (${if(connectionActive) "on" else "off"})"
+      val popup = JBPopupFactory.getInstance.createActionGroupPopup(title, group, context, mnemonics, true)
+      val dimension = popup.getContent.getPreferredSize
+      val at = new Point(0, -dimension.height)
+      popup.show(new RelativePoint(e.getComponent, at))
+    }
+  }
+
+
+  override def getWidget(project: Project): StatusBarWidget = new Widget(project)
+
+  override def getAnchor: String = Anchors.before("Position")
+}

--- a/bsp/src/org/jetbrains/bsp/protocol/BspCommunication.scala
+++ b/bsp/src/org/jetbrains/bsp/protocol/BspCommunication.scala
@@ -99,6 +99,11 @@ class BspCommunication(base: File, executionSettings: BspExecutionSettings) exte
       s.shutdown()
   }
 
+  def alive = session.get() match {
+    case Some(s) => s.isAlive
+    case None => false
+  }
+
   private[protocol] def isIdle(now: Long, timeout: Duration) = session.get() match {
     case None => false
     case Some(s) =>

--- a/bsp/src/org/jetbrains/bsp/protocol/session/BspSession.scala
+++ b/bsp/src/org/jetbrains/bsp/protocol/session/BspSession.scala
@@ -56,6 +56,8 @@ class BspSession private(bspIn: InputStream,
   private val queueProcessor = AppExecutorUtil.getAppScheduledExecutorService
       .scheduleWithFixedDelay(() => nextQueuedCommand, queuePause.toMillis, queuePause.toMillis, TimeUnit.MILLISECONDS)
 
+  def stopServer = serverConnection.cancelable.cancel()
+
   private def notifications(notification: BspNotification): Unit =
     notificationCallbacks.foreach(_.apply(notification))
 

--- a/scala/scala-impl/resources/META-INF/scala-plugin-common.xml
+++ b/scala/scala-impl/resources/META-INF/scala-plugin-common.xml
@@ -451,6 +451,8 @@
 
         <fileBasedIndex implementation="org.jetbrains.plugins.scala.lang.formatting.settings.inference.ScalaDocAsteriskAlignStyleIndexer"/>
 
+        <statusBarWidgetProvider implementation="org.jetbrains.bsp.BspServerWidgetProvider"/>
+
         <applicationService serviceInterface="org.jetbrains.plugins.scala.compiler.ScalaCompileServerSettings"
                         serviceImplementation="org.jetbrains.plugins.scala.compiler.ScalaCompileServerSettings"/>
 


### PR DESCRIPTION

![BSP Icon](https://user-images.githubusercontent.com/1066003/71626044-734daa00-2beb-11ea-8ffd-ed0ba86b5a2d.gif)
This commit adds a BSP server control icon to Status Bar. It allows
user to kill the connection (and start a new one when a new build task
is spawned)

`toggleList` method in BspServerWidgetProvider is almost the same as
in CompileServerManager, but I decided not to extract them to a single
method, as probably there will never be a single reason to change them both.