### PR TITLE
Ask BSP for test execution environment

### DIFF
--- a/bsp/resources/META-INF/BSP.xml
+++ b/bsp/resources/META-INF/BSP.xml
@@ -1,10 +1,6 @@
 <?xml version="1.0" encoding="iso-8859-1"?>
 
 <idea-plugin>
-    <projectListeners>
-        <listener class="org.jetbrains.bsp.project.test.environment.FetchEnvironmentTaskInstaller"
-                  topic="com.intellij.execution.RunManagerListener"/>
-    </projectListeners>
     <extensions defaultExtensionNs="com.intellij">
         <moduleType id="BSP_SYNTHETIC_MODULE" implementationClass="org.jetbrains.bsp.project.BspSyntheticModuleType"/>
         <moduleConfigurationEditorProvider implementation="org.jetbrains.bsp.project.BspSyntheticModuleEditorProvider"/>
@@ -45,6 +41,11 @@
         <java.programPatcher implementation="org.jetbrains.bsp.project.test.environment.BspJvmEnvironmentProgramPatcher"/>
         <stepsBeforeRunProvider implementation="org.jetbrains.bsp.project.test.environment.BspFetchTestEnvironmentTaskProvider"/>
     </extensions>
+
+    <projectListeners>
+        <listener class="org.jetbrains.bsp.project.test.environment.BspFetchEnvironmentTaskInstaller"
+                  topic="com.intellij.execution.RunManagerListener"/>
+    </projectListeners>
 
     <actions>
     </actions>

--- a/bsp/resources/META-INF/BSP.xml
+++ b/bsp/resources/META-INF/BSP.xml
@@ -1,7 +1,10 @@
 <?xml version="1.0" encoding="iso-8859-1"?>
 
 <idea-plugin>
-
+    <projectListeners>
+        <listener class="org.jetbrains.bsp.project.test.environment.FetchEnvironmentTaskInstaller"
+                  topic="com.intellij.execution.RunManagerListener"/>
+    </projectListeners>
     <extensions defaultExtensionNs="com.intellij">
         <moduleType id="BSP_SYNTHETIC_MODULE" implementationClass="org.jetbrains.bsp.project.BspSyntheticModuleType"/>
         <moduleConfigurationEditorProvider implementation="org.jetbrains.bsp.project.BspSyntheticModuleEditorProvider"/>
@@ -17,7 +20,6 @@
         <projectService serviceImplementation="org.jetbrains.bsp.settings.BspSettings"/>
         <projectService serviceImplementation="org.jetbrains.bsp.settings.BspLocalSettings"/>
         <projectService serviceImplementation="org.jetbrains.bsp.BspBuildLoopService"/>
-        <projectService serviceImplementation="org.jetbrains.bsp.project.test.environment.BspFetchEnvironmentTaskInstaller"/>
 
         <applicationService serviceImplementation="org.jetbrains.bsp.protocol.BspCommunicationService"/>
 

--- a/bsp/resources/META-INF/BSP.xml
+++ b/bsp/resources/META-INF/BSP.xml
@@ -41,6 +41,7 @@
         <statusBarWidgetProvider implementation="org.jetbrains.bsp.BspServerWidgetProvider"/>
 
         <postStartupActivity implementation="org.jetbrains.bsp.project.test.environment.BspFetchEnvironmentTaskInstaller$Startup"/>
+        <java.programPatcher implementation="org.jetbrains.bsp.project.test.environment.BspJvmEnvironmentProgramPatcher"/>
     </extensions>
 
     <actions>

--- a/bsp/resources/META-INF/BSP.xml
+++ b/bsp/resources/META-INF/BSP.xml
@@ -17,6 +17,7 @@
         <projectService serviceImplementation="org.jetbrains.bsp.settings.BspSettings"/>
         <projectService serviceImplementation="org.jetbrains.bsp.settings.BspLocalSettings"/>
         <projectService serviceImplementation="org.jetbrains.bsp.BspBuildLoopService"/>
+        <projectService serviceImplementation="org.jetbrains.bsp.project.test.environment.BspFetchEnvironmentTaskInstaller"/>
 
         <applicationService serviceImplementation="org.jetbrains.bsp.protocol.BspCommunicationService"/>
 
@@ -39,6 +40,7 @@
 
         <statusBarWidgetProvider implementation="org.jetbrains.bsp.BspServerWidgetProvider"/>
 
+        <postStartupActivity implementation="org.jetbrains.bsp.project.test.environment.BspFetchEnvironmentTaskInstaller$Startup"/>
     </extensions>
 
     <actions>

--- a/bsp/resources/META-INF/BSP.xml
+++ b/bsp/resources/META-INF/BSP.xml
@@ -42,8 +42,8 @@
 
         <statusBarWidgetProvider implementation="org.jetbrains.bsp.BspServerWidgetProvider"/>
 
-        <postStartupActivity implementation="org.jetbrains.bsp.project.test.environment.BspFetchEnvironmentTaskInstaller$Startup"/>
         <java.programPatcher implementation="org.jetbrains.bsp.project.test.environment.BspJvmEnvironmentProgramPatcher"/>
+        <stepsBeforeRunProvider implementation="org.jetbrains.bsp.project.test.environment.BspFetchTestEnvironmentTaskProvider"/>
     </extensions>
 
     <actions>

--- a/bsp/resources/messages/BspBundle.properties
+++ b/bsp/resources/messages/BspBundle.properties
@@ -22,6 +22,17 @@ bsp.task.unknown.status.code=Unknown status code {0}
 ### org/jetbrains/bsp/project/BspFetchTestEnvironmentTaskProvider.scala
 bsp.task.fetching.sources = "Fetching source list from BSP"
 bsp.task.fetchng.jvm.test.environment = "Fetching JVM test environment from BSP"
+bsp.task.choose.target.message = "Could not infer BSP target, please choose one from the list"
+bsp.task.choose.target.title =  "Choose BSP target"
+bsp.task.error.could.not.find.potential.targets = "Could not find potential targets for "
+bsp.task.error.could.not.extract.path = "Could not extract project path from module "
+bsp.task.error.could.not.detect.run.classes =  "Could not detect run classes for configuration "
+bsp.task.error.could.not.fetch.sources = "Could not fetch sources lists from BSP server. 'buildTarget/sources' request failed"
+bsp.task.error.could.not.choose.any.target.id = "Could not choose any target ID"
+bsp.task.error.could.not.fetch.test.jvm.environment = "Failed to fetch test JVM environment"
+bsp.task.error = "Error while fetching test environment from BSP: "
+bsp.task.error.test.env.not.supported = "Build Server does not support 'buildTarget/jvmTestEnvironment' endpoint"
+bsp.task.name = "Use BSP environment"
 
 ### org/jetbrains/bsp/project/bspModuleType.scala
 bsp.synthetic.module=BSP synthetic module

--- a/bsp/resources/messages/BspBundle.properties
+++ b/bsp/resources/messages/BspBundle.properties
@@ -19,6 +19,10 @@ bsp.task.server.does.not.support.cleaning.build.cache=Server does not support cl
 bsp.task.targets.not.cleaned=Targets not cleaned, rebuild cancelled: {0}
 bsp.task.unknown.status.code=Unknown status code {0}
 
+### org/jetbrains/bsp/project/BspFetchTestEnvironmentTaskProvider.scala
+bsp.task.fetching.sources = "Fetching source list from BSP"
+bsp.task.fetchng.jvm.test.environment = "Fetching JVM test environment from BSP"
+
 ### org/jetbrains/bsp/project/bspModuleType.scala
 bsp.synthetic.module=BSP synthetic module
 bsp.synthetic.module.description=BSP synthetic modules map the project structure to IntelliJ and do not correspond to targets

--- a/bsp/resources/messages/BspBundle.properties
+++ b/bsp/resources/messages/BspBundle.properties
@@ -20,19 +20,19 @@ bsp.task.targets.not.cleaned=Targets not cleaned, rebuild cancelled: {0}
 bsp.task.unknown.status.code=Unknown status code {0}
 
 ### org/jetbrains/bsp/project/BspFetchTestEnvironmentTaskProvider.scala
-bsp.task.fetching.sources = "Fetching source list from BSP"
-bsp.task.fetchng.jvm.test.environment = "Fetching JVM test environment from BSP"
-bsp.task.choose.target.message = "Could not infer BSP target, please choose one from the list"
-bsp.task.choose.target.title =  "Choose BSP target"
-bsp.task.error.could.not.find.potential.targets = "Could not find potential targets for "
-bsp.task.error.could.not.extract.path = "Could not extract project path from module "
-bsp.task.error.could.not.detect.run.classes =  "Could not detect run classes for configuration "
-bsp.task.error.could.not.fetch.sources = "Could not fetch sources lists from BSP server. 'buildTarget/sources' request failed"
-bsp.task.error.could.not.choose.any.target.id = "Could not choose any target ID"
-bsp.task.error.could.not.fetch.test.jvm.environment = "Failed to fetch test JVM environment"
-bsp.task.error = "Error while fetching test environment from BSP: "
-bsp.task.error.test.env.not.supported = "Build Server does not support 'buildTarget/jvmTestEnvironment' endpoint"
-bsp.task.name = "Use BSP environment"
+bsp.task.fetching.sources=Fetching source list from BSP
+bsp.task.fetchng.jvm.test.environment=Fetching JVM test environment from BSP
+bsp.task.choose.target.message=Could not infer BSP target, please choose one from the list
+bsp.task.choose.target.title=Choose BSP target
+bsp.task.error.could.not.find.potential.targets=Could not find potential targets for {0}
+bsp.task.error.could.not.extract.path=Could not extract project path from module {0}
+bsp.task.error.could.not.detect.run.classes=Could not detect run classes for configuration {0}
+bsp.task.error.could.not.fetch.sources=Could not fetch sources lists from BSP server. 'buildTarget/sources' request failed
+bsp.task.error.could.not.choose.any.target.id=Could not choose any target ID
+bsp.task.error.could.not.fetch.test.jvm.environment=Failed to fetch test JVM environment
+bsp.task.error=Error while fetching test environment from BSP: {0}
+bsp.task.error.test.env.not.supported=Build Server does not support 'buildTarget/jvmTestEnvironment' endpoint
+bsp.task.name=Use BSP environment
 
 ### org/jetbrains/bsp/project/bspModuleType.scala
 bsp.synthetic.module=BSP synthetic module

--- a/bsp/src/org/jetbrains/bsp/BSP.scala
+++ b/bsp/src/org/jetbrains/bsp/BSP.scala
@@ -17,8 +17,4 @@ object BSP {
   val ProjectSystemId = new ProjectSystemId("BSP", Name)
 
   val balloonNotification: NotificationGroup = NotificationGroup.balloonGroup(Name)
-
-  def isBspModule(module: Module) = {
-    ExternalSystemApiUtil.isExternalSystemAwareModule(BSP.ProjectSystemId.getId, module)
-  }
 }

--- a/bsp/src/org/jetbrains/bsp/BSP.scala
+++ b/bsp/src/org/jetbrains/bsp/BSP.scala
@@ -2,6 +2,9 @@ package org.jetbrains.bsp
 
 import com.intellij.notification.NotificationGroup
 import com.intellij.openapi.externalSystem.model.ProjectSystemId
+import com.intellij.openapi.externalSystem.util.ExternalSystemApiUtil
+import com.intellij.openapi.module.Module
+import com.intellij.openapi.util.registry.Registry
 import javax.swing.Icon
 import org.jetbrains.annotations.Nls
 
@@ -14,4 +17,8 @@ object BSP {
   val ProjectSystemId = new ProjectSystemId("BSP", Name)
 
   val balloonNotification: NotificationGroup = NotificationGroup.balloonGroup(Name)
+
+  def isBspModule(module: Module) = {
+    ExternalSystemApiUtil.isExternalSystemAwareModule(BSP.ProjectSystemId.getId, module)
+  }
 }

--- a/bsp/src/org/jetbrains/bsp/project/test/environment/BspFetchEnvironmentTaskInstaller.scala
+++ b/bsp/src/org/jetbrains/bsp/project/test/environment/BspFetchEnvironmentTaskInstaller.scala
@@ -1,10 +1,11 @@
 package org.jetbrains.bsp.project.test.environment
 
 import com.intellij.execution.{RunManagerEx, RunManagerListener, RunnerAndConfigurationSettings}
+import com.intellij.openapi.project.Project
 
-class BspFetchEnvironmentTaskInstaller extends RunManagerListener {
+class BspFetchEnvironmentTaskInstaller(project: Project) extends RunManagerListener {
   override def runConfigurationAdded(settings: RunnerAndConfigurationSettings): Unit = {
-    val runManager = RunManagerEx.getInstanceEx(settings.getConfiguration.getProject)
+    val runManager = RunManagerEx.getInstanceEx(project)
     val runConfiguration = settings.getConfiguration
     if (BspTesting.isBspRunnerSupportedConfiguration(runConfiguration)) {
       val beforeRunTasks = runManager.getBeforeRunTasks(runConfiguration)

--- a/bsp/src/org/jetbrains/bsp/project/test/environment/BspFetchEnvironmentTaskInstaller.scala
+++ b/bsp/src/org/jetbrains/bsp/project/test/environment/BspFetchEnvironmentTaskInstaller.scala
@@ -1,0 +1,28 @@
+package org.jetbrains.bsp.project.test.environment
+
+import com.intellij.execution.{RunManagerEx, RunManagerListener, RunnerAndConfigurationSettings}
+import com.intellij.openapi.components.ProjectComponent
+import com.intellij.openapi.project.Project
+
+class BspFetchEnvironmentTaskInstaller(project: Project) extends ProjectComponent {
+  override def projectOpened(): Unit = {
+    val runManager = RunManagerEx.getInstanceEx(project)
+    project.getMessageBus.connect().subscribe(RunManagerListener.TOPIC,
+      new RunManagerListener {
+        override def runConfigurationAdded(settings: RunnerAndConfigurationSettings): Unit = {
+          val runConfiguration = settings.getConfiguration
+          if (BspTesting.isBspRunnerSupportedConfiguration(runConfiguration)) {
+            val beforeRunTasks = runManager.getBeforeRunTasks(runConfiguration)
+            val task = new BspFetchTestEnvironmentTask
+            task.setEnabled(true)
+            beforeRunTasks.add(task)
+            val tasks = runManager.getBeforeRunTasks(BspFetchTestEnvironmentTask.runTaskKey)
+            if (tasks.isEmpty) {
+              runManager.setBeforeRunTasks(runConfiguration, beforeRunTasks)
+            }
+          }
+        }
+      }
+    )
+  }
+}

--- a/bsp/src/org/jetbrains/bsp/project/test/environment/BspFetchEnvironmentTaskInstaller.scala
+++ b/bsp/src/org/jetbrains/bsp/project/test/environment/BspFetchEnvironmentTaskInstaller.scala
@@ -1,41 +1,20 @@
 package org.jetbrains.bsp.project.test.environment
 
 import com.intellij.execution.{RunManagerEx, RunManagerListener, RunnerAndConfigurationSettings}
-import com.intellij.openapi.components.ProjectComponent
-import com.intellij.openapi.project.Project
-import com.intellij.openapi.startup.StartupActivity
 
-final class BspFetchEnvironmentTaskInstaller(project: Project) {
-  def init(): Unit = {
-    val runManager = RunManagerEx.getInstanceEx(project)
-    project.getMessageBus.connect().subscribe(RunManagerListener.TOPIC,
-      new RunManagerListener {
-        override def runConfigurationAdded(settings: RunnerAndConfigurationSettings): Unit = {
-          val runConfiguration = settings.getConfiguration
-          if (BspTesting.isBspRunnerSupportedConfiguration(runConfiguration)) {
-            val beforeRunTasks = runManager.getBeforeRunTasks(runConfiguration)
-            val task = new BspFetchTestEnvironmentTask
-            task.setEnabled(true)
-            beforeRunTasks.add(task)
-            val tasks = runManager.getBeforeRunTasks(BspFetchTestEnvironmentTask.runTaskKey)
-            if (tasks.isEmpty) {
-              runManager.setBeforeRunTasks(runConfiguration, beforeRunTasks)
-            }
-          }
-        }
+class BspFetchEnvironmentTaskInstaller extends RunManagerListener {
+  override def runConfigurationAdded(settings: RunnerAndConfigurationSettings): Unit = {
+    val runManager = RunManagerEx.getInstanceEx(settings.getConfiguration.getProject)
+    val runConfiguration = settings.getConfiguration
+    if (BspTesting.isBspRunnerSupportedConfiguration(runConfiguration)) {
+      val beforeRunTasks = runManager.getBeforeRunTasks(runConfiguration)
+      val task = new BspFetchTestEnvironmentTask
+      task.setEnabled(true)
+      beforeRunTasks.add(task)
+      val tasks = runManager.getBeforeRunTasks(BspFetchTestEnvironmentTask.runTaskKey)
+      if (tasks.isEmpty) {
+        runManager.setBeforeRunTasks(runConfiguration, beforeRunTasks)
       }
-    )
-  }
-}
-
-object BspFetchEnvironmentTaskInstaller {
-  def getInstance(project: Project): BspFetchEnvironmentTaskInstaller = {
-    project.getService(classOf[BspFetchEnvironmentTaskInstaller])
-  }
-
-  private final class Startup extends StartupActivity {
-    override def runActivity(project: Project): Unit = {
-      getInstance(project).init()
     }
   }
 }

--- a/bsp/src/org/jetbrains/bsp/project/test/environment/BspFetchEnvironmentTaskInstaller.scala
+++ b/bsp/src/org/jetbrains/bsp/project/test/environment/BspFetchEnvironmentTaskInstaller.scala
@@ -3,9 +3,10 @@ package org.jetbrains.bsp.project.test.environment
 import com.intellij.execution.{RunManagerEx, RunManagerListener, RunnerAndConfigurationSettings}
 import com.intellij.openapi.components.ProjectComponent
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.startup.StartupActivity
 
-class BspFetchEnvironmentTaskInstaller(project: Project) extends ProjectComponent {
-  override def projectOpened(): Unit = {
+final class BspFetchEnvironmentTaskInstaller(project: Project) {
+  def init(): Unit = {
     val runManager = RunManagerEx.getInstanceEx(project)
     project.getMessageBus.connect().subscribe(RunManagerListener.TOPIC,
       new RunManagerListener {
@@ -24,5 +25,17 @@ class BspFetchEnvironmentTaskInstaller(project: Project) extends ProjectComponen
         }
       }
     )
+  }
+}
+
+object BspFetchEnvironmentTaskInstaller {
+  def getInstance(project: Project): BspFetchEnvironmentTaskInstaller = {
+    project.getService(classOf[BspFetchEnvironmentTaskInstaller])
+  }
+
+  private final class Startup extends StartupActivity {
+    override def runActivity(project: Project): Unit = {
+      getInstance(project).init()
+    }
   }
 }

--- a/bsp/src/org/jetbrains/bsp/project/test/environment/BspFetchTestEnvironmentTask.scala
+++ b/bsp/src/org/jetbrains/bsp/project/test/environment/BspFetchTestEnvironmentTask.scala
@@ -1,0 +1,30 @@
+package org.jetbrains.bsp.project.test.environment
+
+import com.intellij.execution.BeforeRunTask
+import org.jdom.Element
+import com.intellij.openapi.util.Key
+
+object BspFetchTestEnvironmentTask {
+  val runTaskKey: Key[BspFetchTestEnvironmentTask] = Key.create("BSP.BeforeRunTask")
+
+  val jvmTestEnvironmentKey: Key[JvmTestEnvironment] = Key.create("BSP.JvmTestEnvironment")
+}
+class BspFetchTestEnvironmentTask extends BeforeRunTask[BspFetchTestEnvironmentTask](BspFetchTestEnvironmentTask.runTaskKey) {
+  var state: Option[String] = None
+
+  val CHOSEN_TARGET = "CHOSEN_TARGET"
+
+  override def writeExternal(element: Element): Unit = {
+    super.writeExternal(element)
+    state match {
+      case Some(value) => element.setAttribute(CHOSEN_TARGET, value)
+      case None => element.removeAttribute(CHOSEN_TARGET)
+    }
+
+  }
+
+  override def readExternal(element: Element): Unit = {
+    super.readExternal(element)
+    state = Option(element.getAttributeValue(CHOSEN_TARGET))
+  }
+}

--- a/bsp/src/org/jetbrains/bsp/project/test/environment/BspFetchTestEnvironmentTaskProvider.scala
+++ b/bsp/src/org/jetbrains/bsp/project/test/environment/BspFetchTestEnvironmentTaskProvider.scala
@@ -113,7 +113,7 @@ class BspFetchTestEnvironmentTaskProvider extends BeforeRunTaskProvider[BspFetch
     var chosenTarget: Option[String] = None
     ApplicationManager.getApplication.invokeAndWait { () => {
       chosenTarget = Option(Messages.showEditableChooseDialog(
-        "Could not infer Pants target, please choose one from the list",
+        "Could not infer BSP target, please choose one from the list",
         "Choose pants target",
         Icons.BSP_TOOLWINDOW,
         targetIds.toArray,

--- a/bsp/src/org/jetbrains/bsp/project/test/environment/BspFetchTestEnvironmentTaskProvider.scala
+++ b/bsp/src/org/jetbrains/bsp/project/test/environment/BspFetchTestEnvironmentTaskProvider.scala
@@ -21,7 +21,7 @@ import com.intellij.openapi.ui.Messages
 import com.intellij.psi.{JavaPsiFacade, PsiFile}
 import com.intellij.psi.search.GlobalSearchScope
 import javax.swing.Icon
-import org.jetbrains.bsp.{BSP, Icons}
+import org.jetbrains.bsp.{BSP, BspUtil, Icons}
 import org.jetbrains.bsp.data.BspMetadata
 import org.jetbrains.bsp.protocol.BspCommunication
 import org.jetbrains.plugins.scala.testingSupport.test.scalatest.ScalaTestRunConfiguration
@@ -77,7 +77,7 @@ class BspFetchTestEnvironmentTaskProvider extends BeforeRunTaskProvider[BspFetch
                            task: BspFetchTestEnvironmentTask): Boolean = {
     configuration match {
       case config: ModuleBasedConfiguration[_, _]
-        if BSP.isBspModule(config.getConfigurationModule.getModule) && BspTesting.isBspRunnerSupportedConfiguration(config) => {
+        if BspUtil.isBspModule(config.getConfigurationModule.getModule) && BspTesting.isBspRunnerSupportedConfiguration(config) => {
         val module = config.getConfigurationModule.getModule
         val taskResult: Either[BspGetEnvironmentError, Unit] = for {
           potentialTargets <- getBspTargets(module)
@@ -170,7 +170,7 @@ class BspFetchTestEnvironmentTaskProvider extends BeforeRunTaskProvider[BspFetch
 
   private def getApplicableClasses(configuration: RunConfiguration) = {
     configuration match {
-      case scalaConfig: ModuleBasedConfiguration[_, _] if BSP.isBspModule(scalaConfig.getConfigurationModule.getModule) => {
+      case scalaConfig: ModuleBasedConfiguration[_, _] if BspUtil.isBspModule(scalaConfig.getConfigurationModule.getModule) => {
         val classes = scalaConfig match {
           case p: ScalaTestRunConfiguration =>
             p.testConfigurationData match {

--- a/bsp/src/org/jetbrains/bsp/project/test/environment/BspFetchTestEnvironmentTaskProvider.scala
+++ b/bsp/src/org/jetbrains/bsp/project/test/environment/BspFetchTestEnvironmentTaskProvider.scala
@@ -82,12 +82,12 @@ class BspFetchTestEnvironmentTaskProvider extends BeforeRunTaskProvider[BspFetch
         val module = config.getConfigurationModule.getModule
         val taskResult: Either[BspGetEnvironmentError, Unit] = for {
           potentialTargets <- getBspTargets(module)
-            .toRight(BspGetEnvironmentError(BspBundle.message("bsp.task.error.could.not.find.potential.targets") ++ module.getName))
+            .toRight(BspGetEnvironmentError(BspBundle.message("bsp.task.error.could.not.find.potential.targets",module.getName)))
           projectPath <- Option(ES.getExternalProjectPath(module))
-            .toRight(BspGetEnvironmentError(BspBundle.message("bsp.task.error.could.not.extract.path") + module.getName))
+            .toRight(BspGetEnvironmentError(BspBundle.message("bsp.task.error.could.not.extract.path", module.getName)))
           workspaceUri = Paths.get(projectPath).toUri
           testClasses <- getApplicableClasses(configuration)
-            .toRight(BspGetEnvironmentError(BspBundle.message("bsp.task.error.could.not.detect.run.classes") + configuration.getName))
+            .toRight(BspGetEnvironmentError(BspBundle.message("bsp.task.error.could.not.detect.run.classes", configuration.getName)))
           testSources = testClasses.flatMap(class2File(_, module.getProject))
           targetsMatchingSources <- fetchTargetIdsFromFiles(testSources, workspaceUri, module.getProject, potentialTargets)
             .map(Right(_))
@@ -107,7 +107,7 @@ class BspFetchTestEnvironmentTaskProvider extends BeforeRunTaskProvider[BspFetch
         } yield ()
         taskResult match {
           case Left(value) => {
-            logger.error(BspBundle.message("bsp.task.error"))
+            logger.error(BspBundle.message("bsp.task.error", value))
             false
           }
           case Right(_) => true

--- a/bsp/src/org/jetbrains/bsp/project/test/environment/BspFetchTestEnvironmentTaskProvider.scala
+++ b/bsp/src/org/jetbrains/bsp/project/test/environment/BspFetchTestEnvironmentTaskProvider.scala
@@ -1,0 +1,216 @@
+package org.jetbrains.bsp.project.test.environment
+
+import java.net.URI
+import java.nio.file.Paths
+import java.{lang, util}
+import java.util.concurrent.CompletableFuture
+
+import ch.epfl.scala.bsp4j.{BuildServerCapabilities, BuildTargetIdentifier, JvmTestEnvironmentParams, JvmTestEnvironmentResult, SourcesItem, SourcesParams, SourcesResult}
+import com.intellij.execution.BeforeRunTaskProvider
+import com.intellij.execution.configurations.{ModuleBasedConfiguration, RunConfiguration}
+import com.intellij.execution.runners.ExecutionEnvironment
+import com.intellij.openapi.actionSystem.DataContext
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.externalSystem.model.{DataNode, ProjectKeys}
+import com.intellij.openapi.externalSystem.model.project.ModuleData
+import com.intellij.openapi.externalSystem.util.{ExternalSystemApiUtil => ES}
+import com.intellij.openapi.module.Module
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.Messages
+import com.intellij.psi.{JavaPsiFacade, PsiFile}
+import com.intellij.psi.search.GlobalSearchScope
+import javax.swing.Icon
+import org.jetbrains.bsp.{BSP, Icons}
+import org.jetbrains.bsp.data.BspMetadata
+import org.jetbrains.bsp.protocol.BspCommunication
+import org.jetbrains.plugins.scala.testingSupport.test.scalatest.ScalaTestRunConfiguration
+
+import scala.concurrent.duration._
+import scala.collection.JavaConverters._
+import org.jetbrains.bsp.BspUtil._
+import org.jetbrains.bsp.protocol.session.BspSession.{BspServer, ProcessLogger}
+import org.jetbrains.plugins.scala.build.BuildMessages.EventId
+import org.jetbrains.plugins.scala.build.{BuildMessages, BuildToolWindowReporter}
+import org.jetbrains.plugins.scala.testingSupport.test.testdata.{AllInPackageTestData, ClassTestData}
+
+import scala.concurrent.Await
+import com.intellij.openapi.util.Key
+import org.jetbrains.concurrency.{Promise, Promises}
+import org.jetbrains.plugins.scala.build.BuildToolWindowReporter.CancelBuildAction
+
+case class JvmTestEnvironment(
+                               classpath: Seq[String],
+                               workdir: String,
+                               environmentVariables: Map[String, String],
+                               jvmOptions: Seq[String]
+                             )
+
+class BspFetchTestEnvironmentTaskProvider extends BeforeRunTaskProvider[BspFetchTestEnvironmentTask] {
+  override def getId: Key[BspFetchTestEnvironmentTask] = BspFetchTestEnvironmentTask.runTaskKey
+
+  override def getName: String = "Use BSP environment"
+
+  override def getIcon: Icon = Icons.BSP
+
+  override def createTask(runConfiguration: RunConfiguration): BspFetchTestEnvironmentTask = new BspFetchTestEnvironmentTask
+
+  override def isConfigurable: Boolean = true
+
+  override def configureTask(context: DataContext, configuration: RunConfiguration, task: BspFetchTestEnvironmentTask): Promise[lang.Boolean] = {
+    val module = configuration.asInstanceOf[ScalaTestRunConfiguration].getModule
+    val res = for {
+      potentialTargets <- getBspTargets(module)
+      _ <- askUserForTargetId(potentialTargets.map(_.getUri), task)
+    } yield ()
+    Promises.resolvedPromise(res.isDefined)
+  }
+
+  case class BspGetEnvironmentError(msg: String)
+
+  override def executeTask(context: DataContext,
+                           configuration: RunConfiguration,
+                           env: ExecutionEnvironment,
+                           task: BspFetchTestEnvironmentTask): Boolean = {
+    configuration match {
+      case config: ModuleBasedConfiguration[_, _]
+        if BSP.isBspModule(config.getConfigurationModule.getModule) && BspTesting.isBspRunnerSupportedConfiguration(config) => {
+        val module = config.getConfigurationModule.getModule
+        val c = for {
+          potentialTargets <- getBspTargets(module).toRight(BspGetEnvironmentError(s"Could not find potential targets for ${module.getName}"))
+          projectPath <- Option(ES.getExternalProjectPath(module)).toRight(BspGetEnvironmentError(s"Could not extract project path from module ${module.getName}"))
+          workspaceUri = Paths.get(projectPath).toUri
+          testClasses <- getApplicableClasses(configuration).toRight(BspGetEnvironmentError(s"Could not detect run classes for configuration ${configuration.getName}"))
+          testSources = testClasses.flatMap(class2File(_, module.getProject))
+          targetsMatchingSources = fetchTargetIdsFromFiles(testSources, workspaceUri, module.getProject, potentialTargets)
+          chosenTargetId <- task.state.orElse(if (targetsMatchingSources.length == 1) targetsMatchingSources.headOption.map(_.getUri) else None)
+            .orElse(askUserForTargetId(potentialTargets.map(_.getUri), task))
+            .toRight(BspGetEnvironmentError("Could not choose any target ID"))
+          testEnvironment = fetchJvmTestEnvironment(new BuildTargetIdentifier(chosenTargetId), workspaceUri, module.getProject)
+          _ = config.putUserData(BspFetchTestEnvironmentTask.jvmTestEnvironmentKey, testEnvironment)
+        } yield ()
+        c.isRight
+      }
+      case _ => true
+    }
+
+  }
+
+  private def askUserForTargetId(targetIds: Seq[String], task: BspFetchTestEnvironmentTask): Option[String] = {
+    var chosenTarget: Option[String] = None
+    ApplicationManager.getApplication.invokeAndWait { () => {
+      chosenTarget = Option(Messages.showEditableChooseDialog(
+        "Could not infer Pants target, please choose one from the list",
+        "Choose pants target",
+        Icons.BSP_TOOLWINDOW,
+        targetIds.toArray,
+        targetIds.headOption.getOrElse(""),
+        null
+      ))
+    }
+    }
+    if (chosenTarget.isDefined) {
+      task.state = chosenTarget
+    }
+    chosenTarget
+  }
+
+  private def fetchTargetIdsFromFiles(files: Seq[PsiFile],
+                                      workspace: URI,
+                                      project: Project,
+                                      potentialTargets: Seq[BuildTargetIdentifier]): Seq[BuildTargetIdentifier] = {
+    val communication: BspCommunication = BspCommunication.forWorkspace(workspace.toFile)
+    val bspTaskId: EventId = BuildMessages.randomEventId
+    val cancelToken = scala.concurrent.Promise[Unit]()
+    val cancelAction = new CancelBuildAction(cancelToken)
+
+
+    val reporter = new BuildToolWindowReporter(project = project, buildId = bspTaskId, title = "bsp fetch sources", cancelAction)
+    val sources: util.List[SourcesItem] = Await.result(communication.run(
+      bspSessionTask = getFiles(potentialTargets)(_, _),
+      notifications = _ => (),
+      reporter = reporter,
+      processLogger = processLog(reporter),
+    ).future, 300.millis).getItems
+    filterTargetsContainingSources(sources.asScala, files)
+  }
+
+  /**
+    * @param files       List of sources you are looking for
+    * @param sourceLists List of targets with their sources, that will be searched
+    * @return All targets from `sourceLists` that contain any of the sources from `sources`
+    */
+  private def filterTargetsContainingSources(sourceLists: Seq[SourcesItem], files: Seq[PsiFile]): Seq[BuildTargetIdentifier] = {
+    val fileUris = files.map(_.getVirtualFile.getPath).map(path => Paths.get(path).toUri.toString)
+    sourceLists.filter(_.getSources.asScala.map(_.getUri).exists(fileUris.contains(_))).map(_.getTarget)
+  }
+
+  private def class2File(clazz: String, project: Project): Option[PsiFile] = {
+    val psiFacade = JavaPsiFacade.getInstance(project);
+    val scope = GlobalSearchScope.allScope(project)
+    val matchedClasses = psiFacade.findClasses(clazz, scope);
+    if (matchedClasses.length <= 1) matchedClasses.headOption.map(_.getContainingFile) else None
+  }
+
+  private def getApplicableClasses(configuration: RunConfiguration) = {
+    configuration match {
+      case scalaConfig: ModuleBasedConfiguration[_, _] if BSP.isBspModule(scalaConfig.getConfigurationModule.getModule) => {
+        val classes = scalaConfig match {
+          case p: ScalaTestRunConfiguration =>
+            p.testConfigurationData match {
+              case data: AllInPackageTestData => Some(data.classBuf.asScala)
+              case data: ClassTestData => Some(List(data.testClassPath))
+              case _ => None
+            }
+        }
+        classes
+      }
+    }
+  }
+
+  private def processLog(report: BuildToolWindowReporter): ProcessLogger = { message =>
+    report.log(message)
+  }
+
+  private def fetchJvmTestEnvironment(target: BuildTargetIdentifier, workspace: URI, project: Project): JvmTestEnvironment = {
+    val communication: BspCommunication = BspCommunication.forWorkspace(workspace.toFile)
+    val bspTaskId: EventId = BuildMessages.randomEventId
+    val cancelToken = scala.concurrent.Promise[Unit]()
+    val cancelAction = new CancelBuildAction(cancelToken)
+    val report = new BuildToolWindowReporter(project, bspTaskId, "bsp build", cancelAction)
+    val response = Await.result(communication.run(
+      bspSessionTask = jvmTestEnvironmentBspRequest(List(target))(_, _),
+      notifications = _ => (),
+      reporter = report,
+      processLogger = processLog(report),
+    ).future, 300.millis)
+    val environment = response.getItems.asScala.head
+    JvmTestEnvironment(
+      classpath = environment.getClasspath.asScala.map(x => new URI(x).getPath),
+      workdir = environment.getWorkingDirectory,
+      environmentVariables = environment.getEnvironmentVariables.asScala.toMap,
+      jvmOptions = environment.getJvmOptions.asScala.toList
+    )
+  }
+
+  private def getBspTargets(module: Module): Option[Seq[BuildTargetIdentifier]] =
+    for {
+      moduleId <- Option(ES.getExternalProjectId(module))
+      projectPath <- Option(ES.getExternalProjectPath(module))
+      projectData <- Option(ES.findProjectData(module.getProject, BSP.ProjectSystemId, projectPath))
+      moduleDataNode <- Option(ES.find(
+        projectData, ProjectKeys.MODULE,
+        (node: DataNode[ModuleData]) => node.getData.getId == moduleId))
+      metadata <- Option(ES.find(moduleDataNode, BspMetadata.Key))
+    } yield {
+      val data: BspMetadata = metadata.getData
+      data.targetIds.asScala.map(id => new BuildTargetIdentifier(id.toString)).filterNot(_.getUri == moduleId)
+    }
+
+  private def jvmTestEnvironmentBspRequest(targets: Seq[BuildTargetIdentifier])
+                                          (implicit server: BspServer, capabilities: BuildServerCapabilities): CompletableFuture[JvmTestEnvironmentResult] =
+    server.jvmTestEnvironment(new JvmTestEnvironmentParams(targets.asJava))
+
+  private def getFiles(target: Seq[BuildTargetIdentifier])
+                      (implicit server: BspServer, capabilities: BuildServerCapabilities): CompletableFuture[SourcesResult] =
+    server.buildTargetSources(new SourcesParams(target.asJava))
+}

--- a/bsp/src/org/jetbrains/bsp/project/test/environment/BspFetchTestEnvironmentTaskProvider.scala
+++ b/bsp/src/org/jetbrains/bsp/project/test/environment/BspFetchTestEnvironmentTaskProvider.scala
@@ -210,17 +210,10 @@ class BspFetchTestEnvironmentTaskProvider extends BeforeRunTaskProvider[BspFetch
 
   private def getBspTargets(module: Module): Option[Seq[BuildTargetIdentifier]] =
     for {
+      data <- BspMetadata.get(module.getProject, module)
       moduleId <- Option(ES.getExternalProjectId(module))
-      projectPath <- Option(ES.getExternalProjectPath(module))
-      projectData <- Option(ES.findProjectData(module.getProject, BSP.ProjectSystemId, projectPath))
-      moduleDataNode <- Option(ES.find(
-        projectData, ProjectKeys.MODULE,
-        (node: DataNode[ModuleData]) => node.getData.getId == moduleId))
-      metadata <- Option(ES.find(moduleDataNode, BspMetadata.Key))
-    } yield {
-      val data: BspMetadata = metadata.getData
-      data.targetIds.asScala.map(id => new BuildTargetIdentifier(id.toString)).filterNot(_.getUri == moduleId)
-    }
+      res = data.targetIds.asScala.map(id => new BuildTargetIdentifier(id.toString)).filterNot(_.getUri == moduleId)
+    } yield res
 
   private def jvmTestEnvironmentBspRequest(targets: Seq[BuildTargetIdentifier])
                                           (implicit server: BspServer,

--- a/bsp/src/org/jetbrains/bsp/project/test/environment/BspFetchTestEnvironmentTaskProvider.scala
+++ b/bsp/src/org/jetbrains/bsp/project/test/environment/BspFetchTestEnvironmentTaskProvider.scala
@@ -245,7 +245,7 @@ class BspFetchTestEnvironmentTaskProvider extends BeforeRunTaskProvider[BspFetch
   private def jvmTestEnvironmentBspRequest(targets: Seq[BuildTargetIdentifier])
                                           (implicit server: BspServer,
                                            capabilities: BuildServerCapabilities): CompletableFuture[Either[JvmTestEnvironmentNotSupported.type ,JvmTestEnvironmentResult]] =
-    if (Option(capabilities.getJvmTestEnvironmentProvider).forall(_.booleanValue())) {
+    if (Option(capabilities.getJvmTestEnvironmentProvider).exists(_.booleanValue())) {
       server.jvmTestEnvironment(new JvmTestEnvironmentParams(targets.asJava)).thenApply(Right(_))
     } else {
       CompletableFuture.completedFuture(Left(JvmTestEnvironmentNotSupported))

--- a/bsp/src/org/jetbrains/bsp/project/test/environment/BspFetchTestEnvironmentTaskProvider.scala
+++ b/bsp/src/org/jetbrains/bsp/project/test/environment/BspFetchTestEnvironmentTaskProvider.scala
@@ -21,7 +21,7 @@ import com.intellij.openapi.ui.Messages
 import com.intellij.psi.{JavaPsiFacade, PsiFile}
 import com.intellij.psi.search.GlobalSearchScope
 import javax.swing.Icon
-import org.jetbrains.bsp.{BSP, BspUtil, Icons}
+import org.jetbrains.bsp.{BSP, BspBundle, BspUtil, Icons}
 import org.jetbrains.bsp.data.BspMetadata
 import org.jetbrains.bsp.protocol.BspCommunication
 import org.jetbrains.plugins.scala.testingSupport.test.scalatest.ScalaTestRunConfiguration
@@ -140,7 +140,7 @@ class BspFetchTestEnvironmentTaskProvider extends BeforeRunTaskProvider[BspFetch
 
     implicit val reporter = new BuildToolWindowReporter(project = project,
       buildId = bspTaskId,
-      title = "bsp fetch sources",
+      title = BspBundle.message("bsp.task.fetching.sources"),
       cancelAction)
     val sources: util.List[SourcesItem] = Await.result(communication.run(
       bspSessionTask =  getFiles(potentialTargets)(_, _),
@@ -193,11 +193,11 @@ class BspFetchTestEnvironmentTaskProvider extends BeforeRunTaskProvider[BspFetch
     val bspTaskId: EventId = BuildMessages.randomEventId
     val cancelToken = scala.concurrent.Promise[Unit]()
     val cancelAction = new CancelBuildAction(cancelToken)
-    implicit val report = new BuildToolWindowReporter(project, bspTaskId, "bsp build", cancelAction)
+    implicit val reporter = new BuildToolWindowReporter(project, bspTaskId, BspBundle.message("bsp.task.fetchng.jvm.test.environment"), cancelAction)
     val response = Await.result(communication.run(
       bspSessionTask = jvmTestEnvironmentBspRequest(List(target))(_, _),
       notifications = _ => (),
-      processLogger = processLog(report),
+      processLogger = processLog(reporter),
     ).future, 300.millis)
     val environment = response.getItems.asScala.head
     JvmTestEnvironment(

--- a/bsp/src/org/jetbrains/bsp/project/test/environment/BspJvmEnvironmentProgramPatcher.scala
+++ b/bsp/src/org/jetbrains/bsp/project/test/environment/BspJvmEnvironmentProgramPatcher.scala
@@ -1,0 +1,29 @@
+package org.jetbrains.bsp.project.test.environment
+
+import com.intellij.execution.Executor
+import com.intellij.execution.configurations.{JavaParameters, ModuleBasedConfiguration, RunConfigurationModule, RunProfile}
+import com.intellij.execution.runners.JavaProgramPatcher
+
+import scala.collection.JavaConverters._
+
+class BspJvmEnvironmentProgramPatcher extends JavaProgramPatcher {
+  def patchJavaParameters(executor: Executor, configuration: RunProfile, javaParameters: JavaParameters): Unit = {
+    configuration match {
+      case testConfig: ModuleBasedConfiguration[RunConfigurationModule, _] => {
+        val env = testConfig.getUserData(BspFetchTestEnvironmentTask.jvmTestEnvironmentKey)
+        if (env != null) {
+          val oldEnvironmentVariables = javaParameters.getEnv.asScala.toMap
+          val newEnvironmentVariables = oldEnvironmentVariables ++ env.environmentVariables
+          javaParameters.setEnv(newEnvironmentVariables.asJava)
+
+          val oldClasspath = javaParameters.getClassPath.getPathList.asScala.toList
+          val newClassPath = env.classpath ++ oldClasspath
+          javaParameters.getClassPath.addAll(newClassPath.asJava)
+
+          javaParameters.setWorkingDirectory(env.workdir)
+          javaParameters.getVMParametersList.addAll(env.jvmOptions.asJava)
+        }
+      }
+    }
+  }
+}

--- a/bsp/src/org/jetbrains/bsp/project/test/environment/BspTesting.scala
+++ b/bsp/src/org/jetbrains/bsp/project/test/environment/BspTesting.scala
@@ -1,0 +1,12 @@
+package org.jetbrains.bsp.project.test.environment
+
+import com.intellij.execution.configurations.RunConfiguration
+import org.jetbrains.bsp.BSP
+import org.jetbrains.plugins.scala.testingSupport.test.scalatest.ScalaTestRunConfiguration
+
+object BspTesting {
+  def isBspRunnerSupportedConfiguration(config: RunConfiguration) = config match {
+    case _: ScalaTestRunConfiguration => true
+    case _ => false
+  }
+}

--- a/bsp/src/org/jetbrains/bsp/protocol/session/BspSession.scala
+++ b/bsp/src/org/jetbrains/bsp/protocol/session/BspSession.scala
@@ -337,7 +337,7 @@ object BspSession {
   type NotificationCallback = BspNotification => Unit
   type BspSessionTask[T] = (BspServer, BuildServerCapabilities) => CompletableFuture[T]
 
-  trait BspServer extends bsp4j.BuildServer with bsp4j.ScalaBuildServer
+  trait BspServer extends bsp4j.BuildServer with bsp4j.ScalaBuildServer with bsp4j.JvmBuildServer
   trait BspClient extends bsp4j.BuildClient
 
   private[protocol] def builder(

--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -10,7 +10,7 @@ object Versions {
   val bloopVersion = "1.4.0-RC1-74-e0147604"
   val zincVersion = "1.1.1"
   val intellijVersion = "201.5616.10"
-  val bspVersion = "2.0.0-M5"
+  val bspVersion = "2.0.0-M6"
   val sbtStructureVersion: String = "2018.2.1+4-88400d3f"
   val sbtIdeaShellVersion: String = "2018.3"
   val sbtIdeaCompilerIndicesVersion = "0.1.3"

--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -9,8 +9,8 @@ object Versions {
   val sbtVersion: String = Sbt.latest
   val bloopVersion = "1.4.0-RC1-74-e0147604"
   val zincVersion = "1.1.1"
-  val intellijVersion = "201.5616.10"
-  val bspVersion = "2.0.0-M4"
+  val intellijVersion = "201.5259.13"
+  val bspVersion = "2.0.0-M5"
   val sbtStructureVersion: String = "2018.2.1+4-88400d3f"
   val sbtIdeaShellVersion: String = "2018.3"
   val sbtIdeaCompilerIndicesVersion = "0.1.3"

--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -9,7 +9,7 @@ object Versions {
   val sbtVersion: String = Sbt.latest
   val bloopVersion = "1.4.0-RC1-74-e0147604"
   val zincVersion = "1.1.1"
-  val intellijVersion = "201.5259.13"
+  val intellijVersion = "201.5616.10"
   val bspVersion = "2.0.0-M5"
   val sbtStructureVersion: String = "2018.2.1+4-88400d3f"
   val sbtIdeaShellVersion: String = "2018.3"

--- a/scala/scala-impl/resources/META-INF/scala-plugin-common.xml
+++ b/scala/scala-impl/resources/META-INF/scala-plugin-common.xml
@@ -52,6 +52,8 @@
     </extensions>
 
     <extensions defaultExtensionNs="com.intellij">
+      <java.programPatcher implementation="org.jetbrains.bsp.project.test.environment.BspJvmEnvironmentProgramPatcher"/>
+      <stepsBeforeRunProvider implementation="org.jetbrains.bsp.project.test.environment.BspFetchTestEnvironmentTaskProvider"/>
         <annotator language="JAVA"
                    implementationClass="org.jetbrains.plugins.scala.annotator.template.SealedJavaInheritance"/>
         <annotator language="Scala"
@@ -1676,7 +1678,13 @@
         <resolveScopeProvider implementation="org.jetbrains.plugins.scala.lang.psi.impl.ScalaOutOfSourcesResolveScopeProvider"/>
     </extensions>
 
-    <applicationListeners>
+<project-components>
+    <component>
+        <implementation-class>org.jetbrains.bsp.project.test.environment.BspFetchEnvironmentTaskInstaller</implementation-class>
+      </component>
+</project-components>
+
+<applicationListeners>
         <listener topic="com.intellij.ide.AppLifecycleListener"
                   class="org.jetbrains.plugins.scala.findUsages.compilerReferences.compilation.SbtCompilationSupervisor$Listener"/>
         <listener topic="com.intellij.openapi.project.ProjectManagerListener"

--- a/scala/scala-impl/resources/META-INF/scala-plugin-common.xml
+++ b/scala/scala-impl/resources/META-INF/scala-plugin-common.xml
@@ -52,7 +52,6 @@
     </extensions>
 
     <extensions defaultExtensionNs="com.intellij">
-      <stepsBeforeRunProvider implementation="org.jetbrains.bsp.project.test.environment.BspFetchTestEnvironmentTaskProvider"/>
         <annotator language="JAVA"
                    implementationClass="org.jetbrains.plugins.scala.annotator.template.SealedJavaInheritance"/>
         <annotator language="Scala"
@@ -1677,7 +1676,7 @@
         <resolveScopeProvider implementation="org.jetbrains.plugins.scala.lang.psi.impl.ScalaOutOfSourcesResolveScopeProvider"/>
     </extensions>
 
-<applicationListeners>
+    <applicationListeners>
         <listener topic="com.intellij.ide.AppLifecycleListener"
                   class="org.jetbrains.plugins.scala.findUsages.compilerReferences.compilation.SbtCompilationSupervisor$Listener"/>
         <listener topic="com.intellij.openapi.project.ProjectManagerListener"

--- a/scala/scala-impl/resources/META-INF/scala-plugin-common.xml
+++ b/scala/scala-impl/resources/META-INF/scala-plugin-common.xml
@@ -52,7 +52,6 @@
     </extensions>
 
     <extensions defaultExtensionNs="com.intellij">
-      <java.programPatcher implementation="org.jetbrains.bsp.project.test.environment.BspJvmEnvironmentProgramPatcher"/>
       <stepsBeforeRunProvider implementation="org.jetbrains.bsp.project.test.environment.BspFetchTestEnvironmentTaskProvider"/>
         <annotator language="JAVA"
                    implementationClass="org.jetbrains.plugins.scala.annotator.template.SealedJavaInheritance"/>

--- a/scala/scala-impl/resources/META-INF/scala-plugin-common.xml
+++ b/scala/scala-impl/resources/META-INF/scala-plugin-common.xml
@@ -1714,7 +1714,6 @@
         <listener topic="com.intellij.openapi.project.ProjectManagerListener"
                   class="org.jetbrains.plugins.scala.externalHighlighters.RegisterOnProjectOpenedListener"/>
     </projectListeners>
-
     <actions>
         <action id="Scala.NewClass" class="org.jetbrains.plugins.scala.actions.NewScalaTypeDefinitionAction"
                 text="Scala Class" description="Create new Scala class">

--- a/scala/scala-impl/resources/META-INF/scala-plugin-common.xml
+++ b/scala/scala-impl/resources/META-INF/scala-plugin-common.xml
@@ -1678,12 +1678,6 @@
         <resolveScopeProvider implementation="org.jetbrains.plugins.scala.lang.psi.impl.ScalaOutOfSourcesResolveScopeProvider"/>
     </extensions>
 
-<project-components>
-    <component>
-        <implementation-class>org.jetbrains.bsp.project.test.environment.BspFetchEnvironmentTaskInstaller</implementation-class>
-      </component>
-</project-components>
-
 <applicationListeners>
         <listener topic="com.intellij.ide.AppLifecycleListener"
                   class="org.jetbrains.plugins.scala.findUsages.compilerReferences.compilation.SbtCompilationSupervisor$Listener"/>


### PR DESCRIPTION
When the project is imported from BSP, it is expected that the tests
executed with IntelliJ runners will behave exactly the same as if they
would be run by BSP Server. In order to achieve this, the runner must
download some critical environment parameters from BSP server via
jvmTestEnvironment, and use them to spawn child testing process. These
parameters are:

  - classpath
  - environment variables
  - working directory
  - JVM options

The place where the parameters are set is
`BspJvmEnvironmentProgramPatcher`. Unfortunately, the
JavaProgramPatchers are executed in the Event Dispatch Thread, so it
is forbidden to do a (always blocking) BSP call inside. In order to
overcome it, the BSP call is done in BspFetchTestEnvironmentTask,
which is executed on a pool thread before each test execution. The
environment is then saved via `putUserData`, so the patcher can read
it without blocking.

Another tricky thing here is mapping from IntelliJ module to BSP
target. On the other hand, the targetId is required to receive JVM
environment via BSP. Unfortunately, there may be more than one target that matches
the module, so in cases when it's impossible to unambiguously
determine which target is the right one, a popup is shown, so it's
possible to choose from a list of potential targets. The choice is
saved as a `BspFetchTestEnvironmentTask`'s setting.

This addresses https://youtrack.jetbrains.com/issue/SCL-16934