### PR TITLE
Add support for the context-applied scalac plugin

### DIFF
--- a/scala/scala-impl/src/org/jetbrains/plugins/scala/lang/psi/ScalaPsiUtil.scala
+++ b/scala/scala-impl/src/org/jetbrains/plugins/scala/lang/psi/ScalaPsiUtil.scala
@@ -41,7 +41,6 @@ import org.jetbrains.plugins.scala.lang.psi.api.toplevel.typedef._
 import org.jetbrains.plugins.scala.lang.psi.api.toplevel.{ScPackaging, _}
 import org.jetbrains.plugins.scala.lang.psi.api.{ScPackageLike, ScalaFile, ScalaPsiElement, ScalaRecursiveElementVisitor}
 import org.jetbrains.plugins.scala.lang.psi.impl.ScalaPsiElementFactory._
-import org.jetbrains.plugins.scala.lang.psi.impl.base.types.ScCompoundTypeElementImpl
 import org.jetbrains.plugins.scala.lang.psi.impl.expr.ApplyOrUpdateInvocation
 import org.jetbrains.plugins.scala.lang.psi.impl.toplevel.typedef.TypeDefinitionMembers
 import org.jetbrains.plugins.scala.lang.psi.impl.{ScPackageImpl, ScalaPsiManager}

--- a/scala/scala-impl/src/org/jetbrains/plugins/scala/project/ScalaModuleSettings.scala
+++ b/scala/scala-impl/src/org/jetbrains/plugins/scala/project/ScalaModuleSettings.scala
@@ -67,6 +67,9 @@ private class ScalaModuleSettings(module: Module, val scalaSdk: LibraryEx) {
   val betterMonadicForPluginEnabled: Boolean =
     compilerPlugins.exists(_.contains("better-monadic-for"))
 
+  val contextAppliedPluginEnabled: Boolean =
+    compilerPlugins.exists(_.contains("context-applied"))
+
   /**
    * Should we check if it's a Single Abstract Method?
    * In 2.11 works with -Xexperimental

--- a/scala/scala-impl/src/org/jetbrains/plugins/scala/project/package.scala
+++ b/scala/scala-impl/src/org/jetbrains/plugins/scala/project/package.scala
@@ -195,6 +195,9 @@ package object project {
     def betterMonadicForPluginEnabled: Boolean =
       scalaModuleSettings.exists(_.betterMonadicForPluginEnabled)
 
+    def contextAppliedPluginEnabled: Boolean =
+      scalaModuleSettings.exists(_.contextAppliedPluginEnabled)
+
     /**
      * Should we check if it's a Single Abstract Method?
      * In 2.11 works with -Xexperimental
@@ -338,6 +341,8 @@ package object project {
     def kindProjectorPlugin: Option[String] = inThisModuleOrProject(_.kindProjectorPlugin).flatten
 
     def betterMonadicForEnabled: Boolean = isDefinedInModuleOrProject(_.betterMonadicForPluginEnabled)
+
+    def contextAppliedEnabled: Boolean = isDefinedInModuleOrProject(_.contextAppliedPluginEnabled)
 
     def isSAMEnabled: Boolean = isDefinedInModuleOrProject(_.isSAMEnabled)
 

--- a/scala/scala-impl/test/org/jetbrains/plugins/scala/lang/resolve2/ContextAppliedTest.scala
+++ b/scala/scala-impl/test/org/jetbrains/plugins/scala/lang/resolve2/ContextAppliedTest.scala
@@ -1,0 +1,37 @@
+package org.jetbrains.plugins.scala.lang.resolve2
+
+import org.jetbrains.plugins.scala.project.settings.ScalaCompilerConfiguration
+
+/**
+ * Yannick Heiber, 16.02.2020
+ */
+
+class ContextAppliedTest extends ResolveTestBase {
+  override def folderPath: String = {
+    super.folderPath + "function/contextApplied/"
+  }
+
+
+  override def setUp(): Unit = {
+    super.setUp()
+
+    val defaultProfile = ScalaCompilerConfiguration.instanceIn(getProjectAdapter).defaultProfile
+    val newSettings = defaultProfile.getSettings.copy(
+      plugins = defaultProfile.getSettings.plugins :+ "context-applied"
+    )
+    defaultProfile.setSettings(newSettings)
+  }
+
+  def testFunctionSingleBound() = doTest()
+
+  def testClassSingleBound() = doTest()
+
+  def testFunctionWithExistingParam() = doTest()
+
+  def testAnyValClassSingleBound() = doTest()
+
+  def testFunctionMultiBound() = doTest()
+
+  def testFunctionMultiBoundOrder() = doTest()
+
+}

--- a/scala/scala-impl/testdata/resolve2/function/contextApplied/AnyValClassSingleBound.scala
+++ b/scala/scala-impl/testdata/resolve2/function/contextApplied/AnyValClassSingleBound.scala
@@ -1,0 +1,7 @@
+trait Log[F[_]] {
+  def log(msg: String): F[Unit]
+}
+
+class Foo(val dummy: Boolean) extends AnyVal {
+  def bar[T[_]: Log] = /* resolved: false */ T.log("Hello")
+}

--- a/scala/scala-impl/testdata/resolve2/function/contextApplied/ClassSingleBound.scala
+++ b/scala/scala-impl/testdata/resolve2/function/contextApplied/ClassSingleBound.scala
@@ -1,0 +1,7 @@
+trait Log[F[_]] {
+  def log(msg: String): F[Unit]
+}
+
+class foo[T[_]: Log]() {
+  /* resolved: true */ T. /* offset: 24 */ log("Hello")
+}

--- a/scala/scala-impl/testdata/resolve2/function/contextApplied/FunctionMultiBound.scala
+++ b/scala/scala-impl/testdata/resolve2/function/contextApplied/FunctionMultiBound.scala
@@ -1,0 +1,12 @@
+trait Log[F[_]] {
+  def log(msg: String): F[Unit]
+}
+
+trait Console[F[_]] {
+  def read: F[Unit]
+}
+
+def foo[T[_]: Log : Console] = {
+  /* resolved: true */T./* offset: 24 */log("Hello")
+  /* resolved: true */T./* offset: 81 */read
+}

--- a/scala/scala-impl/testdata/resolve2/function/contextApplied/FunctionMultiBoundOrder.scala
+++ b/scala/scala-impl/testdata/resolve2/function/contextApplied/FunctionMultiBoundOrder.scala
@@ -1,0 +1,15 @@
+trait Base[F[_]] {
+  def go(): Unit
+}
+
+trait First[F[_]] extends Base[F] {
+  def go(): Unit = println("First")
+}
+
+trait Second[F[_]] extends Base[F] {
+  def go(): Unit = println("Second")
+}
+
+def foo[T[_]: First : Second] = /* resolved: true */ T./* offset: 81 */go()
+
+def bar[T[_]: Second : First] = /* resolved: true */ T./* offset: 157 */go()

--- a/scala/scala-impl/testdata/resolve2/function/contextApplied/FunctionSingleBound.scala
+++ b/scala/scala-impl/testdata/resolve2/function/contextApplied/FunctionSingleBound.scala
@@ -1,0 +1,5 @@
+trait Log[F[_]] {
+  def log(msg: String): F[Unit]
+}
+
+def foo[T[_]: Log] = /* resolved: true */T./* offset: 24 */log("Hello")

--- a/scala/scala-impl/testdata/resolve2/function/contextApplied/FunctionWithExistingParam.scala
+++ b/scala/scala-impl/testdata/resolve2/function/contextApplied/FunctionWithExistingParam.scala
@@ -1,0 +1,5 @@
+trait Log[F[_]] {
+  def log(msg: String): F[Unit]
+}
+
+def foo[T[_]: Log](T: Unit) = /* resolved: true */T./* resolved: false */log("Hello")


### PR DESCRIPTION
Extends the support for context bounds to also virtually generate implicit parameters which mimic the syntactic sugar provided by the [context-applied](https://github.com/augustjune/context-applied) scalac plugin. This allows users of this plugin to edit their code in IntelliJ without it complaining, while it doesn't change anything for Scala projects not using the plugin.

The limitations of context-applied (no parameter with same name, no support in `AnyVal`) are respected and have their own test cases.

Example of how the internal expansion looks like for a piece of code relying on _context-applied_:
```scala
trait Log[F[_]] {
  def log(msg: String): F[Unit]
}

class Foo(val dummy: Boolean) {
  def bar[T[_]: Log: Console] = T.log("Hello")
}
```
becomes virtually (the first two implicit params are generated already by IntelliJ, only the third (`T`) is new):
```scala
// Log definiton
class Foo(val dummy: Boolean) {
  def bar[T[_]](implicit bar$Log$0: Log[T], bar$Console$0: Console[T], T: Console[T] with Log[T]) = T.log("Hello")
}
```