### PR TITLE
SCL-17067: provide title for code folding settings

### DIFF
--- a/scala/scala-impl/resources/org/jetbrains/plugins/scala/editor/EditorBundle.properties
+++ b/scala/scala-impl/resources/org/jetbrains/plugins/scala/editor/EditorBundle.properties
@@ -1,11 +1,11 @@
 ### org/jetbrains/plugins/scala/editor/codeFolding/ScalaCodeFoldingOptionsProvider.java
-checkbox.collapse.shell.comments=Shell comments (Scala scripts)
-checkbox.collapse.block.comments=Block comments (Scala)
-checkbox.collapse.method.call.bodies=Method call bodies (Scala)
-checkbox.collapse.template.bodies=Template bodies (Scala)
-checkbox.collapse.type.lambdas=Type Lambdas (Scala)
-checkbox.collapse.packagings=Packagings (Scala)
-checkbox.collapse.multiline.strings=Multi-line strings (Scala)
-checkbox.collapse.custom.regions=Custom regions (Scala)
-checkbox.collapse.multiline.blocks=Multi-line blocks (Scala)
-checkbox.add.folding.for.all.blocks=Show code folding outline for all multi-line blocks (Scala)
+checkbox.collapse.shell.comments=Shell comments
+checkbox.collapse.block.comments=Block comments
+checkbox.collapse.method.call.bodies=Method call bodies
+checkbox.collapse.template.bodies=Template bodies
+checkbox.collapse.type.lambdas=Type Lambdas
+checkbox.collapse.packagings=Packagings
+checkbox.collapse.multiline.strings=Multi-line strings
+checkbox.collapse.custom.regions=Custom regions
+checkbox.collapse.multiline.blocks=Multi-line blocks
+checkbox.add.folding.for.all.blocks=Show code folding outline for all multi-line blocks

--- a/scala/scala-impl/src/org/jetbrains/plugins/scala/editor/codeFolding/ScalaCodeFoldingOptionsProvider.java
+++ b/scala/scala-impl/src/org/jetbrains/plugins/scala/editor/codeFolding/ScalaCodeFoldingOptionsProvider.java
@@ -13,7 +13,7 @@ import org.jetbrains.plugins.scala.settings.ScalaCodeFoldingSettings;
 public class ScalaCodeFoldingOptionsProvider extends BeanConfigurable<ScalaCodeFoldingSettings> implements CodeFoldingOptionsProvider {
 
   public ScalaCodeFoldingOptionsProvider() {
-    super(ScalaCodeFoldingSettings.getInstance());
+    super(ScalaCodeFoldingSettings.getInstance(), "Scala");
     checkBox("FoldingForAllBlocks", EditorBundle.message("checkbox.add.folding.for.all.blocks"));
 
     checkBox("CollapseShellComments", EditorBundle.message("checkbox.collapse.shell.comments"));


### PR DESCRIPTION
It should fix NPE on 2020.1 platform and make the corresponding settings more structured

| Before | After |
|-|-|
| ![image](https://user-images.githubusercontent.com/2539310/74821144-36ad4d80-5314-11ea-8c00-0c9a7ed83c40.png) | ![image](https://user-images.githubusercontent.com/2539310/74821186-4331a600-5314-11ea-9e74-b19af6193a2b.png) |


#SCL-17067 fixed
#SCL-16722 fixed