### PR TITLE
Basic support for JUnit/BSP test runs

### DIFF
--- a/bsp/src/org/jetbrains/bsp/project/test/environment/BspJvmEnvironmentProgramPatcher.scala
+++ b/bsp/src/org/jetbrains/bsp/project/test/environment/BspJvmEnvironmentProgramPatcher.scala
@@ -3,6 +3,7 @@ package org.jetbrains.bsp.project.test.environment
 import com.intellij.execution.Executor
 import com.intellij.execution.configurations.{JavaParameters, ModuleBasedConfiguration, RunConfigurationModule, RunProfile}
 import com.intellij.execution.runners.JavaProgramPatcher
+import com.intellij.openapi.util.UserDataHolderBase
 import org.jetbrains.plugins.scala.testingSupport.test.AbstractTestRunConfiguration
 
 import scala.collection.JavaConverters._
@@ -11,7 +12,7 @@ class BspJvmEnvironmentProgramPatcher extends JavaProgramPatcher {
 
   override def patchJavaParameters(executor: Executor, configuration: RunProfile, javaParameters: JavaParameters): Unit = {
     configuration match {
-      case testConfig: AbstractTestRunConfiguration =>
+      case testConfig: UserDataHolderBase =>
         val env = testConfig.getUserData(BspFetchTestEnvironmentTask.jvmTestEnvironmentKey)
         if (env != null) {
           val oldEnvironmentVariables = javaParameters.getEnv.asScala.toMap

--- a/bsp/src/org/jetbrains/bsp/project/test/environment/BspTesting.scala
+++ b/bsp/src/org/jetbrains/bsp/project/test/environment/BspTesting.scala
@@ -1,12 +1,14 @@
 package org.jetbrains.bsp.project.test.environment
 
 import com.intellij.execution.configurations.RunConfiguration
+import com.intellij.execution.junit.JUnitConfiguration
 import org.jetbrains.plugins.scala.testingSupport.test.scalatest.ScalaTestRunConfiguration
 
 object BspTesting {
   def isBspRunnerSupportedConfiguration(config: RunConfiguration): Boolean =
     config match {
       case _: ScalaTestRunConfiguration => true
+      case _: JUnitConfiguration => true
       case _ => false
     }
 }


### PR DESCRIPTION
No detection of BSP targets yet. When running JUnit test
configuration, IntelliJ always asks for the BSP target.