### PR TITLE
More verbose errors in BspMetadata.get

### DIFF
--- a/bsp/resources/messages/ScalaBspBundle.properties
+++ b/bsp/resources/messages/ScalaBspBundle.properties
@@ -106,3 +106,9 @@ bsp.protocol.specific.settings=BSP-specific settings
 
 ### <unused>
 bsp.task.error.could.not.detect.run.classes=Could not detect run classes for configuration {0}
+
+### org/jetbrains/bsp/data/dataObjects.scala
+bsp.metadata.error.project.info=BspMetadata.get: Could not get project info of project '{0}'
+bsp.metadata.error.project.structure=BspMetadata.get: Could not get project structure '{0}'
+bsp.metadata.error.data.node=BspMetadata.get: Could not get data node of of project '{0}'
+bsp.metadata.error.module.metadata=BspMetadata.get: Could not get module metadata of '{0}'

--- a/bsp/resources/messages/ScalaBspBundle.properties
+++ b/bsp/resources/messages/ScalaBspBundle.properties
@@ -79,6 +79,8 @@ bsp.task.error.could.not.fetch.test.jvm.environment=Failed to fetch test JVM env
 bsp.task.error=Error while fetching test environment from BSP: {0}
 bsp.task.error.test.env.not.supported=Build Server does not support 'buildTarget/jvmTestEnvironment' endpoint
 bsp.task.name=Use BSP environment
+bsp.task.get.external.project.error=Could not extract external project id for '{0}'
+bsp.task.could.not.get.potential.targets=Error while getting potential targets list: '{0}'
 
 ### org/jetbrains/bsp/protocol/BspCommunication.scala
 bsp.protocol.connection.failed=bsp connection failed: {0}

--- a/bsp/src/org/jetbrains/bsp/project/test/BspTestRunner.scala
+++ b/bsp/src/org/jetbrains/bsp/project/test/BspTestRunner.scala
@@ -56,7 +56,7 @@ class BspTestRunner(
 
   private def targets(): List[URI] = {
     ModuleManager.getInstance(project).getModules.toList
-      .flatMap(BspMetadata.get(project, _))
+      .flatMap(BspMetadata.get(project, _).toOption)
       .flatMap(x => x.targetIds.asScala.toList)
   }
 

--- a/bsp/src/org/jetbrains/bsp/project/test/FetchScalaTestClassesTask.scala
+++ b/bsp/src/org/jetbrains/bsp/project/test/FetchScalaTestClassesTask.scala
@@ -38,7 +38,7 @@ class FetchScalaTestClassesTask(project: Project,
 
     val targetsByWorkspace = ModuleManager.getInstance(project).getModules.toList
       .flatMap { module =>
-        val targets = BspMetadata.get(project, module).toList.flatMap(_.targetIds.asScala)
+        val targets = BspMetadata.get(project, module).toOption.toList.flatMap(_.targetIds.asScala)
         val modulePath = ExternalSystemApiUtil.getExternalProjectPath(module)
         val workspacePath = Paths.get(modulePath)
         targets.map(t => (workspacePath, new BuildTargetIdentifier(t.toString)))


### PR DESCRIPTION
Also return value type from `Option` to `Either`. Also utilize the new error messages in `BspFetchTestEnvironmentTaskProvider`, but converted back to `Option` in other places where it's used.