### PR TITLE
No need to filter-out modules with the same ID as BSP target

### DIFF
--- a/bsp/src/org/jetbrains/bsp/project/test/environment/BspFetchTestEnvironmentTaskProvider.scala
+++ b/bsp/src/org/jetbrains/bsp/project/test/environment/BspFetchTestEnvironmentTaskProvider.scala
@@ -239,8 +239,7 @@ class BspFetchTestEnvironmentTaskProvider extends BeforeRunTaskProvider[BspFetch
   private def getBspTargets(module: Module): Option[Seq[BuildTargetIdentifier]] =
     for {
       data <- BspMetadata.get(module.getProject, module)
-      moduleId <- Option(ES.getExternalProjectId(module))
-      res = data.targetIds.asScala.map(id => new BuildTargetIdentifier(id.toString)).filterNot(_.getUri == moduleId)
+      res = data.targetIds.asScala.map(id => new BuildTargetIdentifier(id.toString))
     } yield res
 
   private def jvmTestEnvironmentBspRequest(targets: Seq[BuildTargetIdentifier])


### PR DESCRIPTION
It was done due to misunderstanding