### PR TITLE
Read jdk from bsp server

### DIFF
--- a/bsp/src/org/jetbrains/bsp/data/dataObjects.scala
+++ b/bsp/src/org/jetbrains/bsp/data/dataObjects.scala
@@ -45,6 +45,11 @@ object BspProjectData {
 }
 
 
+case class JdkData @PropertyMapping(Array("javaHome", "javaVersion"))(
+  @Nullable javaHome: URI,
+  @Nullable javaVersion: String
+) extends BspEntityData
+
 @SerialVersionUID(3)
 case class ScalaSdkData @PropertyMapping(Array("scalaOrganization", "scalaVersion", "scalacClasspath", "scalacOptions"))(
   @NotNull scalaOrganization: String,

--- a/bsp/src/org/jetbrains/bsp/project/resolver/BspResolverDescriptors.scala
+++ b/bsp/src/org/jetbrains/bsp/project/resolver/BspResolverDescriptors.scala
@@ -3,6 +3,7 @@ package org.jetbrains.bsp.project.resolver
 import java.io.File
 
 import ch.epfl.scala.bsp4j._
+import org.jetbrains.bsp.data.JdkData
 import org.jetbrains.bsp.data.{SbtBuildModuleDataBsp, ScalaSdkData}
 
 import scala.util.Try
@@ -37,9 +38,13 @@ private[resolver] object BspResolverDescriptors {
   private[resolver] sealed abstract class ModuleKind
 
   private[resolver] case class UnspecifiedModule() extends ModuleKind
-  private[resolver] case class ScalaModule(scalaSdkData: ScalaSdkData) extends ModuleKind
+  private[resolver] case class JvmModule(jdkData: JdkData) extends ModuleKind
+  private[resolver] case class ScalaModule(jdkData: JdkData,
+                                           scalaSdkData: ScalaSdkData
+                                          ) extends ModuleKind
 
-  private[resolver] case class SbtModule(scalaSdkData: ScalaSdkData,
+  private[resolver] case class SbtModule(jdkData: JdkData,
+                                         scalaSdkData: ScalaSdkData,
                                          sbtData: SbtBuildModuleDataBsp
                                         ) extends ModuleKind
 

--- a/bsp/test/org/jetbrains/bsp/project/resolver/BspResolverLogicProperties.scala
+++ b/bsp/test/org/jetbrains/bsp/project/resolver/BspResolverLogicProperties.scala
@@ -44,7 +44,7 @@ class  BspResolverLogicProperties extends AssertionsForJUnit with Checkers {
   def testGetScalaSdkData(): Unit = check(
     forAll { (scalaBuildTarget: ScalaBuildTarget, scalacOptionsItem: ScalacOptionsItem) =>
 
-      val data = getScalaSdkData(scalaBuildTarget, Some(scalacOptionsItem))
+      val (_, data) = getScalaSdkData(scalaBuildTarget, Some(scalacOptionsItem))
       val jarsToClasspath = ! scalaBuildTarget.getJars.isEmpty ==> ! data.scalacClasspath.isEmpty
 
       jarsToClasspath && data.scalaVersion != null

--- a/bsp/test/org/jetbrains/bsp/project/resolver/Generators.scala
+++ b/bsp/test/org/jetbrains/bsp/project/resolver/Generators.scala
@@ -8,6 +8,7 @@ import ch.epfl.scala.bsp.testkit.gen.UtilGenerators.{genFileUriString, genPath}
 import ch.epfl.scala.bsp.testkit.gen.bsp4jArbitrary._
 import ch.epfl.scala.bsp4j.{BuildTarget, BuildTargetIdentifier}
 import com.google.gson.{Gson, GsonBuilder}
+import org.jetbrains.bsp.data.JdkData
 import org.jetbrains.bsp.data.ScalaSdkData
 import org.jetbrains.bsp.project.resolver.BspResolverDescriptors.{ModuleDescription, SourceDirectory, _}
 import org.scalacheck.Arbitrary.arbitrary
@@ -89,9 +90,15 @@ object Generators {
     scalacOptions <- arbitrary[String].list
   } yield ScalaSdkData(scalaOrganization, scalaVersion.orNull, scalacClasspath, scalacOptions)
 
+  def genJdkData: Gen[JdkData] = for {
+    javaHome <- genFileUri
+    javaVersion <- arbitrary[String]
+  } yield JdkData(javaHome, javaVersion)
+
   def genModuleKind: Gen[ModuleKind] = for {
+    jdkData <- genJdkData
     scalaSdkData <- genScalaSdkData
-  } yield ScalaModule(scalaSdkData)
+  } yield ScalaModule(jdkData, scalaSdkData)
 
   def genModuleDescription: Gen[ModuleDescription] = for {
     id <- arbitrary[String]

--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -10,7 +10,7 @@ object Versions {
   val bloopVersion = "1.4.0-RC1-94-a2be783d"
   val zincVersion = "1.1.1"
   val intellijVersion = "201.6487.11"
-  val bspVersion = "2.0.0-M7"
+  val bspVersion = "2.0.0-M8"
   val sbtStructureVersion: String = "2018.2.1+4-88400d3f"
   val sbtIdeaShellVersion: String = "2018.3"
   val sbtIdeaCompilerIndicesVersion = "0.1.3"


### PR DESCRIPTION
depends on PRs to bloop and bsp
For now the information about jdk from bsp is used to setup the project sdk (not for individual modules)
https://github.com/build-server-protocol/build-server-protocol/pull/113
https://github.com/scalacenter/bloop/pull/1214