### PR TITLE
Conditional dependency on JUnit

### DIFF
--- a/bsp/resources/META-INF/BSP-JUnit.xml
+++ b/bsp/resources/META-INF/BSP-JUnit.xml
@@ -1,0 +1,6 @@
+
+<idea-plugin>
+    <extensions defaultExtensionNs="com.intellij">
+        <runConfigurationClassExtractor implementation="org.jetbrains.bsp.project.test.environment.JUnitClassExtractor"/>
+    </extensions>
+</idea-plugin>

--- a/bsp/resources/META-INF/BSP.xml
+++ b/bsp/resources/META-INF/BSP.xml
@@ -1,7 +1,14 @@
 <?xml version="1.0" encoding="iso-8859-1"?>
 
 <idea-plugin>
+    <depends optional="true" config-file="BSP-JUnit.xml">JUnit</depends>
+    <extensionPoints>
+        <extensionPoint qualifiedName="com.intellij.runConfigurationClassExtractor"
+                        interface="org.jetbrains.bsp.project.test.environment.RunConfigurationClassExtractor"/>
+    </extensionPoints>
+
     <extensions defaultExtensionNs="com.intellij">
+        <runConfigurationClassExtractor implementation="org.jetbrains.bsp.project.test.environment.ScalaTestClassExtractor"/>
         <moduleType id="BSP_SYNTHETIC_MODULE" implementationClass="org.jetbrains.bsp.project.BspSyntheticModuleType"/>
         <moduleConfigurationEditorProvider implementation="org.jetbrains.bsp.project.BspSyntheticModuleEditorProvider"/>
 

--- a/bsp/src/org/jetbrains/bsp/project/test/environment/BspFetchTestEnvironmentTaskProvider.scala
+++ b/bsp/src/org/jetbrains/bsp/project/test/environment/BspFetchTestEnvironmentTaskProvider.scala
@@ -203,23 +203,12 @@ class BspFetchTestEnvironmentTaskProvider extends BeforeRunTaskProvider[BspFetch
     configuration match {
       case moduleBasedRunConfig: ModuleBasedConfiguration[_, _]
         if BspUtil.isBspModule(moduleBasedRunConfig.getConfigurationModule.getModule) =>
-        val classes = moduleBasedRunConfig match {
-          case scalaTestConfig: ScalaTestRunConfiguration =>
-            scalaTestConfig.testConfigurationData match {
-              case data: AllInPackageTestData => data.classBuf.asScala
-              case data: ClassTestData => List(data.testClassPath)
-              case _ => List()
-            }
-          case junitConfig: JUnitConfiguration => {
-            junitConfig.getTestType match {
-              case JUnitConfiguration.TEST_METHOD | JUnitConfiguration.TEST_CLASS =>
-                List(junitConfig.getPersistentData.getMainClassName)
-              case _ => List()
-            }
-          }
-          case _ => List()
-        }
-        classes
+
+        val cl = RunConfigurationClassExtractor.EP_NAME.getExtensionList().asScala
+          .find(_.runConfigurationSupported(moduleBasedRunConfig))
+          .flatMap(_.classes(moduleBasedRunConfig))
+
+        cl.getOrElse(List())
     }
   }
 

--- a/bsp/src/org/jetbrains/bsp/project/test/environment/BspTesting.scala
+++ b/bsp/src/org/jetbrains/bsp/project/test/environment/BspTesting.scala
@@ -4,11 +4,10 @@ import com.intellij.execution.configurations.RunConfiguration
 import com.intellij.execution.junit.JUnitConfiguration
 import org.jetbrains.plugins.scala.testingSupport.test.scalatest.ScalaTestRunConfiguration
 
+import scala.collection.JavaConverters._
+
 object BspTesting {
   def isBspRunnerSupportedConfiguration(config: RunConfiguration): Boolean =
-    config match {
-      case _: ScalaTestRunConfiguration => true
-      case _: JUnitConfiguration => true
-      case _ => false
-    }
+    RunConfigurationClassExtractor.EP_NAME.getExtensionList().asScala
+      .exists(_.runConfigurationSupported(config))
 }

--- a/bsp/src/org/jetbrains/bsp/project/test/environment/JUnitClassExtractor.scala
+++ b/bsp/src/org/jetbrains/bsp/project/test/environment/JUnitClassExtractor.scala
@@ -1,0 +1,21 @@
+package org.jetbrains.bsp.project.test.environment
+import com.intellij.execution.configurations.RunConfiguration
+import com.intellij.execution.junit.JUnitConfiguration
+
+class JUnitClassExtractor extends RunConfigurationClassExtractor {
+  override def runConfigurationSupported(config: RunConfiguration): Boolean =
+    config.isInstanceOf[JUnitConfiguration]
+
+  override def classes(config: RunConfiguration): Option[List[String]] = {
+    config match {
+      case jUnitConfig: JUnitConfiguration =>
+        jUnitConfig.getTestType match {
+          case JUnitConfiguration.TEST_METHOD | JUnitConfiguration.TEST_CLASS =>
+            Some(List(jUnitConfig.getPersistentData.getMainClassName))
+          case _ => None
+        }
+      case _ => None
+    }
+  }
+}
+

--- a/bsp/src/org/jetbrains/bsp/project/test/environment/RunConfigurationClassExtractor.scala
+++ b/bsp/src/org/jetbrains/bsp/project/test/environment/RunConfigurationClassExtractor.scala
@@ -1,0 +1,14 @@
+package org.jetbrains.bsp.project.test.environment
+
+import com.intellij.execution.configurations.RunConfiguration
+import com.intellij.openapi.extensions.ExtensionPointName
+
+object RunConfigurationClassExtractor{
+  val EP_NAME: ExtensionPointName[RunConfigurationClassExtractor] =
+    ExtensionPointName.create("com.intellij.runConfigurationClassExtractor")
+}
+
+trait RunConfigurationClassExtractor {
+  def classes(config: RunConfiguration) : Option[List[String]]
+  def runConfigurationSupported(config: RunConfiguration): Boolean
+}

--- a/bsp/src/org/jetbrains/bsp/project/test/environment/ScalaTestClassExtractor.scala
+++ b/bsp/src/org/jetbrains/bsp/project/test/environment/ScalaTestClassExtractor.scala
@@ -1,0 +1,24 @@
+package org.jetbrains.bsp.project.test.environment
+
+import com.intellij.execution.configurations.RunConfiguration
+import org.jetbrains.plugins.scala.testingSupport.test.scalatest.ScalaTestRunConfiguration
+import org.jetbrains.plugins.scala.testingSupport.test.testdata.{AllInPackageTestData, ClassTestData}
+
+import scala.collection.JavaConverters._
+
+class ScalaTestClassExtractor extends RunConfigurationClassExtractor {
+  override def runConfigurationSupported(config: RunConfiguration): Boolean =
+    config.isInstanceOf[ScalaTestRunConfiguration]
+
+  override def classes(config: RunConfiguration): Option[List[String]] = {
+    config match {
+      case scalaTestConfig: ScalaTestRunConfiguration =>
+        scalaTestConfig.testConfigurationData match {
+          case data: AllInPackageTestData => Some(data.classBuf.asScala.toList)
+          case data: ClassTestData => Some(List(data.testClassPath))
+          case _ => None
+        }
+      case _ => None
+    }
+  }
+}


### PR DESCRIPTION
Before this commit, the Scala Plugin was unconditionally dependent on
JUnit plugin (it was referencing JUnitConfiguration class). This could
cause some problems, for example when JUnit plugin was disabled.

This commit makes this dependency conditional. Functions referencing
JUnitConfiguration has been moved to `runConfigurationClassExtractor`
extension, that is loaded only when JUnit plugin is enabled.

Addresses https://youtrack.jetbrains.com/issue/SCL-17209