### PR TITLE
Workaround for lsp4j cancellation problem

### DIFF
--- a/bsp/src/org/jetbrains/bsp/project/BspTask.scala
+++ b/bsp/src/org/jetbrains/bsp/project/BspTask.scala
@@ -76,7 +76,7 @@ class BspTask[T](project: Project,
   }
 
   override def onCancel(): Unit = {
-    resultPromise.failure(new ProcessCanceledException())
+    resultPromise.tryFailure(new ProcessCanceledException())
   }
 
   override def run(indicator: ProgressIndicator): Unit = {
@@ -132,7 +132,7 @@ class BspTask[T](project: Project,
     }
     else reporter.finish(combinedMessages)
 
-    resultPromise.success(combinedMessages)
+    resultPromise.trySuccess(combinedMessages)
   }
 
   private def messagesWithStatus(reporter: BuildReporter,

--- a/bsp/src/org/jetbrains/bsp/protocol/session/jobs.scala
+++ b/bsp/src/org/jetbrains/bsp/protocol/session/jobs.scala
@@ -12,6 +12,7 @@ import org.jetbrains.bsp.protocol.session.jobs.BspSessionJob
 import org.jetbrains.bsp.{BspError, BspTaskCancelled}
 
 import scala.concurrent.{CancellationException, Future, Promise}
+import scala.concurrent.ExecutionContext.Implicits.global
 
 object jobs {
 
@@ -59,6 +60,16 @@ private[session] class FailedBspSessionJob[T,A](problem: BspError) extends BspSe
 
 }
 
+case class RunningBspTask[T](
+                           future: CompletableFuture[T],
+                           cancellation: Promise[Boolean]
+                         ) {
+  future.whenComplete(
+    (_: T, _: Throwable) => {
+      cancellation.trySuccess(false)
+    })
+  def cancel: Boolean = cancellation.trySuccess(true)
+}
 
 private[session] class Bsp4jJob[T,A](task: BspSessionTask[T],
                                      default: A,
@@ -69,7 +80,7 @@ private[session] class Bsp4jJob[T,A](task: BspSessionTask[T],
   private val promise = Promise[(T,A)]
   private var a: A = default
 
-  private val runningTask: AtomicReference[Option[CompletableFuture[(T,A)]]] = new AtomicReference(None)
+  private val runningTask: AtomicReference[Option[RunningBspTask[(T, A)]]] = new AtomicReference(None)
 
   override private[session] def notification(bspNotification: BspNotification): Unit = {
     a = aggregator(a, bspNotification)
@@ -79,8 +90,14 @@ private[session] class Bsp4jJob[T,A](task: BspSessionTask[T],
     processLogger(message)
   }
 
-  private def doRun(bspServer: BspServer, capabilities: BuildServerCapabilities): CompletableFuture[(T,A)] = {
-    task(bspServer, capabilities).thenApply[(T,A)]((t:T) => (t,a))
+  private def doRun(bspServer: BspServer, capabilities: BuildServerCapabilities): RunningBspTask[(T,A)] = {
+    val originalFuture = task(bspServer, capabilities)
+    val cancellationPromise = Promise[Boolean]()
+    cancellationPromise.future.foreach {
+      case true => originalFuture.cancel(true)
+      case _ =>
+    }
+    val result = originalFuture.thenApply[(T,A)]((t:T) => (t,a))
       .whenComplete((result: (T,A), error: Throwable) => {
         if (error != null) error match {
           case cancel: CancellationException =>
@@ -91,17 +108,18 @@ private[session] class Bsp4jJob[T,A](task: BspSessionTask[T],
           promise.success(result)
         }
       })
+    RunningBspTask(result, cancellationPromise)
   }
 
   override private[session] def run(bspServer: BspServer, capabilities: BuildServerCapabilities): CompletableFuture[(T, A)] =
     runningTask.synchronized {
       runningTask.get match {
-        case Some(running) =>
-          running
+        case Some(RunningBspTask(result, _)) =>
+          result
         case None =>
           val running = doRun(bspServer, capabilities)
           runningTask.set(Some(running))
-          running
+          running.future
       }
     }
 
@@ -114,11 +132,13 @@ private[session] class Bsp4jJob[T,A](task: BspSessionTask[T],
   override def cancelWithError(error: BspError): Unit = runningTask.synchronized {
     runningTask.get() match {
       case Some(toCancel) =>
-        toCancel.cancel(true)
+        toCancel.cancel
       case None =>
         val errorFuture = new CompletableFuture[(T,A)]
+        val errorCancelationPromise = Promise[Boolean]()
         errorFuture.completeExceptionally(error)
-        runningTask.set(Some(errorFuture))
+        errorCancelationPromise.failure(error)
+        runningTask.set(Some(RunningBspTask(errorFuture, errorCancelationPromise)))
     }
 
     promise.failure(error)


### PR DESCRIPTION
This is only a POC, the right fix should probably be done in lsp4j.

lsp4j's cancellation is implemented in that way, the
`CompletableFuture` returned from the client library contains
overriden `cancel` function:
https://github.com/eclipse/lsp4j/blob/ad99a3d77139351dbc00c2dacd388fe749652309/org.eclipse.lsp4j.jsonrpc/src/main/java/org/eclipse/lsp4j/jsonrpc/RemoteEndpoint.java#L149-L152

Unfortunately, if a CompletableFuture is mapped with `applyThen`, the
information about overriding is lost, so cancel must be called on the
original future.

In BSP-related code we modify the future a few times, so as long as
it's not fixed in intellij, we have to store the original future and
call cancel on it, instead of on derived one.