### PR TITLE
Position BSP environment classpath items before all other

### DIFF
--- a/bsp/src/org/jetbrains/bsp/project/test/environment/BspJvmEnvironmentProgramPatcher.scala
+++ b/bsp/src/org/jetbrains/bsp/project/test/environment/BspJvmEnvironmentProgramPatcher.scala
@@ -21,6 +21,7 @@ class BspJvmEnvironmentProgramPatcher extends JavaProgramPatcher {
 
           val oldClasspath = javaParameters.getClassPath.getPathList.asScala.toList
           val newClassPath = env.classpath ++ oldClasspath
+          javaParameters.getClassPath.clear()
           javaParameters.getClassPath.addAll(newClassPath.asJava)
 
           javaParameters.setWorkingDirectory(env.workdir)


### PR DESCRIPTION
When we fetch classpath items via bspTestEnvironment endpoint, we
concatenate them to the list that is already set by other IntelliJ
components. We don't override it, because they may contain some
extra classes that are required to correcly communicate with
the UI. Nevertheless, the items from BSP are more important and they
should have higher priority (co they need to be placed before all
other ones)