### PR TITLE
Correctly handle ill-formed BSP target's URI

### DIFF
--- a/bsp/src/org/jetbrains/bsp/project/test/environment/BspSelectTargetDialog.scala
+++ b/bsp/src/org/jetbrains/bsp/project/test/environment/BspSelectTargetDialog.scala
@@ -6,7 +6,7 @@ import java.net.URI
 import com.intellij.CommonBundle
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.{ComboBox, DialogWrapper}
-import javax.swing.{JComponent, JLabel, JPanel, SwingConstants}
+import javax.swing.{JComponent, JPanel, SwingConstants}
 import org.jetbrains.bsp.BspBundle
 
 object  BspSelectTargetDialog {
@@ -18,6 +18,20 @@ object  BspSelectTargetDialog {
     }
     result
   }
+
+  implicit class QueryAsMap(uri: URI) {
+    implicit def getQueryAsMap: Map[String, Option[String]] = {
+      uri.getQuery.split("&")
+        .map(_.split("=", 2))
+        .map(item => item(0) -> item.lift(1)).toMap
+    }
+  }
+
+  def visibleNames(targetIds: Seq[URI]): Seq[String] = targetIds.map(visibleName)
+
+  private def visibleName(uri: URI) = {
+    uri.getQueryAsMap.get("id").flatten.getOrElse(uri.toString)
+  }
 }
 class BspSelectTargetDialog(project: Project, targetIds: Seq[URI], selected: Option[URI]) extends DialogWrapper(project, true) {
   setTitle(BspBundle.message("bsp.task.choose.target.title"))
@@ -28,19 +42,12 @@ class BspSelectTargetDialog(project: Project, targetIds: Seq[URI], selected: Opt
 
   def selectedItem: Option[URI] = targetIds.lift(combo.getSelectedIndex)
 
-  def uriQueryToMap(query: String): Map[String, Option[String]] =
-    query.split("&")
-      .map(_.split("=", 2))
-      .map(item => item(0) -> item.lift(1)).toMap
-
-  def visibleNames: Seq[String] = targetIds.flatMap(uri => uriQueryToMap(uri.getQuery).get("id")).toList.flatten
-
   override def createCenterPanel(): JComponent = null
 
   override def createNorthPanel(): JComponent = {
     val selectedIndex = selected.map(targetIds.indexOf(_)).getOrElse(-1)
     combo.setEditable(false)
-    visibleNames.foreach(combo.addItem)
+    BspSelectTargetDialog.visibleNames(targetIds).foreach(combo.addItem)
     combo.setSelectedIndex(selectedIndex)
     combo.setMinimumAndPreferredWidth(Toolkit.getDefaultToolkit.getScreenSize.width / 4)
     val panel = new JPanel(new BorderLayout)

--- a/bsp/test/org/jetbrains/bsp/project/test/environment/BspSelectTargetDialogTest.scala
+++ b/bsp/test/org/jetbrains/bsp/project/test/environment/BspSelectTargetDialogTest.scala
@@ -1,0 +1,32 @@
+package org.jetbrains.bsp.project.test.environment
+
+import java.net.URI
+
+import org.junit.Test
+import org.scalatest.junit.AssertionsForJUnit
+
+class BspSelectTargetDialogTest extends AssertionsForJUnit{
+
+  @Test
+  def visibleNamesForValidUris: Unit = {
+    val uris = List (
+      new URI("file:///home/user/project?id=abc"),
+      new URI("file:///home/user/project?id=def&foo=bar")
+    )
+    assert{
+      BspSelectTargetDialog.visibleNames(uris) == List("abc", "def")
+    }
+  }
+
+  @Test
+  def visibleNameForInvalidUris: Unit = {
+    val uris = List (
+      new URI("file:///home/user/project?id=abc"),
+      new URI("file:///home/user/project?foo=bar") // Missing `id` field
+    )
+    assert{
+      BspSelectTargetDialog.visibleNames(uris) == List("abc", "file:///home/user/project?foo=bar")
+    }
+  }
+
+}


### PR DESCRIPTION
in BspSelectTargetDialog prompt we present allow user to choose BSP
target's URI that will be used by the test runner. We don't present
full URI to the users, but only a shortened, simplified visible name,
that is just the `id` field's value of the URI's query (so for
`file:///tmp/project&id=abc` we present just `abc`.

Previously, in case if any of the target URI's was ill-formed,we would
skip it, because we've been calling `flatten` on a
List[Option[_]]. This could lead to indices-mismatch between targetIds
and visibleNames, and invalid result from `selectedItem` method.

Now, we don't skip anything, if the `id` field cannot be extracted, we
just present the whole URI to the user.