### PR TITLE
Bsp server proxy

### DIFF
--- a/bsp/src/org/jetbrains/bsp/protocol/session/BspSession.scala
+++ b/bsp/src/org/jetbrains/bsp/protocol/session/BspSession.scala
@@ -182,7 +182,7 @@ class BspSession private(bspIn: InputStream,
   }
 
   /**
-   * Some BSP endpoints return `CompletableFuture`s that represend BSP jobs that are
+   * Some BSP endpoints return `CompletableFuture`s that represent BSP jobs that are
    * currently running on BSP server. In order to cancel these, jobs, the `cancel`
    * method of this future should be called. Unfortunately, the original futures that come
    * from lsp4j does not support transformations well - after calling `thenApply`, the `cancel`

--- a/bsp/src/org/jetbrains/bsp/protocol/session/CancellableFuture.scala
+++ b/bsp/src/org/jetbrains/bsp/protocol/session/CancellableFuture.scala
@@ -3,8 +3,8 @@ package org.jetbrains.bsp.protocol.session
 import java.util.concurrent.CompletableFuture
 
 /**
- * JDK's CompletableFutre does not handle cancellation well.
- * When a future does have an overriden `cancel` method, it is lost
+ * JDK's CompletableFuture does not handle cancellation well.
+ * When a future overrides a `cancel` method, it is lost
  * when doing transformations like `thenApply` or `thenCompose`.
  *
  * In Java 9, the new CompletableFuture's method was introduced: `newIncompleteFuture`.

--- a/bsp/src/org/jetbrains/bsp/protocol/session/CancellableFuture.scala
+++ b/bsp/src/org/jetbrains/bsp/protocol/session/CancellableFuture.scala
@@ -1,0 +1,44 @@
+package org.jetbrains.bsp.protocol.session
+
+import java.util.concurrent.CompletableFuture
+
+/**
+ * JDK's CompletableFutre does not handle cancellation well.
+ * When a future does have an overriden `cancel` method, it is lost
+ * when doing transformations like `thenApply` or `thenCompose`.
+ *
+ * In Java 9, the new CompletableFuture's method was introduced: `newIncompleteFuture`.
+ * When using it, the cancel method of the original future will be called event when the
+ * `cancel` is done on a transformed one.
+ *
+ * When we know about CompletableFutures that override `cancel` methods, we should convert them
+ * to CancellableFuture before calling methods like `thenCompose`
+ *
+ * @param original
+ */
+class CancellableFuture[T](original: CompletableFuture[_]) extends CompletableFuture[T] {
+  override def cancel(mayInterruptIfRunning: Boolean): Boolean = {
+    original.cancel(mayInterruptIfRunning)
+    super.cancel(mayInterruptIfRunning)
+  }
+
+  override def newIncompleteFuture[U](): CompletableFuture[U] = {
+    new CancellableFuture(original)
+  }
+}
+
+object CancellableFuture {
+  def from[T](original: CompletableFuture[T]): CancellableFuture[T] = {
+    val result = new CancellableFuture[T](original)
+    original.whenComplete{ (value, error) =>
+      if (error != null) {
+        result.completeExceptionally(error)
+      }
+      else {
+        result.complete(value)
+      }
+      ()
+    }
+    result
+  }
+}

--- a/bsp/src/org/jetbrains/bsp/protocol/session/jobs.scala
+++ b/bsp/src/org/jetbrains/bsp/protocol/session/jobs.scala
@@ -121,7 +121,7 @@ private[session] class Bsp4jJob[T,A](task: BspSessionTask[T],
         runningTask.set(Some(errorFuture))
     }
 
-    promise.failure(error)
+    promise.tryFailure(error)
   }
 }
 


### PR DESCRIPTION
Another approach to workaround lsp4j cancellation issue. This includes:
1. New, more generic, reflection-based solution
2. Reversion commit of the previous fix (as not needed any more)
3. "Promise already completed" fix that appeared after the changes above