### PR TITLE
$outer fields may be inherited

### DIFF
--- a/scala/scala-impl/src/org/jetbrains/plugins/scala/debugger/evaluation/evaluator/ScalaThisEvaluator.scala
+++ b/scala/scala-impl/src/org/jetbrains/plugins/scala/debugger/evaluation/evaluator/ScalaThisEvaluator.scala
@@ -20,7 +20,7 @@ class ScalaThisEvaluator(iterations: Int = 0) extends Evaluator {
     if (objRef == null) {
       return null
     }
-    val list = objRef.referenceType.fields.asScala
+    val list = objRef.referenceType.visibleFields.asScala
     for (field <- list) {
       val name: String = field.name
       if (name != null && name.startsWith("$outer")) {

--- a/scala/scala-impl/test/org/jetbrains/plugins/scala/debugger/evaluateExpression/ScalaThisAndSuperEvaluationTest.scala
+++ b/scala/scala-impl/test/org/jetbrains/plugins/scala/debugger/evaluateExpression/ScalaThisAndSuperEvaluationTest.scala
@@ -254,4 +254,34 @@ class ScalaThisAndSuperEvaluationTestBase extends ScalaDebuggerTestCase {
       evalEquals("foo", "1")
     }
   }
+
+  addFileWithBreakpoints("InnerOuterInheritedOuterFieldEtc.scala",
+    s"""
+       |object InnerOuterInheritedOuterFieldEtc {
+       |  class Outer extends BaseClass {
+       |    class HasOuterField {
+       |      def capture = Outer.this
+       |    }
+       |    class Z extends HasOuterField {
+       |      def goo {
+       |        ""$bp
+       |      }
+       |    }
+       |
+       |    def goo {
+       |      new Z {}.goo
+       |    }
+       |  }
+       |  def main(args: Array[String]) {
+       |    new Outer().goo
+       |  }
+       |}
+      """.stripMargin.trim()
+  )
+  def testInnerOuterInheritedOuterFieldEtc(): Unit = {
+    runDebugger() {
+      waitForBreakpoint()
+      evalEquals("foo", "1")
+    }
+  }
 }


### PR DESCRIPTION
Scalac re-uses the outer field of a base class. Use `visibleFields` to make `this` evalution consider such inherited fields.

(First part of a few debugger improvements (mostly for scala-async) that I'm working towards in https://github.com/retronym/intellij-scala/pull/1)