### PR TITLE
Avoid watching .bloop and .bsp directory for project change

### DIFF
--- a/bsp/src/org/jetbrains/bsp/project/BspExternalSystemManager.scala
+++ b/bsp/src/org/jetbrains/bsp/project/BspExternalSystemManager.scala
@@ -1,8 +1,9 @@
 package org.jetbrains.bsp.project
 
 import java.io.File
-import java.util
+import java.util.{Collections, List => JList, Map => JMap}
 
+import com.google.gson.Gson
 import com.intellij.execution.configurations.SimpleJavaParameters
 import com.intellij.openapi
 import com.intellij.openapi.externalSystem.model.ProjectSystemId
@@ -10,10 +11,14 @@ import com.intellij.openapi.externalSystem.{ExternalSystemAutoImportAware, Exter
 import com.intellij.openapi.fileChooser.FileChooserDescriptor
 import com.intellij.openapi.options.Configurable
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.Key
+import com.intellij.openapi.util.UserDataHolder
+import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.util.Function
 import org.jetbrains.bsp._
 import org.jetbrains.bsp.project.resolver.BspProjectResolver
 import org.jetbrains.bsp.settings._
+import org.jetbrains.bsp.project.BspExternalSystemManager.DetectExternalProjectFiles
 
 import scala.collection.JavaConverters._
 
@@ -42,20 +47,58 @@ class BspExternalSystemManager extends ExternalSystemManager[BspProjectSettings,
   override def enhanceRemoteProcessing(parameters: SimpleJavaParameters): Unit = ()
 
   override def getAffectedExternalProjectPath(changedFileOrDirPath: String, project: Project): String = {
-    val file = new File(changedFileOrDirPath)
-    val isConfigFile = (BspUtil.isBspConfigFile(file) || BspUtil.isBloopConfigFile(file)) &&
-      BspUtil.workspaces(project).contains(file.getParentFile.toPath)
+    if (detectExternalProjectFiles(project)) {
+      val file = new File(changedFileOrDirPath)
+      val isConfigFile = (BspUtil.isBspConfigFile(file) || BspUtil.isBloopConfigFile(file)) &&
+        BspUtil.workspaces(project).contains(file.getParentFile.toPath)
 
-    if (isConfigFile) file.getParentFile.getAbsolutePath
-    else null
+      if (isConfigFile) file.getParentFile.getAbsolutePath
+      else null
+    } else null
   }
 
-  override def getAffectedExternalProjectFiles(projectPath: String, project: Project): util.List[File] = {
-    val workspace = new File(projectPath)
-    val bspConfigs = BspUtil.bspConfigFiles(workspace)
-    val bloopConfigs = BspUtil.bloopConfigDir(workspace).toList
-      .flatMap(_.listFiles(file => file.getName.endsWith(".json")).toList)
+  override def getAffectedExternalProjectFiles(projectPath: String, project: Project): JList[File] = {
+    if (detectExternalProjectFiles(project)) {
+      val workspace = new File(projectPath)
+      val bspConfigs = BspUtil.bspConfigFiles(workspace)
+      val bloopConfigs = BspUtil.bloopConfigDir(workspace).toList
+        .flatMap(_.listFiles(file => file.getName.endsWith(".json")).toList)
 
-    (bspConfigs ++ bloopConfigs).asJava
+      (bspConfigs ++ bloopConfigs).asJava
+    } else {
+      Collections.emptyList()
+    }
   }
+
+  private def detectExternalProjectFiles(project: Project): Boolean = {
+    cached(DetectExternalProjectFiles, project) {
+      if (BspUtil.isBspProject(project)) {
+        val workspace = new File(project.getBasePath)
+        val files = BspUtil.bspConfigFiles(workspace)
+        files.forall { file =>
+          val bspConnectionDetails = parseAsMap(file)
+          !bspConnectionDetails.get("X-detectExternalProjectFiles").contains(false)
+        }
+      } else true
+    }
+  }
+
+  private def parseAsMap(file: File): Map[String, Any] = {
+    val virtualFile = LocalFileSystem.getInstance.findFileByIoFile(file)
+    val content = new String(virtualFile.contentsToByteArray())
+    new Gson().fromJson(content, classOf[JMap[String, _]]).asScala.toMap
+  }
+
+  private def cached[A](key: Key[A], holder: UserDataHolder)(compute: => A): A = {
+    Option(holder.getUserData(key)).getOrElse {
+      val computed = compute
+      holder.putUserData(key, computed)
+      computed
+    }
+  }
+
+}
+
+object BspExternalSystemManager {
+  val DetectExternalProjectFiles: Key[Boolean] = Key.create[Boolean]("BSP.detectExternalProjectFiles")
 }


### PR DESCRIPTION
When these files are watched it causes automatic project refresh on each startup of Intellij. Also always brings in a floating refresh project button that is confusing.