### PR TITLE
Remove noisy library data message for bsp dependencies

### DIFF
--- a/bsp/resources/META-INF/BSP.xml
+++ b/bsp/resources/META-INF/BSP.xml
@@ -4,9 +4,11 @@
     <depends optional="true" config-file="BSP-JUnit.xml">JUnit</depends>
     <extensionPoints>
         <extensionPoint qualifiedName="com.intellij.bspEnvironmentRunnerExtension"
-                        interface="org.jetbrains.bsp.project.test.environment.BspEnvironmentRunnerExtension"/>
+                        interface="org.jetbrains.bsp.project.test.environment.BspEnvironmentRunnerExtension"
+                        dynamic="true"/>
         <extensionPoint qualifiedName="com.intellij.bspResolverNamingExtension"
-                        interface="org.jetbrains.bsp.project.resolver.BspResolverNamingExtension"/>
+                        interface="org.jetbrains.bsp.project.resolver.BspResolverNamingExtension"
+                        dynamic="true"/>
     </extensionPoints>
 
     <extensions defaultExtensionNs="com.intellij">

--- a/bsp/resources/META-INF/BSP.xml
+++ b/bsp/resources/META-INF/BSP.xml
@@ -5,6 +5,8 @@
     <extensionPoints>
         <extensionPoint qualifiedName="com.intellij.bspEnvironmentRunnerExtension"
                         interface="org.jetbrains.bsp.project.test.environment.BspEnvironmentRunnerExtension"/>
+        <extensionPoint qualifiedName="com.intellij.bspResolverNamingExtension"
+                        interface="org.jetbrains.bsp.project.resolver.BspResolverNamingExtension"/>
     </extensionPoints>
 
     <extensions defaultExtensionNs="com.intellij">

--- a/bsp/src/org/jetbrains/bsp/project/resolver/BspResolverDescriptors.scala
+++ b/bsp/src/org/jetbrains/bsp/project/resolver/BspResolverDescriptors.scala
@@ -9,51 +9,51 @@ import org.jetbrains.bsp.data.{SbtBuildModuleDataBsp, ScalaSdkData}
 import scala.util.Try
 
 
-private[resolver] object BspResolverDescriptors {
+object BspResolverDescriptors {
 
-  private[resolver] type TestClassId = String
+  type TestClassId = String
 
-  private[resolver] case class ModuleDescription(data: ModuleDescriptionData,
-                                                 moduleKindData: ModuleKind)
+  case class ModuleDescription(data: ModuleDescriptionData,
+                               moduleKindData: ModuleKind)
 
-  private[resolver] case class ModuleDescriptionData(id: String,
-                                                     name: String,
-                                                     targets: Seq[BuildTarget],
-                                                     targetDependencies: Seq[BuildTargetIdentifier],
-                                                     targetTestDependencies: Seq[BuildTargetIdentifier],
-                                                     basePath: Option[File],
-                                                     output: Option[File],
-                                                     testOutput: Option[File],
-                                                     sourceDirs: Seq[SourceDirectory],
-                                                     testSourceDirs: Seq[SourceDirectory],
-                                                     resourceDirs: Seq[SourceDirectory],
-                                                     testResourceDirs: Seq[SourceDirectory],
-                                                     classpath: Seq[File],
-                                                     classpathSources: Seq[File],
-                                                     testClasspath: Seq[File],
-                                                     testClasspathSources: Seq[File])
+  case class ModuleDescriptionData(id: String,
+                                   name: String,
+                                   targets: Seq[BuildTarget],
+                                   targetDependencies: Seq[BuildTargetIdentifier],
+                                   targetTestDependencies: Seq[BuildTargetIdentifier],
+                                   basePath: Option[File],
+                                   output: Option[File],
+                                   testOutput: Option[File],
+                                   sourceDirs: Seq[SourceDirectory],
+                                   testSourceDirs: Seq[SourceDirectory],
+                                   resourceDirs: Seq[SourceDirectory],
+                                   testResourceDirs: Seq[SourceDirectory],
+                                   classpath: Seq[File],
+                                   classpathSources: Seq[File],
+                                   testClasspath: Seq[File],
+                                   testClasspathSources: Seq[File])
 
-  private[resolver] case class ProjectModules(modules: Seq[ModuleDescription], synthetic: Seq[ModuleDescription])
+  case class ProjectModules(modules: Seq[ModuleDescription], synthetic: Seq[ModuleDescription])
 
-  private[resolver] sealed abstract class ModuleKind
+  sealed abstract class ModuleKind
 
-  private[resolver] case class UnspecifiedModule() extends ModuleKind
-  private[resolver] case class JvmModule(jdkData: JdkData) extends ModuleKind
-  private[resolver] case class ScalaModule(jdkData: JdkData,
-                                           scalaSdkData: ScalaSdkData
-                                          ) extends ModuleKind
+  case class UnspecifiedModule() extends ModuleKind
+  case class JvmModule(jdkData: JdkData) extends ModuleKind
+  case class ScalaModule(jdkData: JdkData,
+                         scalaSdkData: ScalaSdkData
+                        ) extends ModuleKind
 
-  private[resolver] case class SbtModule(jdkData: JdkData,
-                                         scalaSdkData: ScalaSdkData,
-                                         sbtData: SbtBuildModuleDataBsp
-                                        ) extends ModuleKind
+  case class SbtModule(jdkData: JdkData,
+                       scalaSdkData: ScalaSdkData,
+                       sbtData: SbtBuildModuleDataBsp
+                      ) extends ModuleKind
 
-  private[resolver] case class TargetData(sources: Try[SourcesResult],
-                                          dependencySources: Try[DependencySourcesResult],
-                                          resources: Try[ResourcesResult],
-                                          scalacOptions: Try[ScalacOptionsResult] // TODO should be optional
-                                         )
+  case class TargetData(sources: Try[SourcesResult],
+                        dependencySources: Try[DependencySourcesResult],
+                        resources: Try[ResourcesResult],
+                        scalacOptions: Try[ScalacOptionsResult] // TODO should be optional
+                       )
 
-  private[resolver] case class SourceDirectory(directory: File, generated: Boolean, packagePrefix: Option[String])
+  case class SourceDirectory(directory: File, generated: Boolean, packagePrefix: Option[String])
 
 }

--- a/bsp/src/org/jetbrains/bsp/project/resolver/BspResolverLogic.scala
+++ b/bsp/src/org/jetbrains/bsp/project/resolver/BspResolverLogic.scala
@@ -544,7 +544,10 @@ private[resolver] object BspResolverLogic {
 
     moduleData.setInheritProjectCompileOutputPath(false)
 
-    val libraryData = new LibraryData(BSP.ProjectSystemId, BspBundle.message("bsp.resolver.modulename.dependencies", moduleName))
+    val libraryDataName =
+      BspResolverNamingExtension.libraryData(moduleDescription)
+        .getOrElse(BspBundle.message("bsp.resolver.modulename.dependencies", moduleName))
+    val libraryData = new LibraryData(BSP.ProjectSystemId, libraryDataName)
     moduleDescriptionData.classpath.foreach { path =>
       libraryData.addPath(LibraryPathType.BINARY, path.getCanonicalPath)
     }
@@ -554,7 +557,10 @@ private[resolver] object BspResolverLogic {
     val libraryDependencyData = new LibraryDependencyData(moduleData, libraryData, LibraryLevel.MODULE)
     libraryDependencyData.setScope(DependencyScope.COMPILE)
 
-    val libraryTestData = new LibraryData(BSP.ProjectSystemId, BspBundle.message("bsp.resolver.modulename.test.dependencies", moduleName))
+    val libraryTestDataName =
+      BspResolverNamingExtension.libraryTestData(moduleDescription)
+        .getOrElse(BspBundle.message("bsp.resolver.modulename.test.dependencies", moduleName))
+    val libraryTestData = new LibraryData(BSP.ProjectSystemId, libraryTestDataName)
     moduleDescriptionData.testClasspath.foreach { path =>
       libraryTestData.addPath(LibraryPathType.BINARY, path.getCanonicalPath)
     }

--- a/bsp/src/org/jetbrains/bsp/project/resolver/BspResolverNamingExtension.scala
+++ b/bsp/src/org/jetbrains/bsp/project/resolver/BspResolverNamingExtension.scala
@@ -1,0 +1,28 @@
+package org.jetbrains.bsp.project.resolver
+
+import com.intellij.openapi.extensions.ExtensionPointName
+import org.jetbrains.bsp.project.resolver.BspResolverDescriptors.ModuleDescription
+
+trait BspResolverNamingExtension {
+  def libraryData(moduleDescription: ModuleDescription): Option[String]
+
+  def libraryTestData(moduleDescription: ModuleDescription): Option[String]
+}
+
+object BspResolverNamingExtension {
+  val EP_NAME =
+    ExtensionPointName.create[BspResolverNamingExtension]("com.intellij.bspResolverNamingExtension")
+
+  def libraryData(moduleDescription: ModuleDescription): Option[String] = {
+    get(_.libraryData(moduleDescription))
+  }
+
+  def libraryTestData(moduleDescription: ModuleDescription): Option[String] = {
+    get(_.libraryTestData(moduleDescription))
+  }
+
+  private def get(apply: BspResolverNamingExtension => Option[String]): Option[String] = {
+    EP_NAME.getExtensions.iterator.map(apply).collectFirst { case Some(r) => r }
+  }
+
+}

--- a/bsp/src/org/jetbrains/bsp/project/resolver/BspResolverNamingExtension.scala
+++ b/bsp/src/org/jetbrains/bsp/project/resolver/BspResolverNamingExtension.scala
@@ -3,6 +3,12 @@ package org.jetbrains.bsp.project.resolver
 import com.intellij.openapi.extensions.ExtensionPointName
 import org.jetbrains.bsp.project.resolver.BspResolverDescriptors.ModuleDescription
 
+/**
+ * This extension allows to customize names created during BSP project import/refresh.
+ * These names are displayed in class search window, as well as used to group
+ * libraries under External Libraries node in project view.
+ * You may for example use it to apply custom shortening logic for long names.
+ **/
 trait BspResolverNamingExtension {
   def libraryData(moduleDescription: ModuleDescription): Option[String]
 


### PR DESCRIPTION
Currently when looking for class there is this noisy `bsp: bsp test dependencies (<jar name>)` text near each class. This PR changes the extra text to empty string which results in simply `<jar name>` being shown without any extra noise.

![Screenshot 2020-04-06 at 17 55 29](https://user-images.githubusercontent.com/1408093/78589519-d88aea00-782f-11ea-9ea4-fe55b13ffe17.png)