### PR TITLE
Add support for newtype library

### DIFF
--- a/scala/scala-impl/resources/META-INF/scala-plugin-common.xml
+++ b/scala/scala-impl/resources/META-INF/scala-plugin-common.xml
@@ -32,6 +32,7 @@
         <syntheticMemberInjector implementation="org.jetbrains.plugins.scala.lang.psi.impl.toplevel.typedef.CirceCodecInjector"/>
         <syntheticMemberInjector implementation="scala.meta.intellij.MetaSupportInjector"/>
         <syntheticMemberInjector implementation="org.jetbrains.plugins.scala.lang.psi.impl.toplevel.typedef.QuasiQuotesInjector"/>
+        <syntheticMemberInjector implementation="org.jetbrains.plugins.scala.lang.psi.impl.toplevel.typedef.NewTypeInjector"/>
         <syntheticMemberInjector implementation="org.jetbrains.plugins.scala.lang.psi.impl.toplevel.typedef.simulacrum.SimulacrumInjector"/>
 
         <genericTypeNamesProvider

--- a/scala/scala-impl/src/org/jetbrains/plugins/scala/lang/psi/impl/toplevel/typedef/NewTypeInjector.scala
+++ b/scala/scala-impl/src/org/jetbrains/plugins/scala/lang/psi/impl/toplevel/typedef/NewTypeInjector.scala
@@ -1,0 +1,68 @@
+package org.jetbrains.plugins.scala.lang.psi.impl
+package toplevel
+package typedef
+
+import org.jetbrains.plugins.scala.lang.psi.api.toplevel.typedef.{ScClass, ScObject, ScTypeDefinition}
+import org.jetbrains.plugins.scala.lang.psi.types.{ScParameterizedType, ScType}
+
+class NewTypeInjector extends SyntheticMembersInjector {
+
+  import NewTypeInjector._
+
+  override def injectFunctions(source: ScTypeDefinition): Seq[String] = {
+    val companionClass = source match {
+      case obj: ScObject => obj.fakeCompanionClassOrCompanionClass
+      case _ => null
+    }
+
+    companionClass match {
+      case clazz: ScClass if isNewType(clazz) =>
+        mkCompanionMembers(clazz)
+      case _ => Nil
+    }
+  }
+}
+
+object NewTypeInjector {
+
+  private def isNewType(clazz: ScClass): Boolean = {
+    clazz.findAnnotationNoAliases("_root_.io.estatico.newtype.macros.newtype") != null ||
+      clazz.findAnnotationNoAliases("_root_.io.estatico.newtype.macros.newsubtype") != null
+  }
+
+  private def mkCompanionMembers(clazz: ScClass): Seq[String] = clazz.parameters.headOption.flatMap(_.`type`().toOption).map { reprType =>
+    val (reprName, hasDifferentShape) = reprType match {
+      case pt: ScParameterizedType => pt.designator.canonicalText -> (pt.typeArguments.map(_.canonicalText) != clazz.typeParameters.map(_.getName))
+      case t => t.canonicalText -> clazz.typeParameters.nonEmpty
+    }
+
+    val fullReprName = reprType.canonicalText
+    val typeParams = clazz.typeParameters.map(_.typeParameterText)
+
+    val isHigherKinded = typeParams.nonEmpty
+    val declareTypeParams = if (isHigherKinded) typeParams.mkString(",", ",", "") else ""
+    val appliedTypeParams = if (isHigherKinded) typeParams.map(_.replaceAll("\\[.*\\]", "")).mkString("[", ",", "]") else ""
+    val shape = if (isHigherKinded) typeParams.map(_.replaceAll("\\w+", "_")).mkString("[", ",", "]") else ""
+    val className = clazz.getName
+
+    val deriving = List(s"def deriving[TC[_]$declareTypeParams](implicit ev: TC[$fullReprName]): TC[$className$appliedTypeParams] = ???")
+    val derivingK = if (isHigherKinded && !hasDifferentShape) List(s"def derivingK[TC[_$shape]](implicit ev: TC[$reprName]): TC[$className] = ???") else Nil
+
+    val coercibles = List(
+      s"implicit def unsafeWrap$appliedTypeParams: _root_.io.estatico.newtype.Coercible[$fullReprName, $className$appliedTypeParams] = ???",
+      s"implicit def unsafeUnwrap$appliedTypeParams: _root_.io.estatico.newtype.Coercible[$className$appliedTypeParams, $fullReprName] = ???",
+      s"implicit def unsafeWrapM[M[_]$declareTypeParams]: _root_.io.estatico.newtype.Coercible[M[$fullReprName], M[$className$appliedTypeParams]] = ???",
+      s"implicit def unsafeUnwrapM[M[_]$declareTypeParams]: _root_.io.estatico.newtype.Coercible[M[$className$appliedTypeParams], M[$fullReprName]] = ???",
+      s"implicit def cannotWrapArrayAmbiguous1$appliedTypeParams: _root_.io.estatico.newtype.Coercible[_root_.scala.Array[$fullReprName], _root_.scala.Array[$className$appliedTypeParams]] = ???",
+      s"implicit def cannotWrapArrayAmbiguous2$appliedTypeParams: _root_.io.estatico.newtype.Coercible[_root_.scala.Array[$fullReprName], _root_.scala.Array[$className$appliedTypeParams]] = ???",
+      s"implicit def cannotUnwrapArrayAmbiguous1$appliedTypeParams: _root_.io.estatico.newtype.Coercible[_root_.scala.Array[$className$appliedTypeParams], _root_.scala.Array[$fullReprName]] = ???",
+      s"implicit def cannotUnwrapArrayAmbiguous2$appliedTypeParams: _root_.io.estatico.newtype.Coercible[_root_.scala.Array[$className$appliedTypeParams], _root_.scala.Array[$fullReprName]] = ???"
+    )
+    val coerciblesK = if (isHigherKinded && !hasDifferentShape) List(
+      s"implicit def unsafeWrapK[T[_$appliedTypeParams]]: _root_.io.estatico.newtype.Coercible[T[$reprName], T[$className]] = ???",
+      s"implicit def unsafeUnwrapK[T[_$appliedTypeParams]]: _root_.io.estatico.newtype.Coercible[T[$className], T[$reprName]] = ???",
+    ) else Nil
+
+    deriving ++ derivingK ++ coercibles ++ coerciblesK
+  }.getOrElse(Nil)
+}

--- a/scala/scala-impl/test/org/jetbrains/plugins/scala/lang/macros/NewTypeTest.scala
+++ b/scala/scala-impl/test/org/jetbrains/plugins/scala/lang/macros/NewTypeTest.scala
@@ -1,0 +1,210 @@
+package org.jetbrains.plugins.scala
+package lang
+package macros
+
+import com.intellij.psi.util.PsiTreeUtil
+import org.jetbrains.plugins.scala.DependencyManagerBase._
+import org.jetbrains.plugins.scala.base.ScalaLightCodeInsightFixtureTestAdapter
+import org.jetbrains.plugins.scala.base.ScalaLightCodeInsightFixtureTestAdapter._
+import org.jetbrains.plugins.scala.base.libraryLoaders.{IvyManagedLoader, LibraryLoader}
+import org.jetbrains.plugins.scala.lang.macros.SynteticInjectorsTestUtils._
+import org.jetbrains.plugins.scala.lang.psi.api.toplevel.typedef.{ScObject, ScTypeDefinition}
+
+class NewTypeTest extends ScalaLightCodeInsightFixtureTestAdapter {
+
+  override def librariesLoaders: Seq[LibraryLoader] =
+    super.librariesLoaders :+ IvyManagedLoader("io.estatico" %% "newtype" % "0.4.3")
+
+  private def getSourceElement(text: String): ScObject = {
+    val normalized = normalize(text)
+    val caretPos = normalized.indexOf("<caret>")
+    val file = configureFromFileText(normalized.replace("<caret>", ""))
+    val cls = PsiTreeUtil.findElementOfClassAtOffset(file, caretPos, classOf[ScTypeDefinition], false)
+    cls.fakeCompanionModule.getOrElse(
+      throw new IllegalArgumentException(s"Companion object not found for class at caret in $text.")
+    )
+  }
+
+  def testSimpleType(): Unit = {
+    val text =
+      s"""
+         |import _root_.io.estatico.newtype.macros.newtype
+         |
+         |package object types {
+         |  @newtype <caret>case class WidgetId(toInt: Int)
+         |}
+       """.stripMargin
+
+    val widgetIdObject = getSourceElement(text)
+
+    val syntheticStructure =
+      `object`("WidgetId")(
+        `def`("deriving", "[TC] TC[Int] => TC[types.WidgetId]"),
+        `implicit`("unsafeWrap", "_root_.io.estatico.newtype.Coercible[Int, types.WidgetId]"),
+        `implicit`("unsafeUnwrap", "_root_.io.estatico.newtype.Coercible[types.WidgetId, Int]"),
+        `implicit`("unsafeWrapM", "[M] Coercible[M[Int], M[types.WidgetId]]"),
+        `implicit`("unsafeUnwrapM", "[M] Coercible[M[types.WidgetId], M[Int]]"),
+        `implicit`("cannotWrapArrayAmbiguous1", "_root_.io.estatico.newtype.Coercible[_root_.scala.Array[Int], _root_.scala.Array[types.WidgetId]]"),
+        `implicit`("cannotWrapArrayAmbiguous2", "_root_.io.estatico.newtype.Coercible[_root_.scala.Array[Int], _root_.scala.Array[types.WidgetId]]"),
+        `implicit`("cannotUnwrapArrayAmbiguous1", "_root_.io.estatico.newtype.Coercible[_root_.scala.Array[types.WidgetId], _root_.scala.Array[Int]]"),
+        `implicit`("cannotUnwrapArrayAmbiguous2", "_root_.io.estatico.newtype.Coercible[_root_.scala.Array[types.WidgetId], _root_.scala.Array[Int]]")
+      )
+
+    widgetIdObject mustBeLike syntheticStructure
+  }
+
+  def testHKT1(): Unit = {
+    val text =
+      s"""
+         |import _root_.io.estatico.newtype.macros.newtype
+         |
+         |package object types {
+         |  @newtype <caret>case class Maybe[A](toOption: Option[A])
+         |}
+       """.stripMargin
+
+    val maybeObject = getSourceElement(text)
+
+    val syntheticStructure =
+      `object`("Maybe")(
+        `def`("deriving", "[TC, A] TC[Option[A]] => TC[types.Maybe[A]]"),
+        `def`("derivingK", "[TC] TC[Option] => TC[types.Maybe]"),
+        `implicit`("unsafeWrap", "[A] Coercible[Option[A], types.Maybe[A]]"),
+        `implicit`("unsafeUnwrap", "[A] Coercible[types.Maybe[A], Option[A]]"),
+        `implicit`("unsafeWrapM", "[M, A] Coercible[M[Option[A]], M[types.Maybe[A]]]"),
+        `implicit`("unsafeUnwrapM", "[M, A] Coercible[M[types.Maybe[A]], M[Option[A]]]"),
+        `implicit`("unsafeWrapK", "[T] Coercible[T[Option], T[types.Maybe]]"),
+        `implicit`("unsafeUnwrapK", "[T] Coercible[T[types.Maybe], T[Option]]"),
+        `implicit`("cannotWrapArrayAmbiguous1", "[A] Coercible[Array[Option[A]], Array[types.Maybe[A]]]"),
+        `implicit`("cannotWrapArrayAmbiguous2", "[A] Coercible[Array[Option[A]], Array[types.Maybe[A]]]"),
+        `implicit`("cannotUnwrapArrayAmbiguous1", "[A] Coercible[Array[types.Maybe[A]], Array[Option[A]]]"),
+        `implicit`("cannotUnwrapArrayAmbiguous2", "[A] Coercible[Array[types.Maybe[A]], Array[Option[A]]]")
+      )
+
+    maybeObject mustBeLike syntheticStructure
+  }
+
+  def testHKT2(): Unit = {
+    val text =
+      s"""
+         |import _root_.io.estatico.newtype.macros.newtype
+         |
+         |package object types {
+         |  @newtype <caret>case class Branch[A, B](toEither: Either[A, B])
+         |}
+       """.stripMargin
+
+    val branchObject = getSourceElement(text)
+
+    val syntheticStructure =
+      `object`("Branch")(
+        `def`("deriving", "[TC, A, B] TC[Either[A, B]] => TC[types.Branch[A, B]]"),
+        `def`("derivingK", "[TC] TC[Either] => TC[types.Branch]"),
+        `implicit`("unsafeWrap", "[A, B] Coercible[Either[A, B], types.Branch[A, B]]"),
+        `implicit`("unsafeUnwrap", "[A, B] Coercible[types.Branch[A, B], Either[A, B]]"),
+        `implicit`("unsafeWrapM", "[M, A, B] Coercible[M[Either[A, B]], M[types.Branch[A, B]]]"),
+        `implicit`("unsafeUnwrapM", "[M, A, B] Coercible[M[types.Branch[A, B]], M[Either[A, B]]]"),
+        `implicit`("unsafeWrapK", "[T] Coercible[T[Either], T[types.Branch]]"),
+        `implicit`("unsafeUnwrapK", "[T] Coercible[T[types.Branch], T[Either]]"),
+        `implicit`("cannotWrapArrayAmbiguous1", "[A, B] Coercible[Array[Either[A, B]], Array[types.Branch[A, B]]]"),
+        `implicit`("cannotWrapArrayAmbiguous2", "[A, B] Coercible[Array[Either[A, B]], Array[types.Branch[A, B]]]"),
+        `implicit`("cannotUnwrapArrayAmbiguous1", "[A, B] Coercible[Array[types.Branch[A, B]], Array[Either[A, B]]]"),
+        `implicit`("cannotUnwrapArrayAmbiguous2", "[A, B] Coercible[Array[types.Branch[A, B]], Array[Either[A, B]]]")
+      )
+
+    branchObject mustBeLike syntheticStructure
+  }
+
+  def testHKTWithHKTParam(): Unit = {
+    val text =
+      s"""
+         |import _root_.io.estatico.newtype.macros.newtype
+         |
+         |package object types {
+         |  trait Functor[F[_]]
+         |  @newtype <caret>case class HKTWrapper[F[_]](fun: Functor[F])
+         |}
+       """.stripMargin
+
+    val branchObject = getSourceElement(text)
+
+    val syntheticStructure =
+      `object`("HKTWrapper")(
+        `def`("deriving", "[TC, F] TC[types.Functor[F]] => TC[types.HKTWrapper[F]]"),
+        `def`("derivingK", "[TC] TC[types.Functor] => TC[types.HKTWrapper]"),
+        `implicit`("unsafeWrap", "[F] Coercible[types.Functor[F], types.HKTWrapper[F]]"),
+        `implicit`("unsafeUnwrap", "[F] Coercible[types.HKTWrapper[F], types.Functor[F]]"),
+        `implicit`("unsafeWrapM", "[M, F] Coercible[M[types.Functor[F]], M[types.HKTWrapper[F]]]"),
+        `implicit`("unsafeUnwrapM", "[M, F] Coercible[M[types.HKTWrapper[F]], M[types.Functor[F]]]"),
+        `implicit`("unsafeWrapK", "[T] Coercible[T[types.Functor], T[types.HKTWrapper]]"),
+        `implicit`("unsafeUnwrapK", "[T] Coercible[T[types.HKTWrapper], T[types.Functor]]"),
+        `implicit`("cannotWrapArrayAmbiguous1", "[F] Coercible[Array[types.Functor[F]], Array[types.HKTWrapper[F]]]"),
+        `implicit`("cannotWrapArrayAmbiguous2", "[F] Coercible[Array[types.Functor[F]], Array[types.HKTWrapper[F]]]"),
+        `implicit`("cannotUnwrapArrayAmbiguous1", "[F] Coercible[Array[types.HKTWrapper[F]], Array[types.Functor[F]]]"),
+        `implicit`("cannotUnwrapArrayAmbiguous2", "[F] Coercible[Array[types.HKTWrapper[F]], Array[types.Functor[F]]]")
+      )
+
+    branchObject mustBeLike syntheticStructure
+  }
+
+  def testHKTWithHKTParamAndOthers(): Unit = {
+    val text =
+      s"""
+         |import _root_.io.estatico.newtype.macros.newtype
+         |
+         |package object types {
+         |  trait ConstK[F[_], A]
+         |  @newtype <caret>case class HKTPlusWrapper[F[_], A](fun: ConstK[F, A])
+         |}
+       """.stripMargin
+
+    val branchObject = getSourceElement(text)
+
+    val syntheticStructure =
+      `object`("HKTPlusWrapper")(
+        `def`("deriving", "[TC, F, A] TC[types.ConstK[F, A]] => TC[types.HKTPlusWrapper[F, A]]"),
+        `def`("derivingK", "[TC] TC[types.ConstK] => TC[types.HKTPlusWrapper]"),
+        `implicit`("unsafeWrap", "[F, A] Coercible[types.ConstK[F, A], types.HKTPlusWrapper[F, A]]"),
+        `implicit`("unsafeUnwrap", "[F, A] Coercible[types.HKTPlusWrapper[F, A], types.ConstK[F, A]]"),
+        `implicit`("unsafeWrapM", "[M, F, A] Coercible[M[types.ConstK[F, A]], M[types.HKTPlusWrapper[F, A]]]"),
+        `implicit`("unsafeUnwrapM", "[M, F, A] Coercible[M[types.HKTPlusWrapper[F, A]], M[types.ConstK[F, A]]]"),
+        `implicit`("unsafeWrapK", "[T] Coercible[T[types.ConstK], T[types.HKTPlusWrapper]]"),
+        `implicit`("unsafeUnwrapK", "[T] Coercible[T[types.HKTPlusWrapper], T[types.ConstK]]"),
+        `implicit`("cannotWrapArrayAmbiguous1", "[F, A] Coercible[Array[types.ConstK[F, A]], Array[types.HKTPlusWrapper[F, A]]]"),
+        `implicit`("cannotWrapArrayAmbiguous2", "[F, A] Coercible[Array[types.ConstK[F, A]], Array[types.HKTPlusWrapper[F, A]]]"),
+        `implicit`("cannotUnwrapArrayAmbiguous1", "[F, A] Coercible[Array[types.HKTPlusWrapper[F, A]], Array[types.ConstK[F, A]]]"),
+        `implicit`("cannotUnwrapArrayAmbiguous2", "[F, A] Coercible[Array[types.HKTPlusWrapper[F, A]], Array[types.ConstK[F, A]]]")
+      )
+
+    branchObject mustBeLike syntheticStructure
+  }
+
+  def testDifferentShapedHKT(): Unit = {
+    val text =
+      s"""
+         |import _root_.io.estatico.newtype.macros.newtype
+         |
+         |package object types {
+         |  @newtype <caret>case class EitherT[F[_], L, R](x: F[Either[L, R]])
+         |}
+       """.stripMargin
+
+    val eitherTObject = getSourceElement(text)
+
+    val syntheticStructure =
+      `object`("EitherT")(
+        `def`("deriving", "[TC, F, L, R] TC[F[Either[L, R]]] => TC[types.EitherT[F, L, R]]"),
+        // TODO: Add derivingK, unsafeWrapK and unsafeUnwrapK when it is possible to specify their types properly
+        `implicit`("unsafeWrap", "[F, L, R] Coercible[F[Either[L, R]], types.EitherT[F, L, R]]"),
+        `implicit`("unsafeUnwrap", "[F, L, R] Coercible[types.EitherT[F, L, R], F[Either[L, R]]]"),
+        `implicit`("unsafeWrapM", "[M, F, L, R] Coercible[M[F[Either[L, R]]], M[types.EitherT[F, L, R]]]"),
+        `implicit`("unsafeUnwrapM", "[M, F, L, R] Coercible[M[types.EitherT[F, L, R]], M[F[Either[L, R]]]]"),
+        `implicit`("cannotWrapArrayAmbiguous1", "[F, L, R] Coercible[Array[F[Either[L, R]]], Array[types.EitherT[F, L, R]]]"),
+        `implicit`("cannotWrapArrayAmbiguous2", "[F, L, R] Coercible[Array[F[Either[L, R]]], Array[types.EitherT[F, L, R]]]"),
+        `implicit`("cannotUnwrapArrayAmbiguous1", "[F, L, R] Coercible[Array[types.EitherT[F, L, R]], Array[F[Either[L, R]]]]"),
+        `implicit`("cannotUnwrapArrayAmbiguous2", "[F, L, R] Coercible[Array[types.EitherT[F, L, R]], Array[F[Either[L, R]]]]")
+      )
+
+    eitherTObject mustBeLike syntheticStructure
+  }
+}


### PR DESCRIPTION
Support for https://github.com/estatico/scala-newtype, a somewhat popular library for doing newtyping in Scala.

Details: Add injections for @newtype and @newsubtype, declaring the macro-generated implicits and derivation methods in the companion object to avoid IntelliJ to show errors for their usage. Includes tests for different kinds.