### PR TITLE
Detect VCS root on bsp project import

### DIFF
--- a/bsp/src/org/jetbrains/bsp/data/dataObjects.scala
+++ b/bsp/src/org/jetbrains/bsp/data/dataObjects.scala
@@ -37,11 +37,15 @@ object BspEntityData {
 }
 
 @SerialVersionUID(1)
-case class BspProjectData @PropertyMapping(Array("jdk")) private (@Nullable jdk: SdkReference) extends BspEntityData
+case class BspProjectData @PropertyMapping(Array("jdk", "vcsRootsCandidates")) private (
+  @Nullable jdk: SdkReference,
+  @NotNull vcsRootsCandidates: util.List[File]
+) extends BspEntityData
 
 object BspProjectData {
   val Key: Key[BspProjectData] = datakey(classOf[BspProjectData], weight = ProjectKeys.PROJECT.getProcessingWeight +  1)
-  def apply(sdk: Option[SdkReference]): BspProjectData = BspProjectData(sdk.orNull)
+  def apply(sdk: Option[SdkReference], vcsRootsCandidates: util.List[File]): BspProjectData =
+    BspProjectData(sdk.orNull, vcsRootsCandidates)
 }
 
 

--- a/bsp/src/org/jetbrains/bsp/project/resolver/BspResolverLogic.scala
+++ b/bsp/src/org/jetbrains/bsp/project/resolver/BspResolverLogic.scala
@@ -458,7 +458,8 @@ private[resolver] object BspResolverLogic {
 
     val bspProjectData = {
       val jdkReference = inferProjectJdk(modules)
-      new DataNode[BspProjectData](BspProjectData.Key, BspProjectData(jdkReference), projectNode)
+      val vcsRootsCandidates = projectModules.modules.flatMap(_.data.basePath).distinct
+      new DataNode[BspProjectData](BspProjectData.Key, BspProjectData(jdkReference, vcsRootsCandidates.asJava), projectNode)
     }
 
     // effects


### PR DESCRIPTION
Fastpass creates bsp project root in different directory than repo root, hence repository auto detection mechanism fails to find actual repository (it detects based on project.basePath).

I am not sure if this is the correct place to do it (any suggestions welcome). I implemented logic to select a non root module as base for vcs root lookup, and then later I use auto detect mechanism on it and add found root.