### PR TITLE
Fix link to Scalastyle website

### DIFF
--- a/scala/scala-impl/resources/inspectionDescriptions/ScalaStyle.html
+++ b/scala/scala-impl/resources/inspectionDescriptions/ScalaStyle.html
@@ -5,6 +5,6 @@ Scalastyle examines your Scala code and indicates potential problems with it.
 Place the config file in <code>&lt;root&gt;</code> or <code>&lt;root&gt;/.idea</code> or <code>&lt;root&gt;/project</code> directory.
 <br/>Config file name can be <code>scalastyle-config.xml</code> or <code>scalastyle_config.xml</code>. Configs for test sources can be overridden by <code>scalastyle-test-config.xml</code> or <code>scalastyle_test_config.xml</code>.
 <br><br>
-Full documentation is available on the <a href="https://www.scalastyle.org/">Scalastyle website</a>.
+Full documentation is available on the <a href="http://www.scalastyle.org/">Scalastyle website</a>.
 </body>
 </html>


### PR DESCRIPTION
The inspection description for Scalastyle links to https://www.scalastyle.org/, which yields a security warning because the certificate is only valid for (*.)nfshost.com at the time of writing this issue. I'm not sure if it was ever valid — Google indexes only the HTTP version. We should link to http://www.scalastyle.org/ instead, at least until the Scalastyle maintainers fix their certificate.

#SCL-17594 fixed