### PR TITLE
Avoid errors on immutable list when installing bsp fetch environment task

### DIFF
--- a/bsp/src/org/jetbrains/bsp/project/test/environment/BspFetchTestEnvironmentTaskInstaller.scala
+++ b/bsp/src/org/jetbrains/bsp/project/test/environment/BspFetchTestEnvironmentTaskInstaller.scala
@@ -22,10 +22,12 @@ class BspFetchTestEnvironmentTaskInstaller(project: Project) extends RunManagerL
     if (BspEnvironmentRunnerExtension.isSupported(runConfiguration)) {
       val tasks = runManager.getBeforeRunTasks(BspFetchEnvironmentTask.runTaskKey)
       if (tasks.isEmpty) {
-        val beforeRunTasks = runManager.getBeforeRunTasks(runConfiguration)
         val task = new BspFetchEnvironmentTask
         task.setEnabled(true)
-        beforeRunTasks.add(task)
+
+        val mutableRunTasks = new java.util.ArrayList(runManager.getBeforeRunTasks(runConfiguration))
+        mutableRunTasks.add(task)
+        runManager.setBeforeRunTasks(runConfiguration, mutableRunTasks)
       }
     }
   }


### PR DESCRIPTION
The install task might fail if there are no tasks in the list (by default the empty list is ummutable and add fails)
```
2020-06-05T16:03:23.6103365Z [intellij-stderr] java.lang.UnsupportedOperationException
2020-06-05T16:03:23.6109718Z [intellij-stderr] 	at java.base/java.util.AbstractList.add(AbstractList.java:153)
2020-06-05T16:03:23.6110109Z [intellij-stderr] 	at java.base/java.util.AbstractList.add(AbstractList.java:111)
2020-06-05T16:03:23.6110557Z [intellij-stderr] 	at org.jetbrains.bsp.project.test.environment.BspFetchTestEnvironmentTaskInstaller.installFetchEnvironmentTask(BspFetchTestEnvironmentTaskInstaller.scala:28)
2020-06-05T16:03:23.6111037Z [intellij-stderr] 	at org.jetbrains.bsp.project.test.environment.BspFetchTestEnvironmentTaskInstaller.runConfigurationAdded(BspFetchTestEnvironmentTaskInstaller.scala:14)
2020-06-05T16:03:23.6111415Z [intellij-stderr] 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
2020-06-05T16:03:23.6111798Z [intellij-stderr] 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
2020-06-05T16:03:23.6112190Z [intellij-stderr] 	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
2020-06-05T16:03:23.6112523Z [intellij-stderr] 	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
2020-06-05T16:03:23.6112877Z [intellij-stderr] 	at com.intellij.util.messages.impl.MessageBusImpl.invokeListener(MessageBusImpl.java:549)
2020-06-05T16:03:23.6113258Z [intellij-stderr] 	at com.intellij.util.messages.impl.MessageBusConnectionImpl.deliverMessage(MessageBusConnectionImpl.java:139)
2020-06-05T16:03:23.6113631Z [intellij-stderr] 	at com.intellij.util.messages.impl.MessageBusImpl.doPumpMessages(MessageBusImpl.java:472)
2020-06-05T16:03:23.6113991Z [intellij-stderr] 	at com.intellij.util.messages.impl.MessageBusImpl.pumpWaitingBuses(MessageBusImpl.java:432)
2020-06-05T16:03:23.6122987Z [intellij-stderr] 	at com.intellij.util.messages.impl.MessageBusImpl.pumpMessages(MessageBusImpl.java:420)
2020-06-05T16:03:23.6123629Z [intellij-stderr] 	at com.intellij.util.messages.impl.MessageBusImpl.sendMessage(MessageBusImpl.java:404)
2020-06-05T16:03:23.6124029Z [intellij-stderr] 	at com.intellij.util.messages.impl.MessageBusImpl.lambda$createTopicHandler$3(MessageBusImpl.java:243)
2020-06-05T16:03:23.6124376Z [intellij-stderr] 	at com.sun.proxy.$Proxy86.runConfigurationAdded(Unknown Source)
2020-06-05T16:03:23.6124745Z [intellij-stderr] 	at com.intellij.execution.impl.RunManagerImpl.doAddConfiguration(RunManagerImpl.kt:439)
2020-06-05T16:03:23.6125269Z [intellij-stderr] 	at com.intellij.execution.impl.RunManagerImpl.addConfiguration(RunManagerImpl.kt:381)
2020-06-05T16:03:23.6126851Z [intellij-stderr] 	at com.virtuslab.handlers.RunConfigurations$.execute(RunConfigurations.scala:67)
2020-06-05T16:03:23.6127688Z [intellij-stderr] 	at com.virtuslab.BaseProbeHandlerContributor.$anonfun$registerHandlers$21(BaseProbeHandlerContributor.scala:46)
2020-06-05T16:03:23.6138501Z [intellij-stderr] 	at com.virtuslab.ProbeHandlers$ProbeHandler.$anonfun$on$2(ProbeHandlers.scala:46)
2020-06-05T16:03:23.6162645Z [intellij-stderr] 	at scala.util.Try$.apply(Try.scala:210)
2020-06-05T16:03:23.6163192Z [intellij-stderr] 	at com.virtuslab.CurrentRequest$.$anonfun$process$1(CurrentRequest.scala:25)
2020-06-05T16:03:23.6163568Z [intellij-stderr] 	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
2020-06-05T16:03:23.6163921Z [intellij-stderr] 	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
2020-06-05T16:03:23.6164231Z [intellij-stderr] 	at java.base/java.lang.Thread.run(Thread.java:834)
```