### PR TITLE
Ensure that loop in `findInLibSources` is interruptible

### DIFF
--- a/scala/scala-impl/src/org/jetbrains/plugins/scala/lang/psi/compiled/ScClsFileViewProvider.scala
+++ b/scala/scala-impl/src/org/jetbrains/plugins/scala/lang/psi/compiled/ScClsFileViewProvider.scala
@@ -6,6 +6,7 @@ package compiled
 import java.{util => ju}
 
 import com.intellij.lang.Language
+import com.intellij.openapi.application.ReadAction
 import com.intellij.openapi.fileTypes.FileType
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.{OrderEntry, OrderRootType, ProjectRootManager, impl => rootsImpl}
@@ -128,9 +129,9 @@ object ScClsFileViewProvider {
       val entriesIterator = entries.iterator
 
       while (entriesIterator.hasNext) {
-        val filesIterator = entriesIterator.next()
+        val filesIterator: Iterator[VirtualFile] = ReadAction.compute(() => entriesIterator.next()
           .getFiles(OrderRootType.SOURCES)
-          .iterator
+          .iterator)
 
         while (filesIterator.hasNext) {
           filesIterator.next().findFileByRelativePath(relPath) match {


### PR DESCRIPTION
In large projects, the llop in `findInLibSources` function may be very
expensive. It's executed with read permissions, so if any write action
happens before it ends, it have to wait. This may lead to UI
freezes. The freezes usually don't occur, because some of the
functions that are called inside the loop, call `ReadAction.compute`
that throws an exception when there is a pending write action. One of
the examples is `MavenProjectsManager.isMavenizedModule`.

Unfortunately this function is not executed in all cases, so in order
to reduce probability of the freeze, it would be good to ensure the
`ReadAction.compute` is called in each iteration.