### PR TITLE
More logs related to BSP execution environment

### DIFF
--- a/bsp/src/org/jetbrains/bsp/project/test/environment/BspFetchTestEnvironmentTaskInstaller.scala
+++ b/bsp/src/org/jetbrains/bsp/project/test/environment/BspFetchTestEnvironmentTaskInstaller.scala
@@ -2,19 +2,28 @@ package org.jetbrains.bsp.project.test.environment
 
 import com.intellij.execution.{RunManager, RunManagerEx, RunManagerListener, RunnerAndConfigurationSettings}
 import com.intellij.openapi.components.ServiceManager
+import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.Project
 
 
 class BspFetchTestEnvironmentTaskInstaller(project: Project) extends RunManagerListener {
-  private var settingsToInit: List[RunnerAndConfigurationSettings] = Nil
+  var logger = Logger.getInstance(classOf[BspFetchTestEnvironmentTaskInstaller])
 
-  override def runConfigurationAdded(settings: RunnerAndConfigurationSettings): Unit = {
+  private var settingsToInit: List[RunnerAndConfigurationSettings] = Nil
+  private var stateLoaded = false
+
+  override def runConfigurationAdded(settings: RunnerAndConfigurationSettings): Unit =  try {
     runManagerEx match {
       case Some(runManager) =>
         installFetchEnvironmentTask(settings, runManager)
-      case None =>
+      case None if !stateLoaded =>
         settingsToInit ::= settings
+        logger.info(s"Adding '${settings.getName}' config to BspFetchTestEnvironmentTaskInstaller queue")
+      case _ =>
+        logger.error("Run manager is null after initialization")
     }
+  } catch {
+    case e: Throwable => logger.error(e)
   }
 
   private def installFetchEnvironmentTask(settings: RunnerAndConfigurationSettings, runManager: RunManagerEx): Unit = {
@@ -34,8 +43,10 @@ class BspFetchTestEnvironmentTaskInstaller(project: Project) extends RunManagerL
 
   override def stateLoaded(runManager: RunManager, isFirstLoadState: Boolean): Unit =
     if (isFirstLoadState && runManager.isInstanceOf[RunManagerEx]) {
-        settingsToInit.foreach(installFetchEnvironmentTask(_, runManager.asInstanceOf[RunManagerEx]))
-        settingsToInit = Nil
+      settingsToInit.foreach(installFetchEnvironmentTask(_, runManager.asInstanceOf[RunManagerEx]))
+      settingsToInit = Nil
+      stateLoaded = true
+      logger.info("RunConfigurations from queue updated")
     }
   
   private def runManagerEx: Option[RunManagerEx] =


### PR DESCRIPTION
I observed that the "Use BSP environment" task is sometimes not added to "Before run tasks" list for tests in BSP-based modules. The problem is hard to reproduce, and there are no logs related to it. 

Interesting fact that is it's something defined at startup - it either works correctly for the entire runtime, until IntelliJ is closed, or does not work at all. 

There are two hypothesis for this:
1. The `BspFetchTestEnvironmentTaskInstaller` is not subscribed to `RunManagerListener` topic
2. The `runConfigurationAdded` callback silently fails for some unknown reason

With these logs I hope I will be able to distinguish which of these two is true.