### PR TITLE
Subscribe to RunManagerListener topic manually

### DIFF
--- a/bsp/resources/META-INF/BSP.xml
+++ b/bsp/resources/META-INF/BSP.xml
@@ -60,14 +60,4 @@
         <stepsBeforeRunProvider implementation="org.jetbrains.bsp.project.test.environment.BspFetchEnvironmentTaskProvider"/>
         <moduleService serviceImplementation="org.jetbrains.bsp.project.test.environment.PersistentBspTargetIdHolder"/>
     </extensions>
-
-    <projectListeners>
-        <listener class="org.jetbrains.bsp.project.test.environment.BspFetchTestEnvironmentTaskInstaller"
-                  topic="com.intellij.execution.RunManagerListener"/>
-    </projectListeners>
-
-    <actions>
-    </actions>
-
-
 </idea-plugin>

--- a/bsp/src/org/jetbrains/bsp/BspStartupActivity.scala
+++ b/bsp/src/org/jetbrains/bsp/BspStartupActivity.scala
@@ -1,13 +1,22 @@
 package org.jetbrains.bsp
 
+import com.intellij.execution.{RunManager, RunManagerListener}
+import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.startup.StartupActivity
+import org.jetbrains.bsp.project.test.environment.BspFetchTestEnvironmentTaskInstaller
 
 class BspStartupActivity extends StartupActivity {
+    val logger= Logger.getInstance(classOf[BspStartupActivity])
+
     @Override
-    override def runActivity(project: Project): Unit = {
+    override def runActivity(project: Project): Unit = try {
         // initialize build loop only for bsp projects
-        if (BspUtil.isBspProject(project))
+        if (BspUtil.isBspProject(project)) {
           BspBuildLoopService.getInstance(project)
+          project.getMessageBus.connect().subscribe(RunManagerListener.TOPIC, new BspFetchTestEnvironmentTaskInstaller(project))
+        }
+    } catch {
+      case e: Throwable => logger.error(e)
     }
 }


### PR DESCRIPTION
We have observed that sometimes the "Use BSP environment" is not added
to run configurations. Interestingly, the problem occurs during whole
IntelliJ process lifetime. Restart is usually a valid workaround.
The reproducibility ratio is very low, but one of the hypothesis is
that, the listener definied via XML file is not correctly subscribed
to the topic. That's why I'd like to directly subscribe it via
`subscribe` method call instead of defining it in XML file.