### PR TITLE
[port from idea201.x] Use the right overload of getBeforeRunTasks

### DIFF
--- a/bsp/src/org/jetbrains/bsp/project/test/environment/BspFetchTestEnvironmentTaskInstaller.scala
+++ b/bsp/src/org/jetbrains/bsp/project/test/environment/BspFetchTestEnvironmentTaskInstaller.scala
@@ -20,7 +20,7 @@ class BspFetchTestEnvironmentTaskInstaller(project: Project) extends RunManagerL
   private def installFetchEnvironmentTask(settings: RunnerAndConfigurationSettings, runManager: RunManagerEx): Unit = {
     val runConfiguration = settings.getConfiguration
     if (BspEnvironmentRunnerExtension.isSupported(runConfiguration)) {
-      val tasks = runManager.getBeforeRunTasks(BspFetchEnvironmentTask.runTaskKey)
+      val tasks = runManager.getBeforeRunTasks(runConfiguration, BspFetchEnvironmentTask.runTaskKey)
       if (tasks.isEmpty) {
         val task = new BspFetchEnvironmentTask
         task.setEnabled(true)


### PR DESCRIPTION
Previously the `getBeforeRunTasks(Key<T> taskProviderId)` was called,
which was returning the result for all existing run configs. This
commit changes the call to `getBeforeRunTasks(@NotNull
RunConfiguration settings, Key<T> taskProviderId)` as we need only the
tasks added to the current run config.

The original PR is here https://github.com/JetBrains/intellij-scala/pull/553