### PR TITLE
scalastyle: search for config file in same content root as file

### DIFF
--- a/scala/scala-impl/src/org/jetbrains/plugins/scala/codeInspection/scalastyle/ScalastyleCodeInspection.scala
+++ b/scala/scala-impl/src/org/jetbrains/plugins/scala/codeInspection/scalastyle/ScalastyleCodeInspection.scala
@@ -1,8 +1,7 @@
 package org.jetbrains.plugins.scala.codeInspection.scalastyle
 
 import com.intellij.codeInspection._
-import com.intellij.openapi.project.Project
-import com.intellij.openapi.roots.TestSourcesFilter
+import com.intellij.openapi.roots.ProjectFileIndex
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.{PsiDocumentManager, PsiElement, PsiFile}
 import org.jetbrains.plugins.scala.codeInspection.scalastyle.ScalastyleCodeInspection._
@@ -29,15 +28,16 @@ object ScalastyleCodeInspection {
   private val cache = new mutable.HashMap[VirtualFile, TimestampedScalastyleConfiguration]()
 
   def configurationFor(file: ScalaFile): Option[ScalastyleConfiguration] = {
-    val project = file.getProject
-    val isTestSource = TestSourcesFilter.isTestSources(file.getVirtualFile, project)
+    val virtualFile = file.getVirtualFile
+    val fileIndex = ProjectFileIndex.getInstance(file.getProject)
 
     import Locations.{possibleSrcConfigFileNames, possibleTestConfigFileNames}
     val possibleFileNames =
-      if (isTestSource) possibleTestConfigFileNames ++ possibleSrcConfigFileNames
+      if (fileIndex.isInTestSourceContent(virtualFile)) possibleTestConfigFileNames ++ possibleSrcConfigFileNames
       else possibleSrcConfigFileNames
 
-    Locations.findIn(project, possibleFileNames).map(latest)
+    Option(fileIndex.getContentRootForFile(virtualFile)).
+      flatMap(Locations.findIn(_, possibleFileNames).map(latest))
   }
 
   def configurationFor(file: PsiFile): Option[ScalastyleConfiguration] = {
@@ -52,11 +52,8 @@ object ScalastyleCodeInspection {
     private def findConfigFile(dir: VirtualFile, possibleConfigFileNames: Seq[String]): Option[VirtualFile] =
       possibleConfigFileNames.flatMap(name => Option(dir.findChild(name))).headOption
 
-    def findIn(project: Project, possibleConfigFileNames: Seq[String]): Option[VirtualFile] = {
-      val root = project.getBaseDir
-      if (root == null) return None
-
-      val dirs = possibleLocations.flatMap(name => Option(root.findChild(name))) :+ root
+    def findIn(contentRoot: VirtualFile, possibleConfigFileNames: Seq[String]): Option[VirtualFile] = {
+      val dirs = possibleLocations.flatMap(name => Option(contentRoot.findChild(name))) :+ contentRoot
       dirs.flatMap(findConfigFile(_, possibleConfigFileNames)).headOption
     }
   }

--- a/scala/scala-impl/test/org/jetbrains/plugins/scala/codeInspection/scalastyle/ScalastyleTest.scala
+++ b/scala/scala-impl/test/org/jetbrains/plugins/scala/codeInspection/scalastyle/ScalastyleTest.scala
@@ -1,14 +1,9 @@
 package org.jetbrains.plugins.scala.codeInspection.scalastyle
 
 import com.intellij.codeInspection.LocalInspectionTool
-import com.intellij.openapi.application.WriteAction
-import com.intellij.openapi.vfs.{VfsUtil, VirtualFile}
 import org.jetbrains.plugins.scala.codeInspection.ScalaInspectionTestBase
-import org.jetbrains.plugins.scala.extensions._
 
 class ScalastyleTest extends ScalaInspectionTestBase {
-
-  import com.intellij.testFramework.EditorTestUtil.{SELECTION_END_TAG => END, SELECTION_START_TAG => START}
 
   val config =
     <scalastyle commentFilter="enabled">
@@ -28,16 +23,8 @@ class ScalastyleTest extends ScalaInspectionTestBase {
   override protected val description = "Class name does not match the regular expression '[A-Z][A-Za-z]*'."
 
   private def setup(): Unit = {
-    def getOrCreateFile(dir: VirtualFile, file: String): VirtualFile =
-      dir.findChild(file).toOption.getOrElse(dir.createChildData(this, file))
-
-    WriteAction.runAndWait { () =>
-      val baseDir = VfsUtil.createDirectoryIfMissing(getProject.getBasePath)
-      val file = getOrCreateFile(baseDir, "scalastyle-config.xml")
-      VfsUtil.saveText(file, configString)
-    }
+    getFixture.addFileToProject("scalastyle-config.xml", configString)
   }
-
 
   def test_ok(): Unit = {
     setup()

--- a/scala/scala-impl/test/org/jetbrains/plugins/scala/codeInspection/scalastyle/ScalastyleTest.scala
+++ b/scala/scala-impl/test/org/jetbrains/plugins/scala/codeInspection/scalastyle/ScalastyleTest.scala
@@ -1,6 +1,8 @@
 package org.jetbrains.plugins.scala.codeInspection.scalastyle
 
 import com.intellij.codeInspection.LocalInspectionTool
+import com.intellij.openapi.application.WriteAction
+import com.intellij.openapi.vfs.{VfsUtil, VirtualFile}
 import org.jetbrains.plugins.scala.codeInspection.ScalaInspectionTestBase
 
 class ScalastyleTest extends ScalaInspectionTestBase {
@@ -38,6 +40,23 @@ class ScalastyleTest extends ScalaInspectionTestBase {
 
   def test(): Unit = {
     setup()
+
+    checkTextHasError(
+      s"""
+         |${START}class test$END
+      """.stripMargin
+    )
+  }
+
+  def testFallback(): Unit = {
+    def getOrCreateFile(dir: VirtualFile, file: String): VirtualFile =
+      Option(dir.findChild(file)).getOrElse(dir.createChildData(this, file))
+
+    WriteAction.runAndWait { () =>
+      val baseDir = VfsUtil.createDirectoryIfMissing(getProject.getBasePath)
+      val file = getOrCreateFile(baseDir, "scalastyle-config.xml")
+      VfsUtil.saveText(file, configString)
+    }
 
     checkTextHasError(
       s"""


### PR DESCRIPTION
The concept of a "project root" is deprecated [1], instead a project
consists of modules with content roots. This swaps the
scalastyle-config.xml lookup from the "project root" to find it within
the same content root as the file it's being applied to.

1: https://github.com/JetBrains/intellij-community/blob/3c162933038a472003a154f62ebc3c03895afc9b/platform/core-api/src/com/intellij/openapi/project/Project.java#L41