### PR TITLE
Add button to terminate BSP Server

### DIFF
--- a/bsp/resources/messages/ScalaBspBundle.properties
+++ b/bsp/resources/messages/ScalaBspBundle.properties
@@ -5,6 +5,7 @@ bsp.session.was.closed=BSP session was closed
 bsp.widget.bsp.connection=BSP Connection
 bsp.widget.kill.bsp.connection.at.uri=Kill BSP connection at {0}
 bsp.widget.stop.all.bsp.connections=Stop all BSP connections
+bsp.widget.bsp.terminate.server=Terminate server: {0}
 bsp.widget.connections=BSP Connections ({0})
 bsp.widget.connections.on=on
 bsp.widget.connections.off=off

--- a/bsp/src/org/jetbrains/bsp/BspServerWidgetProvider.scala
+++ b/bsp/src/org/jetbrains/bsp/BspServerWidgetProvider.scala
@@ -4,10 +4,13 @@ package org.jetbrains.bsp
 import java.awt.Point
 import java.awt.event.{ActionEvent, ActionListener, MouseEvent}
 import java.net.URI
+import java.util.concurrent.TimeUnit
 
 import com.intellij.icons.AllIcons
 import com.intellij.ide.DataManager
 import com.intellij.openapi.actionSystem.{AnAction, AnActionEvent, DefaultActionGroup, Separator}
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.{DumbAware, Project}
 import com.intellij.openapi.ui.popup.JBPopupFactory
 import com.intellij.openapi.util.IconLoader
@@ -16,7 +19,8 @@ import com.intellij.openapi.wm.{StatusBar, StatusBarWidget, StatusBarWidgetProvi
 import com.intellij.ui.awt.RelativePoint
 import com.intellij.util.Consumer
 import javax.swing.{Icon, Timer}
-import org.jetbrains.bsp.protocol.BspCommunicationService
+import org.apache.commons.io.IOUtils
+import org.jetbrains.bsp.protocol.{BspCommunication, BspCommunicationService}
 import org.jetbrains.bsp.settings.BspProjectSettings.BspServerConfig
 
 import scala.collection.JavaConverters._
@@ -25,7 +29,7 @@ class BspServerWidgetProvider extends StatusBarWidgetProvider {
 
   private val IconRunning = org.jetbrains.bsp.Icons.BSP
   private val IconStopped = IconLoader.getDisabledIcon(IconRunning)
-
+  private val logger = Logger.getInstance(classOf[BspServerWidgetProvider])
   private class Widget(project: Project) extends StatusBarWidget {
 
     private val timer = new Timer(1000, TimerListener)
@@ -91,11 +95,51 @@ class BspServerWidgetProvider extends StatusBarWidgetProvider {
       }
     }
 
+    class TerminateServer(uri: URI, config: BspServerConfig) extends AnAction(BspBundle.message("bsp.widget.bsp.terminate.server", uri), BspBundle.message("bsp.widget.bsp.terminate.server"), AllIcons.Actions.Exit) with DumbAware {
+      override def update(e: AnActionEvent): Unit = {
+        val exitCommandDefined  = BspCommunicationService.getInstance.exitCommands(uri, config).toOption.exists(_.nonEmpty)
+        e.getPresentation.setEnabled(exitCommandDefined)
+      }
+
+      override def actionPerformed(e: AnActionEvent): Unit = try {
+        val commands = BspCommunicationService.getInstance.exitCommands(uri, config).getOrElse(List())
+        BspCommunicationService.getInstance.closeAll
+        ApplicationManager.getApplication.executeOnPooledThread(
+          new Runnable {
+            override def run(): Unit = {
+              if (commands.isEmpty) {
+                logger.info(s"BSP server exit command not set in '${BspCommunication.argvExit}' field")
+              } else {
+                logger.info(s"Running BSP server restart")
+              }
+              val timeoutLength = 30
+              commands.foreach { command =>
+                logger.info(s"Running comand: '${command.mkString(" ")}'")
+                val process = new ProcessBuilder(command.asJava).start()
+                val timedOut = !process.waitFor(timeoutLength, TimeUnit.SECONDS)
+                if (timedOut) {
+                  // We log only timouts, and skip regular errors because they occur too often,
+                  // ex. when the server is just not running.
+                  val title = s"Timeout when terminating BSP server after ${timeoutLength} seconds"
+                  val stderr = s"[STDERR]\n${IOUtils.toString(process.getErrorStream, "UTF-8")}\n"
+                  val stdout = s"[STDOUT]\n${IOUtils.toString(process.getInputStream, "UTF-8")}\n"
+                  logger.error(s"$title\n $stderr\n $stdout")
+                }
+              }
+            }
+          }
+        )
+      } catch {
+        case e: Throwable => logger.error(e)
+      }
+    }
+
     private def toggleList(e: MouseEvent): Unit = {
       val openCom = BspCommunicationService.getInstance.listOpenComms
       val connectionClosers =
         (openCom.map(c => new CloseBspSession(c._1, c._2)).toList
-          :+ new CloseAllSessions
+          ++ List(new CloseAllSessions)
+          ++ openCom.map(c => new TerminateServer(c._1, c._2)).toList
           :+ Separator.getInstance
           ).asJava
 
@@ -110,7 +154,6 @@ class BspServerWidgetProvider extends StatusBarWidgetProvider {
       popup.show(new RelativePoint(e.getComponent, at))
     }
   }
-
 
   override def getWidget(project: Project): StatusBarWidget = {
     if (BspUtil.isBspProject(project)) new Widget(project)

--- a/bsp/src/org/jetbrains/bsp/BspServerWidgetProvider.scala
+++ b/bsp/src/org/jetbrains/bsp/BspServerWidgetProvider.scala
@@ -98,7 +98,7 @@ class BspServerWidgetProvider extends StatusBarWidgetProvider {
     class TerminateServer(uri: URI, config: BspServerConfig) extends AnAction(BspBundle.message("bsp.widget.bsp.terminate.server", uri), BspBundle.message("bsp.widget.bsp.terminate.server"), AllIcons.Actions.Exit) with DumbAware {
       override def update(e: AnActionEvent): Unit = {
         val exitCommandDefined  = BspCommunicationService.getInstance.exitCommands(uri, config).toOption.exists(_.nonEmpty)
-        e.getPresentation.setEnabled(exitCommandDefined)
+        e.getPresentation.setVisible(exitCommandDefined)
       }
 
       override def actionPerformed(e: AnActionEvent): Unit = try {

--- a/bsp/src/org/jetbrains/bsp/project/BspExternalSystemManager.scala
+++ b/bsp/src/org/jetbrains/bsp/project/BspExternalSystemManager.scala
@@ -106,4 +106,10 @@ class BspExternalSystemManager extends ExternalSystemManager[BspProjectSettings,
 
 object BspExternalSystemManager {
   val DetectExternalProjectFiles: Key[Boolean] = Key.create[Boolean]("BSP.detectExternalProjectFiles")
+
+  def parseAsMap(file: File): Map[String, Any] = {
+    val virtualFile = LocalFileSystem.getInstance.findFileByIoFile(file)
+    val content = new String(virtualFile.contentsToByteArray())
+    new Gson().fromJson(content, classOf[JMap[String, _]]).asScala.toMap
+  }
 }

--- a/bsp/src/org/jetbrains/bsp/protocol/BspCommunicationService.scala
+++ b/bsp/src/org/jetbrains/bsp/protocol/BspCommunicationService.scala
@@ -12,11 +12,15 @@ import com.intellij.openapi.project.{Project, ProjectManager, ProjectManagerList
 import com.intellij.openapi.util.Disposer
 import com.intellij.util.concurrency.AppExecutorUtil
 import org.jetbrains.bsp.settings.BspProjectSettings.BspServerConfig
+import org.jetbrains.bsp.project.BspExternalSystemManager
+import org.jetbrains.bsp.settings.BspExecutionSettings
 import org.jetbrains.plugins.scala.util.UnloadAwareDisposable
 
 import scala.collection.mutable
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
+import scala.collection.JavaConverters._
+import scala.util.{Success, Try}
 
 class BspCommunicationService extends Disposable {
 
@@ -70,6 +74,13 @@ class BspCommunicationService extends Disposable {
 
     Future.fromTry(tryComm)
       .flatMap(_.closeSession())(ExecutionContext.global)
+  }
+
+  def exitCommands(base: URI, config: BspServerConfig): Try[List[List[String]]] = {
+    comms.get(base, config)
+      .toRight(new NoSuchElementException)
+      .toTry
+      .map(_.exitCommands)
   }
 
   def closeAll: Future[Unit] = {


### PR DESCRIPTION
The button calls command defined in .bsp/bloop.json/argvExit
field. Typically it's just bloop exit. If the field is empty,
a warning is logged.