### PR TITLE
Fix support of non sbt bsp projects

### DIFF
--- a/bsp/src/org/jetbrains/bsp/project/importing/BspProjectResolver.scala
+++ b/bsp/src/org/jetbrains/bsp/project/importing/BspProjectResolver.scala
@@ -154,17 +154,18 @@ class BspProjectResolver extends ExternalSystemProjectResolver[BspExecutionSetti
 
   // special handling for sbt projects: run bloopInstall first
   // TODO support other bloop-enabled build tools as well
-  private def preImport(executionSettings: BspExecutionSettings, workspace: File)(implicit reporter: BuildReporter) = {
+  private def preImport(executionSettings: BspExecutionSettings, workspace: File)(implicit reporter: BuildReporter): Try[BuildMessages] = {
     import BspProjectSettings._
 
     val emptySuccess = Success(BuildMessages.empty.status(BuildMessages.OK))
+    def isSbtProject = new File(workspace, "build.sbt").exists()
 
     if (executionSettings.runPreImportTask) {
       executionSettings.preImportTask match {
         case BspProjectSettings.NoPreImport =>
           emptySuccess
         case BspProjectSettings.AutoPreImport =>
-          if (executionSettings.config == AutoConfig && bloopConfigDir(workspace).isDefined)
+          if (executionSettings.config == AutoConfig && bloopConfigDir(workspace).isDefined && isSbtProject)
             runBloopInstall(workspace)
           else emptySuccess
         case BspProjectSettings.BloopSbtPreImport =>

--- a/bsp/src/org/jetbrains/bsp/project/importing/preimport/BloopPreImporter.scala
+++ b/bsp/src/org/jetbrains/bsp/project/importing/preimport/BloopPreImporter.scala
@@ -7,6 +7,7 @@ import com.intellij.openapi.util.io.FileUtil
 import org.jetbrains.bsp.BspBundle
 import org.jetbrains.plugins.scala.build.{BuildMessages, BuildReporter}
 import org.jetbrains.plugins.scala.buildinfo.BuildInfo
+import org.jetbrains.plugins.scala.extensions.invokeAndWait
 import org.jetbrains.plugins.scala.project.Version
 import org.jetbrains.sbt.SbtUtil.{detectSbtVersion, getDefaultLauncher, sbtVersionParam, upgradedSbtVersion}
 import org.jetbrains.sbt.project.SbtExternalSystemManager
@@ -23,9 +24,10 @@ class BloopPreImporter(dumper: SbtStructureDump, runDump: SbtStructureDump => Tr
 }
 object BloopPreImporter {
   def apply(baseDir: File)(implicit reporter: BuildReporter): BloopPreImporter = {
+    invokeAndWait(ProjectJdkTable.getInstance.preconfigure())
     val jdkType = JavaSdk.getInstance()
     val jdk = ProjectJdkTable.getInstance().findMostRecentSdkOfType(jdkType)
-    val jdkExe = new File(jdkType.getVMExecutablePath(jdk)) // TODO error when none, offer jdk config
+    val jdkExe = new File(jdkType.getVMExecutablePath(jdk))
     val jdkHome = Option(jdk.getHomePath).map(new File(_))
     val sbtLauncher = SbtUtil.getDefaultLauncher
 


### PR DESCRIPTION
I added a naive guard to check if the project is sbt before attempting to run sbt bloopInstall. Checking for `bloopConfigDir` is not enough, as fastpass generates .bloop dir and the project itself is pants based and it needs fastpass to set it up. 
The PR also fixes missing jdk, by ensuring it is preconfigured before attempting to access it.