### PR TITLE
Idea202.x

### DIFF
--- a/scala/scala-impl/src/org/jetbrains/plugins/scala/lang/psi/api/InferUtil.scala
+++ b/scala/scala-impl/src/org/jetbrains/plugins/scala/lang/psi/api/InferUtil.scala
@@ -312,7 +312,7 @@ object InferUtil {
       val expressionToUpdate = Expression(ScSubstitutor.bind(typeParams)(UndefinedType(_)).apply(valueType))
 
       val inferredWithExpected =
-        localTypeInference(internal, Seq(expectedParam), Seq(expressionToUpdate), typeParams,
+        localTypeInference(sameDepth, Seq(expectedParam), Seq(expressionToUpdate), typeParams,
           shouldUndefineParameters = false,
           canThrowSCE = canThrowSCE,
           filterTypeParams = filterTypeParams)

--- a/scala/scala-impl/test/org/jetbrains/plugins/scala/base/libraryLoaders/ScalaSDKLoader.scala
+++ b/scala/scala-impl/test/org/jetbrains/plugins/scala/base/libraryLoaders/ScalaSDKLoader.scala
@@ -15,8 +15,8 @@ import org.junit.Assert._
 
 case class ScalaSDKLoader(includeScalaReflect: Boolean = false) extends LibraryLoader {
 
-  private object DependencyManager extends DependencyManagerBase {
-    override protected val artifactBlackList = Set.empty[String]
+  protected lazy val dependencyManager: DependencyManagerBase = new DependencyManagerBase {
+    override protected val artifactBlackList: Set[String] = Set.empty
   }
 
   import DependencyManagerBase._
@@ -46,13 +46,13 @@ case class ScalaSDKLoader(includeScalaReflect: Boolean = false) extends LibraryL
     scalaLibraryDescription % Types.SRC
 
   final def sourceRoot(implicit version: ScalaVersion): VirtualFile = {
-    val ResolvedDependency(_, file) = DependencyManager.resolveSingle(sourcesDependency)
+    val ResolvedDependency(_, file) = dependencyManager.resolveSingle(sourcesDependency)
     findJarFile(file)
   }
 
   override final def init(implicit module: Module, version: ScalaVersion): Unit = {
     val dependencies = binaryDependencies
-    val resolved = DependencyManager.resolve(dependencies: _*)
+    val resolved = dependencyManager.resolve(dependencies: _*)
 
     if (version.languageLevel == ScalaLanguageLevel.Scala_3_0)
       assertTrue(


### PR DESCRIPTION
Hi @niktrop , I faced the issue with resolving the type of a generic method with some (~10) overrides, each of them has implicit parameters that are used in output type calculations. The calculation of all available overrides freezes the scala plugin.
The issue appeared after https://github.com/JetBrains/intellij-scala/commit/815eff73c6bc244d796c65c094189f918ce1bb10  Could you please check, is this the right fix for the issue?