### PR TITLE
Fix scalatest sbt shell command parameters

### DIFF
--- a/scala/scala-impl/src/org/jetbrains/plugins/scala/testingSupport/test/sbt/SbtCommandsBuilder.scala
+++ b/scala/scala-impl/src/org/jetbrains/plugins/scala/testingSupport/test/sbt/SbtCommandsBuilder.scala
@@ -31,8 +31,10 @@ abstract class SbtCommandsBuilderBase extends SbtCommandsBuilder {
   protected final def quoteSpaces(text: String): String =
     if (text.contains(" ")) s""""$text"""" else text
 
-  private def withClassKey(value: String): String =
-    classKey.fold(" ")(key => key.trim + " " + sanitize(value).trim)
+  private def withClassKey(value: String): String = {
+    val className = sanitize(value).trim
+    classKey.fold(className)(key => key.trim + " " + className)
+  }
 
   // TODO: extract to utils, rename
   private def sanitize(qualifiedName: String): String = qualifiedName.replace("`", "")


### PR DESCRIPTION
ScalaTestRunConfiguration run with sbt (`Use sbt` setting is set to true in TestConfigurationData) doesn't work as expected for package, class nor method test kind. The reason is that the `testOnly` sbt command run in the shell isn't followed by expected arguments that should be provided by `buildTestOnly` method in SbtCommandsBuilderBase implementation for ScalaTestRunConfiguration. The change included in this PR fixes the command parameters creation when `classKey` isn't present which is the case for ScalaTestRunConfiguration.