### PR TITLE
[idea202.x port] Do not spawn ConfigSetupTask for non-BSP imports

### DIFF
--- a/bsp/src/org/jetbrains/bsp/project/importing/bspConfigSteps.scala
+++ b/bsp/src/org/jetbrains/bsp/project/importing/bspConfigSteps.scala
@@ -210,11 +210,13 @@ class BspSetupConfigStep(wizardContext: WizardContext, builder: BspProjectImport
   override def onWizardFinished(): Unit = {
     // TODO this spawns an indicator window which is not nice.
     // show a live log in the window or something?
-    updateDataModel() // without it runSetupTask is null
-    builder.prepare(wizardContext)
-    builder.ensureProjectIsDefined(wizardContext)
-    val task = new ConfigSetupTask(runSetupTask)
-    task.queue()
+    if(wizardContext.getProjectBuilder.isInstanceOf[BspProjectImportBuilder]) {
+      updateDataModel() // without it runSetupTask is null
+      builder.prepare(wizardContext)
+      builder.ensureProjectIsDefined(wizardContext)
+      val task = new ConfigSetupTask(runSetupTask)
+      task.queue()
+    }
   }
 
 }


### PR DESCRIPTION
It seems that the `onWizardFinished` method of BspSetupConfigStep is called
each time, even if other then BSP import method was chosen. This means, we need
to check this inside the method.

idea202.x PR: https://github.com/JetBrains/intellij-scala/pull/568