### PR TITLE
Handle for-comprehension in `invocationText` method

### DIFF
--- a/scala/scala-impl/src/org/jetbrains/plugins/scala/codeInspection/collections/package.scala
+++ b/scala/scala-impl/src/org/jetbrains/plugins/scala/codeInspection/collections/package.scala
@@ -274,14 +274,14 @@ package object collections {
     def argsText = argListText(args)
 
     if (qual == null) {
-      val argsText = argListText(args)
       s"$methName$argsText"
     } else {
       val qualText = qual.getText
       qual match {
         case _ childOf ScInfixExpr(`qual`, _, _) if args.size == 1 =>
-          s"${qual.getText} $methName ${args.head.getText}"
+          s"$qualText $methName ${args.head.getText}"
         case _: ScInfixExpr => s"($qualText).$methName$argsText"
+        case _: ScFor => s"($qualText).$methName$argsText"
         case _ => s"$qualText.$methName$argsText"
       }
 


### PR DESCRIPTION
Initial bug that discovered the problem can be found here https://github.com/zio/zio-intellij/issues/184.
The problem is that `invocationText` doesn't wrap for-comprehensions in parenthesis. This PR hadles this special case.
