### PR TITLE
Fix ideaPort assignment syntax in sbt code snippet

### DIFF
--- a/scala/scala-impl/src/org/jetbrains/plugins/scala/findUsages/compilerReferences/settings/CompilerIndicesSettingsForm.java
+++ b/scala/scala-impl/src/org/jetbrains/plugins/scala/findUsages/compilerReferences/settings/CompilerIndicesSettingsForm.java
@@ -95,7 +95,7 @@ public class CompilerIndicesSettingsForm {
     }
 
     private void updateSbtKeysTextAreaText() {
-        String messagePrefix = "ideaPort in Global :";
+        String messagePrefix = "ideaPort in Global :=";
         buildSettingsTextArea.setText(String.format("%s %d", messagePrefix, portSelector.getNumber()));
     }
 


### PR DESCRIPTION
Replace provided code snippet `ideaPort in Global : 65337` with `ideaPort in Global := 65337`  

Details:

In "Bytecode Indices" preferences, when selecting manual SBT compilation listener configuration, code presented in the "add the following line to build.sbt" field  has a broken assignment symbol (it seems by accident, or maybe it was leftovers from some old syntax 🤷‍♂️ ):

```scala
ideaPort in Global : 65337
```