### PR TITLE
don't add trailing commas for block parameters not enclosed in parentheses

### DIFF
--- a/scala/scala-impl/test/org/jetbrains/plugins/scala/lang/formatter/tests/TrailingCommaTest.scala
+++ b/scala/scala-impl/test/org/jetbrains/plugins/scala/lang/formatter/tests/TrailingCommaTest.scala
@@ -282,6 +282,14 @@ class TrailingCommaTest extends AbstractScalaFormatterTestBase {
     doTextTest(before)
   }
 
+  def testNotAdd_ParameterBlockWithoutParenthesis(): Unit = {
+    getScalaSettings.TRAILING_COMMA_MODE = TrailingCommaMode.TRAILING_COMMA_ADD_WHEN_MULTILINE
+    val before =
+      """action {}
+        |""".stripMargin
+    doTextTest(before)
+  }
+
   def testNotRemove_NotMultilineWithErrorComma(): Unit = {
     getScalaSettings.TRAILING_COMMA_MODE = TrailingCommaMode.TRAILING_COMMA_REMOVE_WHEN_MULTILINE
     val before ="""List(1, 2, 3,)"""


### PR DESCRIPTION
Hey, this is my first contribution here, so let me know if I need to do something differently.

This change should fix https://youtrack.jetbrains.com/issue/SCL-16515

I'm not particularly fond of the code. I didn't study the API very deeply, I just went with the simplest thing that seemed to fix the issue. I'm open to any suggestions to make it cleaner.

I'd like to use the setting `Trailing Comma: Add when multiline` but until this is fixed, it is nearly unusable.