### PR TITLE
Include the link in the CI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![official JetBrains project](https://jb.gg/badges/official.svg)](https://confluence.jetbrains.com/display/ALL/JetBrains+on+GitHub)
-![Scala Plugin Build & Test](https://github.com/JetBrains/intellij-scala/workflows/Scala%20Plugin%20Build%20&%20Test/badge.svg)
+[![Scala Plugin Build & Test](https://github.com/JetBrains/intellij-scala/actions/workflows/build.yml/badge.svg)](https://github.com/JetBrains/intellij-scala/actions/workflows/build.yml)
 [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/JetBrains/intellij-scala)
 
 


### PR DESCRIPTION
This is the badge you get when you go to
<https://github.com/JetBrains/intellij-scala/actions/workflows/build.yml>,
click on the "...", then click on "Create status badge".

(Basically, you were missing the link back to
<https://github.com/JetBrains/intellij-scala/actions/workflows/build.yml>.)