### PR TITLE
Fix broken bloop launcher classpath

### DIFF
--- a/bsp/src/org/jetbrains/bsp/protocol/session/BloopLauncherConnector.scala
+++ b/bsp/src/org/jetbrains/bsp/protocol/session/BloopLauncherConnector.scala
@@ -24,6 +24,7 @@ class BloopLauncherConnector(base: File, compilerOutput: File, capabilities: Bsp
 
     val dependencies = Seq(
       ("ch.epfl.scala" % "bloop-launcher_2.12" % bloopVersion).transitive(),
+      "org.scala-lang.modules" % "scala-collection-compat_2.12" % "2.4.2", //workaround for broken classpath
       "org.scala-lang" % "scala-library" % "2.12.12"
     )
     val launcherClasspath = DependencyManager.resolve(dependencies: _*)


### PR DESCRIPTION
Bloop has broken its bloop launcher, so unless we include this dependency. The launcher is broken.
A possible workaround is to install bloop as mentioned in the attached issue, but this should allow the existing setup to work.

Should fix: 
https://youtrack.jetbrains.com/issue/SCL-18969