### PR TITLE
#SCL-19157 Add integration-test to module description

### DIFF
--- a/bsp/src/org/jetbrains/bsp/project/importing/BspResolverLogic.scala
+++ b/bsp/src/org/jetbrains/bsp/project/importing/BspResolverLogic.scala
@@ -309,7 +309,7 @@ private[importing] object BspResolverLogic {
 
     val targetDeps = target.getDependencies.asScala.toSeq
 
-    val data = if(tags.contains(TEST))
+    val data = if(tags.contains(TEST) || tags.contains(INTEGRATION_TEST))
       dataBasic.copy(
         targetTestDependencies = targetDeps,
         testOutput = outputPath,
@@ -364,7 +364,10 @@ private[importing] object BspResolverLogic {
     val merged = mergeModules(ancestors)
     val id = sharedModuleId(targets)
     val sources = sourceRoots ++ generatedSourceRoots
-    val isTest = targets.forall(_.getTags.asScala.contains(BuildTargetTag.TEST))
+    val isTest = targets.forall{ buildTarget =>
+      val tags = buildTarget.getTags.asScala
+      tags.contains(BuildTargetTag.TEST) || tags.contains(BuildTargetTag.INTEGRATION_TEST)
+    }
 
     val inheritorData = merged.data.copy(
       id = id,

--- a/bsp/test/org/jetbrains/bsp/project/importing/BspResolverLogicTest.scala
+++ b/bsp/test/org/jetbrains/bsp/project/importing/BspResolverLogicTest.scala
@@ -1,9 +1,10 @@
 package org.jetbrains.bsp.project.importing
 
-import ch.epfl.scala.bsp4j.{BuildTarget, BuildTargetCapabilities, BuildTargetIdentifier}
+import ch.epfl.scala.bsp4j.{BuildTarget, BuildTargetCapabilities, BuildTargetIdentifier, BuildTargetTag, SourceItem, SourceItemKind, SourcesItem}
 import org.jetbrains.bsp.project.importing.BspResolverDescriptors.UnspecifiedModule
 import org.junit.Test
 
+import java.nio.file.Paths
 import scala.jdk.CollectionConverters._
 
 class BspResolverLogicTest {
@@ -25,6 +26,40 @@ class BspResolverLogicTest {
     val rootModule = descriptions.modules.head
     assert(rootModule.moduleKindData == UnspecifiedModule())
     assert(rootModule.data.targets.head == target)
+  }
+
+  @Test
+  def testCalculateModuleDescriptionsBaseDirWithTest(): Unit = {
+    val target = new BuildTarget(
+      new BuildTargetIdentifier("ePzqj://jqke:540/n/ius7/jDa/t/z78"),
+      List(BuildTargetTag.TEST).asJava, null, List.empty.asJava,
+      new BuildTargetCapabilities(true, true, true)
+    )
+
+    val path = Paths.get(".").toUri.toString
+    val items = new SourcesItem(target.getId, List(new SourceItem(path, SourceItemKind.DIRECTORY, false)).asJava)
+
+    val descriptions = BspResolverLogic.calculateModuleDescriptions(List(target), Nil, Nil, Seq(items), Nil, Nil)
+    assert(descriptions.modules.size == 1)
+    assert(descriptions.modules.flatMap(_.data.testSourceDirs).size == 1)
+    assert(descriptions.modules.flatMap(_.data.sourceDirs).isEmpty)
+  }
+
+  @Test
+  def testCalculateModuleDescriptionsBaseDirWithIntegrationTest(): Unit = {
+    val target = new BuildTarget(
+      new BuildTargetIdentifier("ePzqj://jqke:540/n/ius7/jDa/t/z78"),
+      List(BuildTargetTag.INTEGRATION_TEST).asJava, null, List.empty.asJava,
+      new BuildTargetCapabilities(true, true, true)
+    )
+
+    val path = Paths.get(".").toUri.toString
+    val items = new SourcesItem(target.getId, List(new SourceItem(path, SourceItemKind.DIRECTORY, false)).asJava)
+
+    val descriptions = BspResolverLogic.calculateModuleDescriptions(List(target), Nil, Nil, Seq(items), Nil, Nil)
+    assert(descriptions.modules.size == 1)
+    assert(descriptions.modules.flatMap(_.data.testSourceDirs).size == 1)
+    assert(descriptions.modules.flatMap(_.data.sourceDirs).isEmpty)
   }
 
 }


### PR DESCRIPTION
The integration tests are not correctly imported in the module/*.iml file : the `isTestSource` property is set to `false`.

This PR fixes this behavior by adding the [BuildTargetTag.INTEGRATION_TEST](https://github.com/build-server-protocol/build-server-protocol/blob/master/bsp4j/src/main/java/ch/epfl/scala/bsp4j/BuildTargetTag.java#L7) to the `isTest` value. 