### PR TITLE
BSP import: don't add Scala library to runtime classpath in Scala SDK

### DIFF
--- a/bsp/src/org/jetbrains/bsp/project/importing/BspResolverLogic.scala
+++ b/bsp/src/org/jetbrains/bsp/project/importing/BspResolverLogic.scala
@@ -821,9 +821,6 @@ private[importing] object BspResolverLogic {
 
         val scalaSdkLibrary = new LibraryData(BSP.ProjectSystemId, s"${ScalaSdkData.LibraryName}-${scalaSdkData.scalaVersion}")
 
-        scalaSdkData.scalacClasspath.forEach { path =>
-          scalaSdkLibrary.addPath(LibraryPathType.BINARY, path.getCanonicalPath)
-        }
         val scalaSdkLibraryDependencyData = new LibraryDependencyData(moduleData, scalaSdkLibrary, LibraryLevel.MODULE)
         scalaSdkLibraryDependencyData.setScope(DependencyScope.COMPILE)
 


### PR DESCRIPTION
When importing a project through bsp, the compiler classpath
(scala-library, scala-reflect, scala-compiler) obtained through
bsp should only be used for the "Compiler classpath" section of the
Scala SDK.

Before this change, the classpath was also added to the module's
`<CLASSES>` ("Standard library" section of the Scala SDK in the UI).
This is
  - slightly incorrect, because it adds the scala-compiler jar to the
    module's classpath
  - not needed, because the scala-library is added to the module's
    classpath as a separate library

https://github.com/scala/scala-dev/issues/786#issuecomment-914567436