### PR TITLE
Derevo: support macro definitions in derivation expressions

### DIFF
--- a/scala/scala-impl/src/org/jetbrains/plugins/scala/externalLibraries/derevo/DerevoInjector.scala
+++ b/scala/scala-impl/src/org/jetbrains/plugins/scala/externalLibraries/derevo/DerevoInjector.scala
@@ -5,7 +5,7 @@ import org.jetbrains.plugins.scala.extensions._
 import org.jetbrains.plugins.scala.externalLibraries.derevo.DerevoInjector._
 import org.jetbrains.plugins.scala.lang.psi.api.base.ScAnnotation
 import org.jetbrains.plugins.scala.lang.psi.api.expr.{ScExpression, ScMethodCall, ScReferenceExpression}
-import org.jetbrains.plugins.scala.lang.psi.api.statements.{ScFunction, ScFunctionDefinition, ScTypeAliasDefinition}
+import org.jetbrains.plugins.scala.lang.psi.api.statements.{ScFunction, ScTypeAliasDefinition}
 import org.jetbrains.plugins.scala.lang.psi.api.toplevel.typedef.{ScObject, ScTemplateDefinition, ScTrait, ScTypeDefinition}
 import org.jetbrains.plugins.scala.lang.psi.impl.toplevel.typedef.SyntheticMembersInjector
 import org.jetbrains.plugins.scala.lang.psi.types.api.TypeParameterType
@@ -137,7 +137,7 @@ class DerevoInjector extends SyntheticMembersInjector {
               }
 
               fn("instance").orElse(fn("apply")).flatMap(extractTcsFromDefDef)
-            case f: ScFunctionDefinition =>
+            case f: ScFunction =>
               extractTcsFromDefDef(f)
 
             case _ => None


### PR DESCRIPTION
This PR reduces requirement from FunctionDefinition to just Function (which can be MacroDefinition as well) and allows to correctly inject macro-based instances with parameters