### PR TITLE
update Zinc version to 1.5.9

### DIFF
--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -8,7 +8,7 @@ object Versions {
   // run runtimeDependencies/update manually
   val sbtVersion: String = Sbt.latest
   val bloopVersion = "1.4.8-81-e170cd66"
-  val zincVersion = "1.5.7"
+  val zincVersion = "1.5.9"
   val intellijVersion = "213.5744.223"
   val bspVersion = "2.0.0-M14"
   val sbtStructureVersion: String = "2021.3.0"


### PR DESCRIPTION
Zinc 1.5.9 updates log4j to 2.16.0, which disables JNDI lookup and fixes a denial of service vulnerability (CVE-2021-45046) 