### PR TITLE
Pass environment used in MacOS terminal to bsp server

### DIFF
--- a/bsp/src/org/jetbrains/bsp/protocol/session/GenericConnector.scala
+++ b/bsp/src/org/jetbrains/bsp/protocol/session/GenericConnector.scala
@@ -1,8 +1,8 @@
 package org.jetbrains.bsp.protocol.session
 
 import java.io.File
-
 import ch.epfl.scala.bsp4j.BspConnectionDetails
+import com.intellij.util.EnvironmentUtil
 import org.jetbrains.bsp.protocol.session.BspServerConnector.{BspCapabilities, ProcessBsp}
 import org.jetbrains.bsp.protocol.session.BspSession.Builder
 import org.jetbrains.bsp.{BspBundle, BspError, BspErrorMessage}
@@ -20,10 +20,11 @@ class GenericConnector(base: File, compilerOutput: File, capabilities: BspCapabi
   }
 
   private def prepareBspSession(details: BspConnectionDetails): Builder = {
-    val process =
-      new java.lang.ProcessBuilder(details.getArgv)
-        .directory(base)
-        .start()
+    val builder = new ProcessBuilder(details.getArgv).directory(base)
+    val env = builder.environment()
+    env.clear()
+    env.putAll(EnvironmentUtil.getEnvironmentMap)
+    val process = builder.start()
 
     val cleanup = () => {
       process.destroy()


### PR DESCRIPTION
By looking at `EnvironmentUtil.getEnvironmentMap` docs it looks like it is a known issue that by default environment variables that are default when running process are quite useless, thus it is required to use this method when starting a process. 
This is specifically targeted at bazel-bsp that is started and later starts bazel server. Currently, bazel server has different environment in command line and IntelliJ, specifically JAVA_HOME and PATH which invalidates cache.