### PR TITLE
Avoid errors when importing javac opts through bsp

### DIFF
--- a/bsp/src/org/jetbrains/bsp/project/importing/BspProjectResolver.scala
+++ b/bsp/src/org/jetbrains/bsp/project/importing/BspProjectResolver.scala
@@ -329,7 +329,7 @@ object BspProjectResolver {
   //noinspection ReferencePassedToNls
   private def fetchJavacOptions(targets: List[BuildTarget], parentId: EventId)(implicit bsp: BspServer, reporter: BuildReporter) = {
     val javaTargetIds = targets
-      .filter(_.getLanguageIds.contains("java"))
+      .filter(t => t.getLanguageIds.contains("java") && t.getDataKind == BuildTargetDataKind.JVM)
       .map(_.getId).asJava
 
     if (! javaTargetIds.isEmpty) {


### PR DESCRIPTION
IntelliJ during fastpass import always reports an error for javac options and this confuses users that maybe import didn't work.
The thing is that target is either scala or java. If it is scala target, all info is fetched using `fetchScalacOptions`. Targets with scala may contain java. Anyway, they are reported with languageIds = ['scala', 'java']. This results in attempts to fetch compiler options twice (using scala and java) while it is enough to do it once.