### PR TITLE
Fix creating duplicate JDK instances from bsp and misinterpreting JDK as JRE

### DIFF
--- a/scala/scala-impl/src/org/jetbrains/plugins/scala/project/external/SdkReference.scala
+++ b/scala/scala-impl/src/org/jetbrains/plugins/scala/project/external/SdkReference.scala
@@ -34,7 +34,9 @@ object SdkUtils {
     sdkRef match {
       case JdkByVersion(version) => findMostRecentJdk(sdk => Option(sdk.getVersionString).exists(_.contains(version)))
       case JdkByName(version)    => findMostRecentJdk(_.getName == version).orElse(findMostRecentJdk(_.getName.contains(version)))
-      case JdkByHome(homeFile)   => findMostRecentJdk(sdk => FileUtil.comparePaths(homeFile.getCanonicalPath, sdk.getHomePath) == 0)
+      case JdkByHome(homeFile)   => findMostRecentJdk(sdk =>
+        FileUtil.comparePaths(homeFile.getCanonicalPath, sdk.getHomePath) == 0 ||
+        FileUtil.pathsEqual(homeFile.getAbsolutePath, sdk.getHomePath))
       case _                     => None
     }
 


### PR DESCRIPTION
There are 2 issues that I found with JDK and BSP.
1. A lot of duplicate JDKs with the same names are created (1 per imported project). This is because `SdkUtils.findProjectSdk` compares provided path as canonical against existing jdk paths. This assumes that existing jdks have canonical paths which is not the case because no such conversion happens during creation of jdk (and this part is expected, we prefer to have jdk path as symlink to be able to easily update jdk without ruining all of the projects). Identical names is caused by not prechecking if such jdk exists. It then causes problems for users editing project model manually, as validation complains about duplicate names.
2. New JDK was alwasy created as isJre == true. Not sure if the default changed over the years or it worked accidentally with fastpass, but now with bazel-bsp it was problematic, as at least for java 8 if it is a JDK and we specify that it is JRE, it doesn't find all of the correct jars and basic JDK classes are not seen. I added a basic heuristic for this. Generally we usually want to assume it is JDK rather than JRE.