### PR TITLE
Ignore non http(s) resolvers when downloading scalafmt

### DIFF
--- a/scala/scala-impl/src/org/jetbrains/plugins/scala/lang/formatting/scalafmt/dynamic/ScalafmtDynamicDownloader.scala
+++ b/scala/scala-impl/src/org/jetbrains/plugins/scala/lang/formatting/scalafmt/dynamic/ScalafmtDynamicDownloader.scala
@@ -54,8 +54,16 @@ object ScalafmtDynamicDownloader {
   ) extends DependencyManagerBase {
 
     // first search in the provided resolvers, then fallback to the default ones
-    override protected def resolvers: Seq[Resolver] =
-      extraResolvers ++ super.resolvers
+    // but only use resolvers with http(s) protocol, to avoid problems with private repositories.
+    // (like gcs, s3, etc.) This is fine since scalafmt should always be published to a public repo.
+    override protected def resolvers: Seq[Resolver] = {
+      val HttpUrl = "(https?://.*)".r
+      (extraResolvers ++ super.resolvers).filter {
+        case MavenResolver(_, HttpUrl(_)) => true
+        case IvyResolver(_, HttpUrl(_))=> true
+        case _ => false
+      }
+    }
 
     override protected val logLevel: Int = org.apache.ivy.util.Message.MSG_INFO
 


### PR DESCRIPTION
This avoids errors while downloading scalafmt, when resolvers with non
http(s) protocols are defined (e.g. gcs or s3 urls) #SCL-19488