### PR TITLE
SCL-19526 Fix SOE in implicit search with raw types + f-bounds

### DIFF
--- a/scala/scala-impl/src/org/jetbrains/plugins/scala/lang/psi/implicits/ImplicitProcessor.scala
+++ b/scala/scala-impl/src/org/jetbrains/plugins/scala/lang/psi/implicits/ImplicitProcessor.scala
@@ -248,13 +248,13 @@ object ImplicitProcessor {
       }
 
       def collectSupers(clazz: PsiClass, subst: ScSubstitutor): Unit = {
-          clazz match {
-            case td: ScTemplateDefinition =>
-              collectPartsIter(td.superTypes.map(subst))
-            case clazz: PsiClass =>
-              collectPartsIter(clazz.getSuperTypes.map(t => subst(t.toScType())))
-          }
+        clazz match {
+          case td: ScTemplateDefinition =>
+            collectPartsIter(td.superTypes.map(subst))
+          case clazz: PsiClass =>
+            collectPartsIter(clazz.getSuperTypes.map(t => subst(t.toScType())))
         }
+      }
 
       tp match {
         case ScDesignatorType(v: ScBindingPattern) => collectPartsTr(v.`type`())

--- a/scala/scala-impl/src/org/jetbrains/plugins/scala/lang/psi/types/ScExistentialArgument.scala
+++ b/scala/scala-impl/src/org/jetbrains/plugins/scala/lang/psi/types/ScExistentialArgument.scala
@@ -28,6 +28,8 @@ trait ScExistentialArgument extends NamedType with ValueType {
 
   def initialize(): Unit = {}
 
+  def typeParamOfRawArg: Option[TypeParameter] = None
+
   override def equivInner(r: ScType, constraints: ConstraintSystem, falseUndef: Boolean): ConstraintsResult = {
     r match {
       case arg: ScExistentialArgument =>
@@ -57,10 +59,11 @@ object ScExistentialArgument {
   //used for representing type parameters of a java raw class type
   //it may have a reference to itself in it's bounds, so it cannot be fully initialized in constructor
   private class Deferred(
-    override val name:           String,
-    override val typeParameters: Seq[TypeParameter],
-    var lowerBound:              () => ScType,
-    var upperBound:              () => ScType
+    override val name:              String,
+    override val typeParameters:    Seq[TypeParameter],
+    override val typeParamOfRawArg: Option[TypeParameter],
+    var lowerBound:                 () => ScType,
+    var upperBound:                 () => ScType
   ) extends ScExistentialArgument {
     @volatile
     private var isInitialized: Boolean = false
@@ -147,10 +150,11 @@ object ScExistentialArgument {
   def deferred(
     name:           String,
     typeParameters: Seq[TypeParameter],
+    typeParamOfRaw: Option[TypeParameter],
     lower:          () => ScType,
     upper:          () => ScType
   ): ScExistentialArgument =
-    new Deferred(name, typeParameters, lower, upper)
+    new Deferred(name, typeParameters, typeParamOfRaw, lower, upper)
 
   def unapply(arg: ScExistentialArgument): Option[(String, Seq[TypeParameter], ScType, ScType)] =
     Some((arg.name, arg.typeParameters, arg.lower, arg.upper))

--- a/scala/scala-impl/src/org/jetbrains/plugins/scala/lang/resolve/processor/MostSpecificUtil.scala
+++ b/scala/scala-impl/src/org/jetbrains/plugins/scala/lang/resolve/processor/MostSpecificUtil.scala
@@ -85,6 +85,7 @@ case class MostSpecificUtil(elem: PsiElement, length: Int) {
           ScExistentialArgument.deferred(
             tp.name,
             tp.typeParameters,
+            None,
             () => existentialArgumentSubst(tp.lowerType),
             () => existentialArgumentSubst(tp.upperType)
           )


### PR DESCRIPTION
Because such types are represented with ScExistentialArgument.Deferred args
(which don't / can't have a useful equals), the recursion guard was being
bypassed.

Replace such Deferred args with dummy stand-in types comprising the
corresponding original class type parameter and the bounds, and use this
in the recursion guard instead.

I've also added a more efficient path for unbounded type parameters;
these can't cause cycles and so can use Complete existential args.
This is not functionally needed by the test. By itself, it would
fix this simpler version of the test:

```diff
-interface Column<V extends String>
+interface Column<V>
```