### PR TITLE
Limit maximum merged module name length to less than MaxFileNameLength

### DIFF
--- a/bsp/src/org/jetbrains/bsp/project/importing/BspResolverLogic.scala
+++ b/bsp/src/org/jetbrains/bsp/project/importing/BspResolverLogic.scala
@@ -399,6 +399,8 @@ private[importing] object BspResolverLogic {
     data
   }
 
+  private final val MaxFileNameLength = FileSystem.getCurrent.getMaxFileNameLength - 50
+
   private[importing] def sharedModuleId(targets: Seq[BuildTarget]): String = {
     val upperCaseWords = """(?<!(^|[A-Z]))(?=[A-Z])""".r
     val pascalCaseWords = """(?<!^)(?=[A-Z][a-z])""".r
@@ -418,9 +420,9 @@ private[importing] object BspResolverLogic {
     }
     val ret = head.map(combine).mkString +
       (if (tail.nonEmpty) tail.map(combine).mkString("(", "", ")") else tail.mkString)
-    if (ret.length > FileSystem.getCurrent.getMaxFileNameLength) {
+    if (ret.length > MaxFileNameLength) {
       val suffix = DigestUtils.md5Hex(ret)
-      val prefix = ret.substring(0, FileSystem.getCurrent.getMaxFileNameLength - suffix.length)
+      val prefix = ret.substring(0, MaxFileNameLength - suffix.length)
       prefix + suffix
     } else {
       ret


### PR DESCRIPTION
#618 attempted to fix this, but during the PR process we changed a 150 character limit to the system max file name length.  Unfortunately this causes issues, IJ may attempt to append `(shared)` to the file name, putting it back over the max limit.

This change adds a 50 character buffer in to allow extra modifications to the file name once created.