### PR TITLE
#SCL-20388: Enumerate modules recursively when building classpath

### DIFF
--- a/scala/scala-impl/src/org/jetbrains/plugins/scala/compiler/RemoteServerConnectorBase.scala
+++ b/scala/scala-impl/src/org/jetbrains/plugins/scala/compiler/RemoteServerConnectorBase.scala
@@ -61,7 +61,7 @@ abstract class RemoteServerConnectorBase(
     f.getCanonicalPath.stripSuffix("!").stripSuffix("!/")
 
   protected def assemblyRuntimeClasspath(): Seq[File] = {
-    val enumerator = OrderEnumerator.orderEntries(module).compileOnly()
+    val enumerator = OrderEnumerator.orderEntries(module).compileOnly().recursively()
     enumerator.getClassesRoots.map(_.toFile).toSeq
   }
 

--- a/scala/scala-impl/test/org/jetbrains/plugins/scala/compiler/TransitiveDependencyClasspathTest.scala
+++ b/scala/scala-impl/test/org/jetbrains/plugins/scala/compiler/TransitiveDependencyClasspathTest.scala
@@ -1,12 +1,14 @@
 package org.jetbrains.plugins.scala.compiler
 
 
-import com.intellij.openapi.module.JavaModuleType
+import com.intellij.openapi.module.{JavaModuleType, Module}
 import com.intellij.openapi.roots.{DependencyScope, ModuleRootModificationUtil}
 import com.intellij.testFramework.PsiTestUtil
 import org.jetbrains.plugins.scala.DependencyManagerBase.RichStr
 import org.jetbrains.plugins.scala.base.libraryLoaders.IvyManagedLoader
 import org.jetbrains.plugins.scala.findUsages.compilerReferences.ScalaCompilerReferenceServiceFixture
+
+import java.io.File
 
 class TransitiveDependencyClasspathTest extends ScalaCompilerReferenceServiceFixture {
   def testClasspathIncludesTransitiveModules(): Unit = {
@@ -20,12 +22,15 @@ class TransitiveDependencyClasspathTest extends ScalaCompilerReferenceServiceFix
     val libLoader = IvyManagedLoader("org.scalatest" %% "scalatest" % "3.2.0")
     libLoader.init(moduleB, version)
 
-    val remoteServerConnectorBase = new RemoteServerConnectorBase(moduleA, None, new java.io.File("/tmp")) {
-      def getResult(): Seq[java.io.File] = assemblyRuntimeClasspath()
-    }
+    val remoteServerConnectorBase = new TestRemoteServerConnectorBase(moduleA, None, new java.io.File("/tmp"))
 
     val r = remoteServerConnectorBase.getResult()
     assert(r.exists(_.toString.contains("scalatest")))
   }
 
+}
+
+class TestRemoteServerConnectorBase (module: Module, filesToCompile: Option[Seq[File]], outputDir: File)
+    extends RemoteServerConnectorBase(module, filesToCompile, outputDir) {
+  def getResult(): Seq[java.io.File] = assemblyRuntimeClasspath()
 }

--- a/scala/scala-impl/test/org/jetbrains/plugins/scala/compiler/TransitiveDependencyClasspathTest.scala
+++ b/scala/scala-impl/test/org/jetbrains/plugins/scala/compiler/TransitiveDependencyClasspathTest.scala
@@ -1,0 +1,31 @@
+package org.jetbrains.plugins.scala.compiler
+
+
+import com.intellij.openapi.module.JavaModuleType
+import com.intellij.openapi.roots.{DependencyScope, ModuleRootModificationUtil}
+import com.intellij.testFramework.PsiTestUtil
+import org.jetbrains.plugins.scala.DependencyManagerBase.RichStr
+import org.jetbrains.plugins.scala.base.libraryLoaders.IvyManagedLoader
+import org.jetbrains.plugins.scala.findUsages.compilerReferences.ScalaCompilerReferenceServiceFixture
+
+class TransitiveDependencyClasspathTest extends ScalaCompilerReferenceServiceFixture {
+  def testClasspathIncludesTransitiveModules(): Unit = {
+    val moduleA = PsiTestUtil.addModule(getProject, JavaModuleType.getModuleType, "A", myFixture.getTempDirFixture.findOrCreateDir("A"))
+    val moduleB = PsiTestUtil.addModule(getProject, JavaModuleType.getModuleType, "B", myFixture.getTempDirFixture.findOrCreateDir("B"))
+    ModuleRootModificationUtil.addDependency(moduleA, getModule)
+    ModuleRootModificationUtil.addDependency(moduleB, getModule)
+    ModuleRootModificationUtil.addDependency(moduleA, moduleB, DependencyScope.COMPILE, true)
+    setUpLibrariesFor(moduleA, moduleB)
+
+    val libLoader = IvyManagedLoader("org.scalatest" %% "scalatest" % "3.2.0")
+    libLoader.init(moduleB, version)
+
+    val remoteServerConnectorBase = new RemoteServerConnectorBase(moduleA, None, new java.io.File("/tmp")) {
+      def getResult(): Seq[java.io.File] = assemblyRuntimeClasspath()
+    }
+
+    val r = remoteServerConnectorBase.getResult()
+    assert(r.exists(_.toString.contains("scalatest")))
+  }
+
+}


### PR DESCRIPTION
This way the classpath of transitive modules will also be added to the runtime classpath.