### PR TITLE
Changed getCanonicalPath to custom toCanonicalPath

### DIFF
--- a/bsp/src/org/jetbrains/bsp/project/importing/BspResolverLogic.scala
+++ b/bsp/src/org/jetbrains/bsp/project/importing/BspResolverLogic.scala
@@ -515,6 +515,13 @@ private[importing] object BspResolverLogic {
       case (first, _) => first
     }
 
+  // extension method added as for better performance than getCanonicalPath method
+  implicit class FileExtensions(val f: File){
+    def getCanonicalPathSimplified: String = {
+      f.toPath.toAbsolutePath.normalize().toString
+    }
+  }
+
   private val jarSuffix = ".jar"
   private val sourcesSuffixes = Seq("-sources", "-src")
   private val javadocSuffix = "-javadoc"
@@ -525,7 +532,7 @@ private[importing] object BspResolverLogic {
       .stripSuffix(javadocSuffix)
   private def libraryPrefix(path: File) =
     if (path.getName.endsWith(jarSuffix))
-      Option(stripSuffixes(path.getCanonicalPath))
+      Option(stripSuffixes(path.getCanonicalPathSimplified))
     else None
   private def libraryName(path: File) =
     stripSuffixes(path.getName)
@@ -535,8 +542,8 @@ private[importing] object BspResolverLogic {
                                      excludedPaths: List[File]
                                    ): DataNode[ProjectData] = {
 
-    val projectRootPath = workspace.getCanonicalPath
-    val moduleFileDirectoryPath = moduleFilesDirectory(workspace).getCanonicalPath
+    val projectRootPath = workspace.getCanonicalPathSimplified
+    val moduleFileDirectoryPath = moduleFilesDirectory(workspace).getCanonicalPathSimplified
     val projectRoot = new File(projectRootPath)
     val projectData = new ProjectData(BSP.ProjectSystemId, projectRoot.getName, projectRootPath, projectRootPath)
     val projectNode = new DataNode[ProjectData](ProjectKeys.PROJECT, projectData, null)
@@ -548,7 +555,7 @@ private[importing] object BspResolverLogic {
         val name = projectRoot.getName + "-root"
         val moduleData = new ModuleData(name, BSP.ProjectSystemId, BspSyntheticModuleType.Id, name, moduleFileDirectoryPath, projectRootPath)
         val moduleNode = new DataNode[ModuleData](ProjectKeys.MODULE, moduleData, projectNode)
-        val contentRootData = new ContentRootData(BSP.ProjectSystemId, projectRoot.getCanonicalPath)
+        val contentRootData = new ContentRootData(BSP.ProjectSystemId, projectRoot.getCanonicalPathSimplified)
         val contentRootDataNode = new DataNode[ContentRootData](ProjectKeys.CONTENT_ROOT, contentRootData, moduleNode)
         moduleNode.addChild(contentRootDataNode)
 
@@ -572,14 +579,14 @@ private[importing] object BspResolverLogic {
           else prefixLibs.map { case prefix -> files => prefix -> (prefix,files) }
         }
         .flatMap { case (pathPrefix, (name, jars)) =>
-          val binary = jars.find(_.getCanonicalPath.endsWith(pathPrefix + jarSuffix))
+          val binary = jars.find(_.getCanonicalPathSimplified.endsWith(pathPrefix + jarSuffix))
           val source = jars.find(j => sourcesSuffixes.exists(j.getName.contains))
           val doc = jars.find(_.getName.contains(javadocSuffix))
           binary.map { bin =>
             val data = new LibraryData(BSP.ProjectSystemId, name)
-            data.addPath(LibraryPathType.BINARY, bin.getCanonicalPath)
-            source.foreach(src => data.addPath(LibraryPathType.SOURCE, src.getCanonicalPath))
-            doc.foreach(doc => data.addPath(LibraryPathType.DOC, doc.getCanonicalPath))
+            data.addPath(LibraryPathType.BINARY, bin.getCanonicalPathSimplified)
+            source.foreach(src => data.addPath(LibraryPathType.SOURCE, src.getCanonicalPathSimplified))
+            doc.foreach(doc => data.addPath(LibraryPathType.DOC, doc.getCanonicalPathSimplified))
             pathPrefix -> data
           }
         }
@@ -665,7 +672,7 @@ private[importing] object BspResolverLogic {
     val moduleDescriptionData = moduleDescription.data
 
     val moduleBase: Option[ContentRootData] = moduleDescriptionData.basePath.map { path =>
-      val base = path.getCanonicalPath
+      val base = path.getCanonicalPathSimplified
       new ContentRootData(BSP.ProjectSystemId, base)
     }
     val sourceRoots = moduleDescriptionData.sourceDirs.map { dir =>
@@ -699,10 +706,10 @@ private[importing] object BspResolverLogic {
     val moduleData = new ModuleData(moduleDescriptionData.id, BSP.ProjectSystemId, moduleType.getId, moduleName, moduleFileDirectoryPath, projectRootPath)
 
     moduleDescriptionData.output.foreach { outputPath =>
-      moduleData.setCompileOutputPath(SOURCE, outputPath.getCanonicalPath)
+      moduleData.setCompileOutputPath(SOURCE, outputPath.getCanonicalPathSimplified)
     }
     moduleDescriptionData.testOutput.foreach { outputPath =>
-      moduleData.setCompileOutputPath(TEST, outputPath.getCanonicalPath)
+      moduleData.setCompileOutputPath(TEST, outputPath.getCanonicalPathSimplified)
     }
 
     moduleData.setInheritProjectCompileOutputPath(false)
@@ -738,8 +745,8 @@ private[importing] object BspResolverLogic {
 
     def configureLibraryDependencyData(name: String, scope: DependencyScope, libs: Iterable[File], sources: Iterable[File]) = {
       val libraryData = new LibraryData(BSP.ProjectSystemId, name)
-      libs.foreach { path => libraryData.addPath(LibraryPathType.BINARY, path.getCanonicalPath) }
-      sources.foreach { path => libraryData.addPath(LibraryPathType.SOURCE, path.getCanonicalPath) }
+      libs.foreach { path => libraryData.addPath(LibraryPathType.BINARY, path.getCanonicalPathSimplified) }
+      sources.foreach { path => libraryData.addPath(LibraryPathType.SOURCE, path.getCanonicalPathSimplified) }
       val libraryDependencyData = new LibraryDependencyData(moduleData, libraryData, LibraryLevel.MODULE)
       libraryDependencyData.setScope(scope)
       libraryDependencyData
@@ -776,7 +783,7 @@ private[importing] object BspResolverLogic {
     val contentRootData: Iterable[ContentRootData] = {
       val rootPathToData: Seq[(String, ContentRootData)] = allSourceRoots.map { case (sourceType, root) =>
         val data = getContentRoot(root.directory, moduleBase)
-        data.storePath(sourceType, root.directory.getCanonicalPath, root.packagePrefix.orNull)
+        data.storePath(sourceType, root.directory.getCanonicalPathSimplified, root.packagePrefix.orNull)
         data.getRootPath -> data
       }
       // effectively deduplicate by content root path. ContentRootData does not implement equals correctly
@@ -813,10 +820,10 @@ private[importing] object BspResolverLogic {
   private[importing] def getContentRoot(dir: File, moduleBase: Option[ContentRootData]) = {
     val baseRoot = for {
       contentRoot <- moduleBase
-      if FileUtil.isAncestor(contentRoot.getRootPath, dir.getCanonicalPath, false)
+      if FileUtil.isAncestor(contentRoot.getRootPath, dir.getCanonicalPathSimplified, false)
     } yield contentRoot
 
-    baseRoot.getOrElse(new ContentRootData(BSP.ProjectSystemId, dir.getCanonicalPath))
+    baseRoot.getOrElse(new ContentRootData(BSP.ProjectSystemId, dir.getCanonicalPathSimplified))
   }
 
 
@@ -928,8 +935,8 @@ private[importing] object BspResolverLogic {
   private[importing] case class Library(name: String, binary: File, sources: Option[File]) {
     val data: LibraryData = {
       val libraryData = new LibraryData(BSP.ProjectSystemId, name)
-      libraryData.addPath(LibraryPathType.BINARY, binary.getCanonicalPath)
-      sources.foreach(src => libraryData.addPath(LibraryPathType.BINARY, src.getCanonicalPath))
+      libraryData.addPath(LibraryPathType.BINARY, binary.getCanonicalPathSimplified)
+      sources.foreach(src => libraryData.addPath(LibraryPathType.BINARY, src.getCanonicalPathSimplified))
       libraryData
     }
   }


### PR DESCRIPTION
Using method getCanonicalPath was very aggravating for CPU and made imports last longer. I added custom toCanonicalPath implicit method that only take AbsolutePath and normalize it which I think is enough and which makes imports faster(for example: before change - ca.11min, after change- ca.3min)