### PR TITLE
Add json, html, js to interpolated injection mappings

### DIFF
--- a/scala/scala-impl/src/org/jetbrains/plugins/scala/settings/ScalaProjectSettings.java
+++ b/scala/scala-impl/src/org/jetbrains/plugins/scala/settings/ScalaProjectSettings.java
@@ -108,6 +108,8 @@ public class ScalaProjectSettings implements PersistentStateComponent<ScalaProje
   private Map<String, String> INTERPOLATED_INJECTION_MAPPING = new HashMap<>();
 
   {
+    INTERPOLATED_INJECTION_MAPPING.put("html", "HTML");
+    INTERPOLATED_INJECTION_MAPPING.put("js", "JavaScript");
     INTERPOLATED_INJECTION_MAPPING.put("json", "JSON");
     INTERPOLATED_INJECTION_MAPPING.put("sql", "SQL");
     INTERPOLATED_INJECTION_MAPPING.put("sqlu", "SQL");

--- a/scala/scala-impl/src/org/jetbrains/plugins/scala/settings/ScalaProjectSettings.java
+++ b/scala/scala-impl/src/org/jetbrains/plugins/scala/settings/ScalaProjectSettings.java
@@ -108,6 +108,7 @@ public class ScalaProjectSettings implements PersistentStateComponent<ScalaProje
   private Map<String, String> INTERPOLATED_INJECTION_MAPPING = new HashMap<>();
 
   {
+    INTERPOLATED_INJECTION_MAPPING.put("json", "JSON");
     INTERPOLATED_INJECTION_MAPPING.put("sql", "SQL");
     INTERPOLATED_INJECTION_MAPPING.put("sqlu", "SQL");
     INTERPOLATED_INJECTION_MAPPING.put("xml", "XML");


### PR DESCRIPTION
issue: https://youtrack.jetbrains.com/issue/SCL-16050/language-injection-via-interpolation-add-default-interpolators-for-htmljsonjsetc

I've manually tested that this works as expected for json and html - I wasn't able to manually test for JS because it isn't supported by community edition. Unfortunately I've had some difficulties with getting tests to run locally.