### PR TITLE
Detect all VCS roots of imported project

### DIFF
--- a/bsp/src/org/jetbrains/bsp/data/BspProjectDataService.scala
+++ b/bsp/src/org/jetbrains/bsp/data/BspProjectDataService.scala
@@ -39,7 +39,7 @@ class BspProjectDataService extends ScalaAbstractProjectDataService[BspProjectDa
 
     val detectedRoots = {
       val detector = project.getService(classOf[VcsRootDetector])
-      val detected = mutable.Set[VcsRoot](currentVcsRoots.toIndexedSeq: _*)
+      val detected = mutable.Set[VcsRoot]()
       vcsRootsCandidates
         .iterator
         .map(LocalFileSystem.getInstance.findFileByIoFile)


### PR DESCRIPTION
Previously, when a BSP's project root and the target it imports had
different VCS roots, the VCS roots of the targets could be ignored.
For instance, this would happen when:

 - /home/user is a VCS root
 - /home/user/projects/my-project is the BSP project root
 - /home/user/code is a VCS root where the BSP targets live.

Initially, before the BSP import, IntelliJ would register `/home/user`
as VCS root (probably because the VCS root, from the point of view of
the BSP project root, is `/home/user`). When importing the BSP targets,
which live under `/home/user/code`, IntelliJ would not attempt to
discover their VCS root because the targets live under a known VCS root.

This commit fixes the issue by considering the VCS roots of the BSP
targets, regardless of the known VCS roots before import.

Note that this logic may still lead to missing VCS root (for instance,
if a BSP target's VCS root is a child of another VCS root). To ensure
correctness, we should try and find the VCS root of every BSP
target individually, at the cost of a slower project import.