### PR TITLE
Fix off-by-one error in line numbers

### DIFF
--- a/scala/scala-impl/src/org/jetbrains/plugins/scala/debugger/LocationLineManager.scala
+++ b/scala/scala-impl/src/org/jetbrains/plugins/scala/debugger/LocationLineManager.scala
@@ -30,7 +30,7 @@ trait LocationLineManager {
 
   def exactLineNumber(location: Location): Int = location match {
     case gen: GeneratedLocation =>
-      gen.lineNumber()
+      ScalaPositionManager.checkedLineNumber(gen)
     case _ =>
       checkAndUpdateCaches(location.declaringType())
       customizedLocationsCache.getOrElse(location, ScalaPositionManager.checkedLineNumber(location))


### PR DESCRIPTION
We need a zero-based line number in this context.