### PR TITLE
Use sbt 1.5 syntax for dumpStructureTo

### DIFF
--- a/scala/scala-impl/src/org/jetbrains/sbt/project/structure/SbtStructureDump.scala
+++ b/scala/scala-impl/src/org/jetbrains/sbt/project/structure/SbtStructureDump.scala
@@ -64,7 +64,7 @@ class SbtStructureDump {
         ideaPort.fold("")(port => s"; set ideaPort in Global := $port")
       } else ""
 
-    val cmd = s";reload; $setCmd ;${if (preferScala2) "preferScala2;" else ""}*/*:dumpStructureTo $structureFilePath; session clear-all $ideaPortSetting"
+    val cmd = s";reload; $setCmd ;${if (preferScala2) "preferScala2;" else ""}*/*/dumpStructureTo $structureFilePath; session clear-all $ideaPortSetting"
     val aggregator = shellMessageAggregator(EventId(s"dump:${UUID.randomUUID()}"), shell, reporter)
 
     shell.command(cmd, BuildMessages.empty, aggregator)


### PR DESCRIPTION
With sbt 1.5+ I started receiving warnings while reloading sbt project in Idea

`[warn] sbt 0.13 shell syntax is deprecated; use slash syntax instead: Global / dumpStructureTo`

This happens because sbt 1.5 deprecated sbt 0.13 syntax with : separator

Here's the ticket [SCL-18893](https://youtrack.jetbrains.com/issue/SCL-18893)