### PR TITLE
add comparison of test module and run configuration module

### DIFF
--- a/scala/scala-impl/src/org/jetbrains/plugins/scala/testingSupport/test/AbstractTestConfigurationProducer.scala
+++ b/scala/scala-impl/src/org/jetbrains/plugins/scala/testingSupport/test/AbstractTestConfigurationProducer.scala
@@ -205,7 +205,7 @@ abstract class AbstractTestConfigurationProducer[T <: AbstractTestRunConfigurati
     else if (TestConfigurationUtil.isPackageConfiguration(location.getPsiElement, configuration))
       true
     else
-      isClassOfTestConfigurationFromLocation(configuration, location)
+      sameModules(configuration, context) && isClassOfTestConfigurationFromLocation(configuration, location)
   }
 
   protected def isClassOfTestConfigurationFromLocation(configuration: T, location: PsiElementLocation): Boolean = {


### PR DESCRIPTION
When there are tests with the same name in different modules, IDE uses the same run configuration, which leads to the launch of the wrong tests.

Example project https://github.com/cobr123/tests_with_same_name_in_two_modules