### PR TITLE
Set Terminal start directory to VCS root for BSP projects

### DIFF
--- a/bsp/resources/META-INF/BSP-Terminal.xml
+++ b/bsp/resources/META-INF/BSP-Terminal.xml
@@ -1,0 +1,5 @@
+<idea-plugin>
+    <extensions defaultExtensionNs="com.intellij">
+        <bspVcsRootExtension implementation="org.jetbrains.bsp.data.TerminalStartDirectoryConfig"/>
+    </extensions>
+</idea-plugin>

--- a/bsp/resources/META-INF/BSP.xml
+++ b/bsp/resources/META-INF/BSP.xml
@@ -2,12 +2,16 @@
 
 <idea-plugin>
     <depends optional="true" config-file="BSP-JUnit.xml">JUnit</depends>
+    <depends optional="true" config-file="BSP-Terminal.xml">org.jetbrains.plugins.terminal</depends>
     <extensionPoints>
         <extensionPoint qualifiedName="com.intellij.bspEnvironmentRunnerExtension"
                         interface="org.jetbrains.bsp.project.test.environment.BspEnvironmentRunnerExtension"
                         dynamic="true"/>
         <extensionPoint qualifiedName="com.intellij.bspResolverNamingExtension"
                         interface="org.jetbrains.bsp.project.importing.BspResolverNamingExtension"
+                        dynamic="true"/>
+        <extensionPoint qualifiedName="com.intellij.bspVcsRootExtension"
+                        interface="org.jetbrains.bsp.data.BspVcsRootExtension"
                         dynamic="true"/>
     </extensionPoints>
 

--- a/bsp/src/org/jetbrains/bsp/data/BspProjectDataService.scala
+++ b/bsp/src/org/jetbrains/bsp/data/BspProjectDataService.scala
@@ -60,6 +60,9 @@ class BspProjectDataService extends ScalaAbstractProjectDataService[BspProjectDa
     val allMappings = (currentMappings.asScala ++ newMappings).asJava
 
     vcsManager.setDirectoryMappings(allMappings)
+    if (newMappings.nonEmpty) {
+      BspVcsRootExtension.onVcsRootAdded(project)
+    }
   }
 
   private def configureJdk(jdk: Option[SdkReference])(implicit project: ProjectContext): Unit = executeProjectChangeAction {

--- a/bsp/src/org/jetbrains/bsp/data/BspVcsRootExtension.scala
+++ b/bsp/src/org/jetbrains/bsp/data/BspVcsRootExtension.scala
@@ -1,0 +1,14 @@
+package org.jetbrains.bsp.data
+
+import com.intellij.openapi.project.Project
+import org.jetbrains.plugins.scala.ExtensionPointDeclaration
+
+trait BspVcsRootExtension {
+  def onVcsRootAdded(project: Project): Unit
+}
+
+object BspVcsRootExtension extends ExtensionPointDeclaration[BspVcsRootExtension]("com.intellij.bspVcsRootExtension") {
+  def onVcsRootAdded(project: Project): Unit = {
+    implementations.foreach(_.onVcsRootAdded(project))
+  }
+}

--- a/bsp/src/org/jetbrains/bsp/data/TerminalStartDirectoryConfig.scala
+++ b/bsp/src/org/jetbrains/bsp/data/TerminalStartDirectoryConfig.scala
@@ -1,0 +1,26 @@
+package org.jetbrains.bsp.data
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vcs.ProjectLevelVcsManager
+import org.jetbrains.plugins.terminal.TerminalProjectOptionsProvider
+
+import scala.jdk.CollectionConverters._
+
+// If the IJ project root does not match workspace git root, the terminal
+// starting directory will be set to IJ project root, which is usually not
+// what users want and they need to change the directory each time.
+// This class convigures terminal start dir to the vcs root.
+class TerminalStartDirectoryConfig extends BspVcsRootExtension {
+
+  def onVcsRootAdded(project: Project): Unit = {
+    val terminal = project.getService(classOf[TerminalProjectOptionsProvider])
+    if (terminal.getDefaultStartingDirectory == terminal.getStartingDirectory) {
+      val vcsManager = ProjectLevelVcsManager.getInstance(project)
+      val currentMappings = vcsManager.getDirectoryMappings
+      currentMappings.asScala.map(_.getDirectory).sortBy(-_.length).headOption.foreach { longestVCSRootPath =>
+        terminal.setStartingDirectory(longestVCSRootPath)
+      }
+    }
+  }
+
+}

--- a/build.sbt
+++ b/build.sbt
@@ -466,6 +466,7 @@ lazy val bsp =
     .settings(
       libraryDependencies ++= DependencyGroups.bsp,
       intellijPlugins += "JUnit".toPlugin,
+      intellijPlugins += "org.jetbrains.plugins.terminal".toPlugin,
       buildInfoPackage := "org.jetbrains.bsp.buildinfo",
       buildInfoKeys := Seq("bloopVersion" -> Versions.bloopVersion),
       buildInfoOptions += BuildInfoOption.ConstantValue,


### PR DESCRIPTION
If the IJ project root does not match workspace git root, the terminal starting directory will be set to IJ project root, which is usually not what users want and they need to change the directory each time. They open a new terminal, or they need to change their terminal settings manually. 
Bsp project can be created outside of the project root or in a subdirectory of it, but to invoke build tool from terminal or interact with git, users want to be at their workspace root in the terminal.
