### PR TITLE
UTest - Fixes

### DIFF
--- a/scala/test-integration/test-runners/src/org/jetbrains/plugins/scala/testingSupport/uTest/UTestRunnerArgs.java
+++ b/scala/test-integration/test-runners/src/org/jetbrains/plugins/scala/testingSupport/uTest/UTestRunnerArgs.java
@@ -36,7 +36,7 @@ public final class UTestRunnerArgs {
                     ++argIdx;
                     if (currentClass == null)
                         throw new RuntimeException("Failed to run tests: no suite class specified for test " + args.get(argIdx));
-                    while (!args.get(argIdx).startsWith("-")) {
+                    while (argIdx < args.size() && !args.get(argIdx).startsWith("-")) {
                         String testName = args.get(argIdx);
                         UTestPath testPath = parseTestPathSafe(currentClass, testName);
                         if (testPath != null)

--- a/scala/test-integration/test-runners/src/org/jetbrains/plugins/scala/testingSupport/uTest/utils/UTestTreeUtils.java
+++ b/scala/test-integration/test-runners/src/org/jetbrains/plugins/scala/testingSupport/uTest/utils/UTestTreeUtils.java
@@ -143,7 +143,11 @@ public class UTestTreeUtils {
         try {
             tree = new Tree<>(walkup, childrenScala);
         } catch (NoSuchMethodError error) {
-            tree = newTree_213(walkup, childrenScala);
+            try {
+                tree = newTree_213(walkup, childrenScala);
+            } catch (NoSuchMethodError error_213) {
+                tree = newTree_212(walkup, childrenScala.toSeq());
+            }
         }
         return tree;
     }
@@ -153,6 +157,18 @@ public class UTestTreeUtils {
         try {
             Class<Tree> clazz = Tree.class;
             Constructor<Tree> constructor = clazz.getConstructor(java.lang.Object.class, scala.collection.immutable.Seq.class);
+            return (Tree<T>) constructor.newInstance(walkup, childrenScala);
+        } catch (NoSuchMethodException | IllegalAccessException | InstantiationException | InvocationTargetException e) {
+            e.printStackTrace();
+            throw expectedError(errorMessage(e));
+        }
+    }
+
+    @SuppressWarnings({"rawtypes", "JavaReflectionMemberAccess", "unchecked"})
+    private static <T> Tree<T> newTree_212(T walkup, scala.collection.Seq<Tree<String>> childrenScala) throws UTestRunExpectedError {
+        try {
+            Class<Tree> clazz = Tree.class;
+            Constructor<Tree> constructor = clazz.getConstructor(java.lang.Object.class, scala.collection.Seq.class);
             return (Tree<T>) constructor.newInstance(walkup, childrenScala);
         } catch (NoSuchMethodException | IllegalAccessException | InstantiationException | InvocationTargetException e) {
             e.printStackTrace();


### PR DESCRIPTION
First commit fixes index out of bounds when specifying `-testName` as last argument
Second commit fixes running inner test in uTest when using scala 2.12, I couldn't reproduce this in a test, but it's easily reproducible in a project: 

MyUTest.scala:
```
package com.shanielh

import org.scalatest.flatspec.AnyFlatSpec
import org.scalatest.funspec.AnyFunSpec
import org.scalatest.matchers.should.Matchers
import utest.{TestSuite, Tests, test}

object MyUTest extends TestSuite {

  val tests = Tests {

    test("outer") {

      test("haha") {
        assert(1 == 1)
      }

      test("outer_2") {
        test("my_test") {
          assert(1 == 1)
        }

        test("myothertest") {
          assert(1 == 2)
        }
      }
    }
  }
}

```

build.sbt:
```
ThisBuild / version := "0.1.0-SNAPSHOT"

ThisBuild / scalaVersion := "2.12.17"

lazy val root = (project in file("."))
  .settings(
    name := "test"
  )

libraryDependencies += "com.lihaoyi" %% "utest" % "0.8.1" % "test"

testFrameworks += new TestFramework("utest.runner.Framework")
```

Place the selection inside `test("haha")` and try running using Ctrl + Shift + R / D, test will not run, with the following console output: 

```
java.lang.NoSuchMethodException: utest.framework.Tree.<init>(java.lang.Object,scala.collection.immutable.Seq)
	at java.base/java.lang.Class.getConstructor0(Class.java:3585)
	at java.base/java.lang.Class.getConstructor(Class.java:2271)
	at org.jetbrains.plugins.scala.testingSupport.uTest.utils.UTestTreeUtils.newTree_213(UTestTreeUtils.java:155)
	at org.jetbrains.plugins.scala.testingSupport.uTest.utils.UTestTreeUtils.newTree(UTestTreeUtils.java:146)
	at org.jetbrains.plugins.scala.testingSupport.uTest.utils.UTestTreeUtils.getTestsSubTreeWithPathToRoot(UTestTreeUtils.java:129)
	at org.jetbrains.plugins.scala.testingSupport.uTest.UTestSuiteRunner.doRunTestSuite(UTestSuiteRunner.java:95)
	at org.jetbrains.plugins.scala.testingSupport.uTest.UTestSuiteRunner.runTestSuite(UTestSuiteRunner.java:57)
	at org.jetbrains.plugins.scala.testingSupport.uTest.UTestSuiteRunner.runTestSuites(UTestSuiteRunner.java:45)
	at org.jetbrains.plugins.scala.testingSupport.uTest.UTestRunner.main(UTestRunner.java:12)
NoSuchMethodException: utest.framework.Tree.<init>(java.lang.Object,scala.collection.immutable.Seq)
```