### PR TITLE
Use exact source roots from BSP where possible

### DIFF
--- a/bsp/src/org/jetbrains/bsp/BspUtil.scala
+++ b/bsp/src/org/jetbrains/bsp/BspUtil.scala
@@ -80,7 +80,8 @@ object BspUtil {
   }
 
   implicit class URIOps(uri: URI) {
-    def toFile: File = Paths.get(uri).toFile
+    def toFile: File = uri.toPath.toFile
+    def toPath: Path = Paths.get(uri)
   }
 
   implicit class CompletableFutureOps[T](cf: CompletableFuture[T]) {

--- a/bsp/src/org/jetbrains/bsp/project/importing/BspResolverLogic.scala
+++ b/bsp/src/org/jetbrains/bsp/project/importing/BspResolverLogic.scala
@@ -117,7 +117,7 @@ private[importing] object BspResolverLogic {
       .map(item => (item.getTarget, item.getOutputPaths.asScala.iterator.map(_.getUri.toURI.toFile).toSeq))
       .toMap
 
-    // Source roots (repoted by BSP) that are not shared with other targets
+    // Source roots (reported by BSP) that are not shared with other targets
     val exclusiveSourceRoots = sourcesItems
       .flatMap(item => item.getRoots.asScala.map(_ -> item.getTarget))
       .groupBy(_._1).view.mapValues(_.map(_._2).toSet)
@@ -965,8 +965,7 @@ private[importing] object BspResolverLogic {
     // 1. synthetic module is depended on by all its parent targets
     // 2. synthetic module depends on all parent target's dependencies
     val dependencyByParent = moduleDependencies.groupBy(_.parent)
-
-    for {
+    val fromParentDeps = for {
       moduleDescription <- projectModules.synthetic
       synthParent <- moduleDescription.data.targets
       dep <- {
@@ -980,6 +979,31 @@ private[importing] object BspResolverLogic {
         parentSynthDependency +: inheritedDeps
       }
     } yield dep
+
+    // If a module is synthetic it composed of multiple targets. For the logic above to work,
+    // these targets need to be present as modules (non-synthetic).
+    // If modules share the same basePath, they will be merged (look at mergedBase in calculateModuleDescriptions)
+    // and hence disappear from the non synthetic modules and dependency cannot be found.
+    // example of such situation:
+    // module/test/fixture
+    // module/test/x/TestA.scala
+    // module/test/x/TestB.scala
+    // Each line is representing a target. All of them have basePath as module/test for valid reasons.
+    // TestA.scala and TestB.scala will be a synthetic target.
+    val fromDirectDeps = for {
+      moduleDescription <- projectModules.synthetic
+      dep <- {
+        val synthId = SynthId(moduleDescription.data.idUri)
+
+        def mapDependencies(targetIds: Seq[BuildTargetIdentifier], scope: DependencyScope) =
+          targetIds.map(id => ModuleDep(synthId, TargetId(id.getUri), scope, `export` = false))
+
+        val sourceDeps = mapDependencies(moduleDescription.data.targetDependencies, DependencyScope.COMPILE)
+        val testDeps = mapDependencies(moduleDescription.data.targetTestDependencies, DependencyScope.TEST)
+        sourceDeps ++ testDeps
+      }
+    } yield dep
+    (fromParentDeps ++ fromDirectDeps).distinct
   }
 
   private[importing] def addModuleDependencies(dependencies: Seq[ModuleDep],


### PR DESCRIPTION
Reasoning is explained in the code comments.
Generally, if someone uses bazel and follows maven structure and keeps a target per standard source set, it will look more natural. The real problem that I am solving here is that something that should be 1 source set becomes 5 source sets, randomly assigned based on enclosing directory and it is inconvenient to run all tests in given module from IntelliJ.