### PR TITLE
SmartJDKLoader: Fix discoverJDK considering JDK installed with SDKMAN.

### DIFF
--- a/scala/scala-impl/test/org/jetbrains/plugins/scala/base/libraryLoaders/SmartJDKLoader.scala
+++ b/scala/scala-impl/test/org/jetbrains/plugins/scala/base/libraryLoaders/SmartJDKLoader.scala
@@ -64,6 +64,7 @@ object SmartJDKLoader {
       userHome + "/Library/Java/JavaVirtualMachines", // mac style
       userHome + "/.jabba/jdk", // jabba (for github actions)
       userHome + "/.jdks", // by default IDEA downloads JDKs here
+      userHome + "/.sdkman/candidates/java" // SDKMAN style
     )
   }
 
@@ -98,7 +99,7 @@ object SmartJDKLoader {
     val versionStrings = Seq(s"1.$versionMajor", s"-$versionMajor", s"jdk$versionMajor")
     val fromEnv = sys.env.get(jdkVersion.toString).orElse(sys.env.get(s"${jdkVersion}_0"))
     val fromEnv64 = sys.env.get(s"${jdkVersion}_x64").orElse(sys.env.get(s"${jdkVersion}_0_x64")) // teamcity style
-    val priorityPaths = Seq(currentJava(versionMajor), fromEnv.orElse(fromEnv64).map(new File(_))).flatten
+    val priorityPaths = Seq(currentJava(versionMajor), fromEnv.orElse(fromEnv64)).flatten.map(new File(_))
 
     priorityPaths.headOption
       .orElse {
@@ -119,7 +120,7 @@ object SmartJDKLoader {
           b.getName == "bin" &&
             b.listFiles().exists(x => x.getName == "javac.exe" || x.getName == "javac")
         }
-    }
+      }.orElse(Some(dir))
   }
 
   private def inJvm(path: String, versionString: String): List[File] =
@@ -132,13 +133,12 @@ object SmartJDKLoader {
           .reverse
           .filter(_.getName.contains(versionString))
           .flatMap(findJDK)
-        }
+      }
 
   private def currentJava(versionMajor: String) =
     Some(SystemInfo.JAVA_VERSION)
       .filter(v => v.startsWith(s"1.$versionMajor") || v.startsWith(versionMajor))
       .flatMap(_ => sys.props.get("java.home"))
-      .flatMap(d => findJDK(new File(d).getParentFile))
 }
 
 


### PR DESCRIPTION
Following the **Setting up the project -> Running The Tests** in the [README.md](https://github.com/JetBrains/intellij-scala#running-the-tests) I launched the `runTypeInferenceTests` task in the sbt shell to run tests.

I noticed that tests failed as soon as the `SmartJDKLoader` tried to find a valid JDK on my machine.

I'm currently using JDK 17 (either temurin or corretto) installed with [SDKMAN](https://sdkman.io/) and not that from Oracle is not installed on my machine, so my `JAVA_HOME` path is not the MacOS default but `$HOME/.sdkman/candidates/java` which was not found by the SmarJDKLoader since there is an ad-hoc implementation for Mac.

**STEPS TO REPRODUCE THE ISSUE**

1. Delete or uninstall  existing Java installation on Mac (`/Library/Java/JavaVirtualMachines`)
2. Go into the sbt shell.
3. Then launch clean and `packageArtifact `.
4. Finally launch `runTypeInferenceTests`.

The errors I've got were:

```
[error] Test org.jetbrains.plugins.scala.lang.typeInference.ArrayTypesConformanceTest.testSCL18020 failed: java.lang.AssertionError: Couldn't find JDK_17, took 0.015 sec
[error]     at org.jetbrains.plugins.scala.base.libraryLoaders.SmartJDKLoader$.createNewJdk(SmartJDKLoader.scala:87)
[error]     at org.jetbrains.plugins.scala.base.libraryLoaders.SmartJDKLoader$.$anonfun$getOrCreateJDK$1(SmartJDKLoader.scala:77)
[error]     at scala.Option.getOrElse(Option.scala:201)
[error]     at org.jetbrains.plugins.scala.base.libraryLoaders.SmartJDKLoader$.getOrCreateJDK(SmartJDKLoader.scala:76)
[error]     at org.jetbrains.plugins.scala.base.ScalaLightCodeInsightFixtureTestCase$$anon$1.getSdk(ScalaLightCodeInsightFixtureTestCase.scala:73)
[error]     at com.intellij.testFramework.LightProjectDescriptor.registerSdk(LightProjectDescriptor.java:56)
[error]     at com.intellij.testFramework.LightPlatformTestCase.lambda$doSetup$3(LightPlatformTestCase.java:258)
[error]     at com.intellij.openapi.application.impl.ApplicationImpl.runIntendedWriteActionOnCurrentThread(ApplicationImpl.java:847)
[error]     at com.intellij.openapi.application.impl.ApplicationImpl.invokeAndWait(ApplicationImpl.java:447)
```

The commit in this pull request respects the previous implementation and can be considered as an extension in allowing also SDKMAN installed JDKs.

Thank you, I'm happy to have opened my first Pull Request in this project 😃 .

Best regards