### PR TITLE
migrate scala sdk extension impl from `intellij-bsp`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -52,6 +52,7 @@ lazy val scalaCommunity: sbt.Project =
       debugger % "test->test;compile->compile",
       testingSupport % "test->test;compile->compile",
       devKitIntegration % "test->test;compile->compile",
+      intellijBspIntegration % "test->test;compile->compile",
       gradleIntegration % "test->test;compile->compile",
       intelliLangIntegration % "test->test;compile->compile",
       mavenIntegration % "test->test;compile->compile",
@@ -626,6 +627,13 @@ lazy val copyrightIntegration =
     .settings(
       intellijPlugins += "com.intellij.copyright".toPlugin,
       packageMethod := PackagingMethod.MergeIntoOther(scalaCommunity)
+    )
+
+lazy val intellijBspIntegration =
+  newProject("intellij-bsp", file("scala/integration/intellij-bsp"))
+    .dependsOn(scalaImpl)
+    .settings(
+      intellijPlugins += "org.jetbrains.bsp::nightly".toPlugin
     )
 
 lazy val gradleIntegration =

--- a/pluginXml/resources/META-INF/plugin.xml
+++ b/pluginXml/resources/META-INF/plugin.xml
@@ -39,6 +39,7 @@
     <idea-version since-build="233.11799" until-build="233.*"/>
 
     <depends>com.intellij.modules.java</depends>
+    <depends optional="true" config-file="scala-intellij-bsp-integration.xml">org.jetbrains.bsp</depends>
     <depends optional="true" config-file="scala-maven-integration.xml">org.jetbrains.idea.maven</depends>
     <depends optional="true" config-file="intellilang-scala-support.xml">org.intellij.intelliLang</depends>
     <depends optional="true" config-file="copyright.xml">com.intellij.copyright</depends>

--- a/scala/integration/intellij-bsp/resources/META-INF/scala-intellij-bsp-integration.xml
+++ b/scala/integration/intellij-bsp/resources/META-INF/scala-intellij-bsp-integration.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="iso-8859-1"?>
+<idea-plugin>
+    <extensions defaultExtensionNs="org.jetbrains.bsp">
+        <scalaSdkExtension implementation="org.jetbrains.plugins.scala.project.bsp.ScalaSdkExtensionImpl"/>
+    </extensions>
+</idea-plugin>

--- a/scala/integration/intellij-bsp/src/org/jetbrains/plugins/scala/project/bsp/ScalaSdkExtensionImpl.scala
+++ b/scala/integration/intellij-bsp/src/org/jetbrains/plugins/scala/project/bsp/ScalaSdkExtensionImpl.scala
@@ -1,0 +1,32 @@
+package org.jetbrains.plugins.scala.project.bsp
+
+import com.intellij.openapi.externalSystem.service.project.IdeModifiableModelsProvider
+import org.jetbrains.plugins.bsp.scala.sdk.ScalaSdkExtension
+import org.jetbrains.plugins.bsp.scala.sdk.ScalaSdk
+import org.jetbrains.plugins.scala.project.ScalaLanguageLevel
+import org.jetbrains.plugins.scala.project.external.ScalaSdkUtils
+
+import java.net.URI
+import java.nio.file.Paths
+
+class ScalaSdkExtensionImpl extends ScalaSdkExtension {
+
+  override def addScalaSdk(scalaSdk: ScalaSdk, ideModifiableModelsProvider: IdeModifiableModelsProvider): Unit = {
+    if (ScalaLanguageLevel.findByVersion(scalaSdk.getScalaVersion).isEmpty) return
+
+    val scalaSdkName = scalaSdk.getName
+    val projectLibrariesModel = ideModifiableModelsProvider.getModifiableProjectLibrariesModel
+    val existingScalaLibrary = projectLibrariesModel.getLibraries.find(_.getName == scalaSdkName)
+    val sdkJars = scalaSdk.getSdkJars.toArray().map(uri => Paths.get(URI.create(uri.toString)).toFile)
+    val scalaLibrary = existingScalaLibrary.getOrElse(projectLibrariesModel.createLibrary(scalaSdkName))
+
+    ScalaSdkUtils.ensureScalaLibraryIsConvertedToScalaSdk(
+      modelsProvider = ideModifiableModelsProvider,
+      library = scalaLibrary,
+      maybeVersion = Some(scalaSdk.getScalaVersion),
+      compilerClasspath = sdkJars.toSeq,
+      scaladocExtraClasspath = Nil,
+      compilerBridgeBinaryJar = None
+    )
+  }
+}


### PR DESCRIPTION
what were done:

- register an additional synthetic scala library and convert it to a scala sdk by internal scala plugin API.