### PR TITLE
[inspection] re-enable comparing unrelated types inspection for scala 3

### DIFF
--- a/scala/scala-impl/src/org/jetbrains/plugins/scala/project/ScalaModuleSettings.scala
+++ b/scala/scala-impl/src/org/jetbrains/plugins/scala/project/ScalaModuleSettings.scala
@@ -7,7 +7,7 @@ import com.intellij.openapi.roots.{OrderEnumerator, OrderRootType, libraries}
 import com.intellij.openapi.util.ModificationTracker
 import com.intellij.openapi.util.io.JarUtil.{containsEntry, getJarAttribute}
 import com.intellij.openapi.vfs.VirtualFile
-import com.intellij.util.CommonProcessors.{CollectProcessor, FindProcessor}
+import com.intellij.util.CommonProcessors.FindProcessor
 import org.jetbrains.plugins.scala.ScalaVersion
 import org.jetbrains.plugins.scala.caches.cached
 import org.jetbrains.plugins.scala.project.ScalaFeatures.SerializableScalaFeatures
@@ -18,7 +18,6 @@ import org.jetbrains.sbt.project.SbtVersionProvider
 
 import java.io.File
 import java.util.jar.Attributes
-import scala.jdk.CollectionConverters.IteratorHasAsScala
 
 private class ScalaModuleSettings private(
   module: Module,
@@ -141,6 +140,9 @@ private class ScalaModuleSettings private(
 
   val isCompilerStrictMode: Boolean =
     settingsForHighlighting.exists(_.strict)
+
+  val isCompilerStrictEqualityMode: Boolean =
+    settingsForHighlighting.exists(_.strictEquality)
 
   val customDefaultImports: Option[Seq[String]] =
     additionalCompilerOptions.collectFirst {

--- a/scala/scala-impl/src/org/jetbrains/plugins/scala/project/package.scala
+++ b/scala/scala-impl/src/org/jetbrains/plugins/scala/project/package.scala
@@ -288,6 +288,9 @@ package object project {
     def isCompilerStrictMode: Boolean =
       scalaModuleSettings.exists(_.isCompilerStrictMode)
 
+    def isCompilerStrictEqualityMode: Boolean =
+      scalaModuleSettings.exists(_.isCompilerStrictEqualityMode)
+
     def scalaCompilerClasspath: Seq[File] = module.scalaSdk
       .fold(throw new ScalaSdkNotConfiguredException(module)) {
         _.properties.compilerClasspath
@@ -536,6 +539,8 @@ package object project {
         module.exists(_.hasScala3)
 
     def isCompilerStrictMode: Boolean = module.exists(_.isCompilerStrictMode)
+
+    def isCompilerStrictEqualityMode: Boolean = isInScala3Module && module.exists(_.isCompilerStrictEqualityMode)
 
     def scalaLanguageLevel: Option[ScalaLanguageLevel] =
       fromFeaturesOrModule(_.languageLevel, _.scalaLanguageLevel)

--- a/scala/scala-impl/src/org/jetbrains/plugins/scala/project/settings/ScalaCompilerSettings.scala
+++ b/scala/scala-impl/src/org/jetbrains/plugins/scala/project/settings/ScalaCompilerSettings.scala
@@ -50,6 +50,8 @@ case class ScalaCompilerSettings(compileOrder: CompileOrder,
   val languageWildcard: Boolean = additionalCompilerOptions.contains("-language:_") ||
     additionalCompilerOptions.contains("--language:_")
   val strict: Boolean = additionalCompilerOptions.contains("-strict")
+  val strictEquality: Boolean = additionalCompilerOptions.contains("-language:strictEquality") ||
+    additionalCompilerOptions.contains("--language:strictEquality")
 
   def getOptionsAsStrings(forScala3Compiler: Boolean): Seq[String] = {
     val state = toState

--- a/scala/scala-impl/test/org/jetbrains/plugins/scala/codeInspection/typeChecking/ComparingUnrelatedTypesInspectionTest.scala
+++ b/scala/scala-impl/test/org/jetbrains/plugins/scala/codeInspection/typeChecking/ComparingUnrelatedTypesInspectionTest.scala
@@ -9,7 +9,8 @@ import org.junit.runner.RunWith
 @RunWith(classOf[MultipleScalaVersionsRunner])
 @RunWithScalaVersions(Array(
   TestScalaVersion.Scala_2_12,
-  TestScalaVersion.Scala_2_13
+  TestScalaVersion.Scala_2_13,
+  TestScalaVersion.Scala_3_Latest
 ))
 abstract class ComparingUnrelatedTypesInspectionTest extends ScalaInspectionTestBase {
 
@@ -316,10 +317,28 @@ class Test20 extends ComparingUnrelatedTypesInspectionTest {
 
 class Test21 extends ComparingUnrelatedTypesInspectionTest {
 
+  override def supportedIn(version: ScalaVersion): Boolean = version < LatestScalaVersions.Scala_3_0
+
   override protected val description: String =
     ScalaInspectionBundle.message("comparing.unrelated.types.hint", "Some[Int]", "List[_]")
 
   def testExistential(): Unit = checkTextHasError(
+    s"${START}Some(1).isInstanceOf[List[_]]$END"
+  )
+}
+
+class Test21_Scala_3 extends ComparingUnrelatedTypesInspectionTest {
+
+  override def supportedIn(version: ScalaVersion): Boolean = version >= LatestScalaVersions.Scala_3_0
+
+  override protected val description: String =
+    ScalaInspectionBundle.message("comparing.unrelated.types.hint", "Some[Int]", "List[?]")
+
+  def testExistential(): Unit = checkTextHasError(
+    s"${START}Some(1).isInstanceOf[List[?]]$END"
+  )
+
+  def testExistentialOldWildcard(): Unit = checkTextHasError(
     s"${START}Some(1).isInstanceOf[List[_]]$END"
   )
 }
@@ -336,10 +355,28 @@ class Test22 extends ComparingUnrelatedTypesInspectionTest {
 
 class Test23 extends ComparingUnrelatedTypesInspectionTest {
 
+  override def supportedIn(version: ScalaVersion): Boolean = version < LatestScalaVersions.Scala_3_0
+
   override protected val description: String =
     ScalaInspectionBundle.message("comparing.unrelated.types.hint", "Some[_]", "Seq[Int]")
 
   def testExistential(): Unit = checkTextHasError(
+    s"def foo(x: Some[_]) { ${START}x == Seq(1)$END }"
+  )
+}
+
+class Test23_Scala_3 extends ComparingUnrelatedTypesInspectionTest {
+
+  override def supportedIn(version: ScalaVersion): Boolean = version >= LatestScalaVersions.Scala_3_0
+
+  override protected val description: String =
+    ScalaInspectionBundle.message("comparing.unrelated.types.hint", "Some[?]", "Seq[Int]")
+
+  def testExistential(): Unit = checkTextHasError(
+    s"def foo(x: Some[?]) { ${START}x == Seq(1)$END }"
+  )
+
+  def testExistentialOldWildcard(): Unit = checkTextHasError(
     s"def foo(x: Some[_]) { ${START}x == Seq(1)$END }"
   )
 }
@@ -437,7 +474,8 @@ class Test29 extends ComparingUnrelatedTypesInspectionTest {
 @RunWithScalaVersions(Array(
   TestScalaVersion.Scala_2_10,
   TestScalaVersion.Scala_2_12,
-  TestScalaVersion.Scala_2_13
+  TestScalaVersion.Scala_2_13,
+  TestScalaVersion.Scala_3_Latest
 ))
 class Test30 extends ComparingUnrelatedTypesInspectionTest {
 
@@ -659,9 +697,6 @@ class TestInstanceOfAutoBoxing3 extends ComparingUnrelatedTypesInspectionTest {
   )
 }
 
-@RunWithScalaVersions(Array(
-  TestScalaVersion.Scala_2_13
-))
 class TestLiteralTypes extends ComparingUnrelatedTypesInspectionTest {
 
   override protected def supportedIn(version: ScalaVersion): Boolean = version >= LatestScalaVersions.Scala_2_13
@@ -1024,5 +1059,216 @@ class TestVariousCasesWithStdTypes extends ComparingUnrelatedTypesInspectionTest
       |  implicit def toList[A](a: A) : List[A] = a :: Nil
       |  1.indexOf($START"2"$END)
       |}""".stripMargin
+  )
+}
+
+class Test33 extends ComparingUnrelatedTypesInspectionTest {
+  override protected def supportedIn(version: ScalaVersion): Boolean = version >= LatestScalaVersions.Scala_3_0
+
+  override protected val description: String =
+    ScalaInspectionBundle.message("comparing.unrelated.types.hint", "String", "Int")
+
+  def testCanEqualLiteralTypes(): Unit = checkTextHasError(
+    s"""
+      |given CanEqual[String, Int] = CanEqual.derived
+      |$START"1" == 1$END
+      |""".stripMargin
+  )
+}
+
+class Test34 extends ComparingUnrelatedTypesInspectionTest {
+  override protected def supportedIn(version: ScalaVersion): Boolean = version >= LatestScalaVersions.Scala_3_0
+
+  override protected val description: String =
+    ScalaInspectionBundle.message("comparing.unrelated.types.hint", "Boolean", "Int")
+
+  def testCanEqualPrimitiveTypes(): Unit = checkTextHasError(
+    s"""
+       |given CanEqual[Boolean, Int] = CanEqual.derived
+       |val b: Boolean = true
+       |val i: Int = 1
+       |${START}b == i$END
+       |""".stripMargin
+  )
+}
+
+class Test35 extends ComparingUnrelatedTypesInspectionTest {
+  override protected def supportedIn(version: ScalaVersion): Boolean = version >= LatestScalaVersions.Scala_3_0
+
+  override protected val description: String =
+    ScalaInspectionBundle.message("comparing.unrelated.types.hint", "Boolean", "Int")
+
+  def testCanEqualPrimitiveTypes(): Unit = checkTextHasError(
+    s"""
+       |given CanEqual[Boolean, Int] = CanEqual.derived
+       |val b: Boolean = true
+       |val i: Int = 1
+       |${START}b == i$END
+       |""".stripMargin
+  )
+}
+
+class Test36 extends ComparingUnrelatedTypesInspectionTest {
+  override protected def supportedIn(version: ScalaVersion): Boolean = version >= LatestScalaVersions.Scala_3_0
+
+  override protected val description: String =
+    ScalaInspectionBundle.message("comparing.unrelated.types.hint", "A", "B")
+
+  def testCanEqualDefined(): Unit = checkTextHasNoErrors(
+    s"""
+       |case class A()
+       |case class B()
+       |given CanEqual[A, B] = CanEqual.derived
+       |A() == B()
+       |""".stripMargin
+  )
+
+  def testCanEqualComparisonWithUnderscore(): Unit = checkTextHasNoErrors(
+    s"""
+       |case class A()
+       |case class B()
+       |given CanEqual[A, B] = CanEqual.derived
+       |List(A()).find(_ == B())
+       |""".stripMargin
+  )
+
+  def testCanEqualSuperType(): Unit = checkTextHasNoErrors(
+    s"""
+       |trait T
+       |case class A() extends T
+       |case class B()
+       |given CanEqual[T, B] = CanEqual.derived
+       |A() == B()
+       |""".stripMargin
+  )
+
+  def testCanEqualOutsideComparisonContext(): Unit = checkTextHasNoErrors(
+    s"""
+       |case class A()
+       |case class B()
+       |given CanEqual[A, B] = CanEqual.derived
+       |def test(): Boolean = A() == B()
+       |""".stripMargin
+    )
+
+  def testCanEqualInHigherContext(): Unit = checkTextHasNoErrors(
+    s"""
+       |case class A()
+       |case class B()
+       |given CanEqual[A, B] = CanEqual.derived
+       |
+       |object Test:
+       |  def test(): Boolean = A() == B()
+       |""".stripMargin
+  )
+
+  def testCanEqualSeveralContextsHigher(): Unit = checkTextHasNoErrors(
+    s"""
+       |case class A()
+       |case class B()
+       |
+       |object Highest:
+       |  given CanEqual[A, B] = CanEqual.derived
+       |
+       |  object Higher:
+       |
+       |    object High:
+       |      def test(): Boolean = A() == B()
+       |""".stripMargin
+  )
+
+  def testCanEqualInUnrelatedContext(): Unit = checkTextHasError(
+    s"""
+       |case class A()
+       |case class B()
+       |
+       |object Unrelated:
+       |  given CanEqual[A, B] = CanEqual.derived
+       |
+       |object Test:
+       |  def test(): Boolean = ${START}A() == B()$END
+       |""".stripMargin
+  )
+
+  def testCanEqualNotDefined(): Unit = checkTextHasError(
+    s"""
+       |case class A()
+       |case class B()
+       |${START}A() == B()$END
+       |""".stripMargin
+  )
+
+  def testCanEqualForIncompatibleSourceType(): Unit = checkTextHasError(
+    s"""
+       |case class A()
+       |case class B()
+       |case class C()
+       |given CanEqual[C, B] = CanEqual.derived
+       |${START}A() == B()$END
+       |""".stripMargin
+  )
+
+  def testCanEqualIncompatibleTargetType(): Unit = checkTextHasError(
+    s"""
+       |case class A()
+       |case class B()
+       |case class C()
+       |given CanEqual[A, C] = CanEqual.derived
+       |${START}A() == B()$END
+       |""".stripMargin
+  )
+
+  def testCanEqualCaseObjects(): Unit = checkTextHasNoErrors(
+    s"""
+       |case object A
+       |case object B
+       |given CanEqual[A, B] = CanEqual.derived
+       |A == B
+       |""".stripMargin
+  )
+
+  def testCanEqualIncompatibleCaseObjects(): Unit = checkTextHasError(
+    s"""
+       |case object A
+       |case object B
+       |case object C
+       |given CanEqual[A, C] = CanEqual.derived
+       |${START}A == B$END
+       |""".stripMargin
+  )
+
+  def testCanEqualImported(): Unit = checkTextHasNoErrors(
+    s"""
+       |case class A()
+       |case class B()
+       |
+       |import Givens.given
+       |A() == B()
+       |
+       |object Givens:
+       |  given CanEqual[A, B] = CanEqual.derived
+       |""".stripMargin
+  )
+
+  def testCanEqualImportedFromCompanion(): Unit = checkTextHasNoErrors(
+    s"""
+       |case class A()
+       |case class B()
+       |
+       |object A:
+       |  given CanEqual[A, B] = CanEqual.derived
+       |
+       |A() == B()
+       |""".stripMargin
+  )
+
+  def testCanEqualDerivedOnTrait(): Unit = checkTextHasNoErrors(
+    s"""
+       |trait T derives CanEqual
+       |case class A() extends T
+       |case class B() extends T
+       |
+       |A() == B()
+       |""".stripMargin
   )
 }


### PR DESCRIPTION
Adds support for '--language:strictEquality' compiler flag and 'CanEqual' when running inspection on scala 3 code