### PR TITLE
[annotator] support scala 3.4 irrefutable patterns in for-comprehension #SCL-22274 fixed

### DIFF
--- a/scala/scala-impl/src/org/jetbrains/plugins/scala/lang/psi/impl/expr/ScForImpl.scala
+++ b/scala/scala-impl/src/org/jetbrains/plugins/scala/lang/psi/impl/expr/ScForImpl.scala
@@ -184,12 +184,13 @@ class ScForImpl(node: ASTNode) extends ScExpressionImplBase(node) with ScFor wit
     }
 
     def needsPatternMatchFilter(pattern: ScPattern): Boolean = {
+      val features = pattern.features
       lazy val hasSc3Case = pattern.prevSiblingNotWhitespace.exists(_.textMatches(ScalaModifier.CASE))
       lazy val hasSc3IrrefutablePatternsEnabled =
-        pattern.features.hasSourceFutureFlag || pattern.scalaLanguageLevel.exists(_ >= ScalaLanguageLevel.Scala_3_4)
+        features.hasSourceFutureFlag || pattern.scalaLanguageLevel.exists(_ >= ScalaLanguageLevel.Scala_3_4)
       lazy val isRefutablePattern = !pattern.isIrrefutableFor(if (forDisplay) pattern.expectedType else None)
 
-      if (pattern.isScala3OrSource3Enabled) {
+      if (features.isScala3) {
         hasSc3Case || (!hasSc3IrrefutablePatternsEnabled && isRefutablePattern)
       } else {
         isRefutablePattern

--- a/scala/scala-impl/src/org/jetbrains/plugins/scala/lang/psi/impl/expr/ScForImpl.scala
+++ b/scala/scala-impl/src/org/jetbrains/plugins/scala/lang/psi/impl/expr/ScForImpl.scala
@@ -185,7 +185,7 @@ class ScForImpl(node: ASTNode) extends ScExpressionImplBase(node) with ScFor wit
 
     def needsPatternMatchFilter(pattern: ScPattern): Boolean = {
       val hasSc3Case = pattern.isScala3OrSource3Enabled &&
-        pattern.prevSiblingNotWhitespace.exists(_.getText == ScalaModifier.CASE)
+        pattern.prevSiblingNotWhitespace.exists(_.textMatches(ScalaModifier.CASE))
       val hasSc3IrrefutablePatternsEnabled = pattern.isScala3OrSource3Enabled &&
         (pattern.features.hasSourceFutureFlag || pattern.scalaLanguageLevel.exists(_ >= ScalaLanguageLevel.Scala_3_4))
 

--- a/scala/scala-impl/src/org/jetbrains/plugins/scala/project/ScalaFeatures.scala
+++ b/scala/scala-impl/src/org/jetbrains/plugins/scala/project/ScalaFeatures.scala
@@ -64,7 +64,7 @@ object ScalaFeatures {
     private def hasNoIndentFlag: Boolean = Bits.hasNoIndentFlag.read(bits)
     private def hasOldSyntaxFlag: Boolean = Bits.hasOldSyntaxFlag.read(bits)
     private def hasDeprecationFlag: Boolean = Bits.hasDeprecationFlag.read(bits)
-    private def hasSourceFutureFlag: Boolean = Bits.hasSourceFutureFlag.read(bits)
+    def hasSourceFutureFlag: Boolean = Bits.hasSourceFutureFlag.read(bits)
     def hasMetaEnabled: Boolean = Bits.hasMetaEnabled.read(bits)
     def hasTrailingCommasEnabled: Boolean = Bits.hasTrailingCommasEnabled.read(bits)
     def hasUnderscoreWildcardsDisabled: Boolean = Bits.hasUnderscoreWildcardsDisabled.read(bits)

--- a/scala/scala-impl/test/org/jetbrains/plugins/scala/annotator/ForComprehensionHighlightingTest.scala
+++ b/scala/scala-impl/test/org/jetbrains/plugins/scala/annotator/ForComprehensionHighlightingTest.scala
@@ -508,11 +508,11 @@ class ForComprehensionSemicolonTest extends ForComprehensionHighlightingTestBase
     assertEquals(2 + 2 + 3 + 3, errors("for{\n; \n; \nx <- Seq(1)\n;\n;\n;\nif x == 3\n;\n;;;\n y = x\n;;\n;} ()"))
 }
 
-class ForComprehensionRefutableTest_3 extends ForComprehensionHighlightingTestBase {
+abstract class ForComprehensionRefutablityTestBase_3 extends ForComprehensionHighlightingTestBase {
 
   import Message.Error
 
-  override protected def supportedIn(version: ScalaVersion): Boolean = version >= LatestScalaVersions.Scala_3_0
+  override protected def supportedIn(version: ScalaVersion): Boolean = version >= LatestScalaVersions.Scala_3_3
 
   def test_case_simple(): Unit = {
     val code =
@@ -538,18 +538,7 @@ class ForComprehensionRefutableTest_3 extends ForComprehensionHighlightingTestBa
     val code =
       """
         |for
-        |  case (a, b) <- Right("", 1)
-        |yield ()
-      """.stripMargin
-
-    assertMessages(code, Error("<-", "Cannot resolve symbol withFilter"))
-  }
-
-  def test_missing_withFilter(): Unit = {
-    val code =
-      """
-        |for
-        |  (a, b) <- Right("", 1)
+        |  case (a, b) <- Right("" -> 1)
         |yield ()
       """.stripMargin
 
@@ -557,7 +546,7 @@ class ForComprehensionRefutableTest_3 extends ForComprehensionHighlightingTestBa
   }
 }
 
-class ForComprehensionIrrefutableTest_3_4 extends ForComprehensionHighlightingTestBase {
+class ForComprehensionRefutabilityTest_From_3_4 extends ForComprehensionRefutablityTestBase_3 {
 
   override protected def supportedIn(version: ScalaVersion): Boolean = version >= LatestScalaVersions.Scala_3_4
 
@@ -573,10 +562,27 @@ class ForComprehensionIrrefutableTest_3_4 extends ForComprehensionHighlightingTe
   }
 }
 
-class ForComprehensionIrrefutableTest_3_future extends ForComprehensionHighlightingTestBase {
+class ForComprehensionRefutabilityTest_3_3 extends ForComprehensionRefutablityTestBase_3 {
 
-  override protected def supportedIn(version: ScalaVersion): Boolean =
-    version >= LatestScalaVersions.Scala_3_0 && version < LatestScalaVersions.Scala_3_4
+  import Message.Error
+
+  override protected def supportedIn(version: ScalaVersion): Boolean = version == LatestScalaVersions.Scala_3_3
+
+  def test_missing_withFilter(): Unit = {
+    val code =
+      """
+        |for
+        |  (a, b) <- Right("" -> 1)
+        |yield ()
+      """.stripMargin
+
+    assertMessages(code, Error("<-", "Cannot resolve symbol withFilter"))
+  }
+}
+
+class ForComprehensionRefutabilityTest_3_3_future extends ForComprehensionRefutablityTestBase_3 {
+
+  override protected def supportedIn(version: ScalaVersion): Boolean = version == LatestScalaVersions.Scala_3_3
 
   override protected def setUp(): Unit = {
     super.setUp()

--- a/scala/scala-impl/test/org/jetbrains/plugins/scala/annotator/ForComprehensionHighlightingTest.scala
+++ b/scala/scala-impl/test/org/jetbrains/plugins/scala/annotator/ForComprehensionHighlightingTest.scala
@@ -453,7 +453,8 @@ class ForComprehensionHighlightingTest_with_filter extends ForComprehensionHighl
 class ForComprehensionHighlightingTest_with_BetterMonadicFor extends ForComprehensionHighlightingTestBase {
   import Message._
 
-  override protected def supportedIn(version: ScalaVersion): Boolean = version >= LatestScalaVersions.Scala_2_12
+  override protected def supportedIn(version: ScalaVersion): Boolean =
+    version >= LatestScalaVersions.Scala_2_12 && version < LatestScalaVersions.Scala_3_0
 
   override protected def setUp(): Unit = {
     super.setUp()


### PR DESCRIPTION
This fixes false missing `withFilters` error for irrefutable patterns in for comprehensions introduced with Scala 3.4 and Scala 3.0 + `-source:future`.

Related #SCL-22468