### PR TITLE
[SCL-22785] Fixed incorrect collection type in ScalaDirtyScopeHolder.

### DIFF
--- a/scala/compiler-integration/src/org/jetbrains/plugins/scala/compiler/references/ScalaDirtyScopeHolder.scala
+++ b/scala/compiler-integration/src/org/jetbrains/plugins/scala/compiler/references/ScalaDirtyScopeHolder.scala
@@ -60,7 +60,7 @@ private class ScalaDirtyScopeHolder(
     import scala.collection.mutable
     import scala.jdk.CollectionConverters._
 
-    val visited = mutable.Stack.empty[ScopedModule]
+    val visited = mutable.Set.empty[ScopedModule]
     val stack = scopes.to(mutable.Stack)
 
     while (stack.nonEmpty) {


### PR DESCRIPTION
Changed collection type used in ScalaDirtyScopeHolder from Stack to Set. Stack caused the method to have a very high computational complexity. Change speeds up the "open compiler index reader" background task 60x times.