### PR TITLE
Add optional seenfromClass to ThisTypeSubstitution

### DIFF
--- a/scala/scala-impl/src/org/jetbrains/plugins/scala/lang/psi/types/BaseTypes.scala
+++ b/scala/scala-impl/src/org/jetbrains/plugins/scala/lang/psi/types/BaseTypes.scala
@@ -132,7 +132,15 @@ private class BaseTypesIterator(tp: ScType) extends Iterator[ScType] {
           }
           else None
         case ScThisType(clazz) =>
-          clazz.getTypeWithProjections().toOption
+          // Given:
+          //   trait Father[A] { trait Son }
+          //   trait Charles extends Father[Int] {
+          //     trait William extends Father[String] with Son
+          //   }
+          // then William.this.type.baseType(trait Son)
+          // should return Charles.this.Son not Charles#Son
+          // (what `clazz.getTypeWithProjections()` returns)
+          clazz.`type`().toOption
         case tpt: TypeParameterType =>
           Some(tpt.upperType)
         case ScExistentialArgument(_, Nil, _, upper) =>

--- a/scala/scala-impl/src/org/jetbrains/plugins/scala/lang/psi/types/api/designator/ScProjectionType.scala
+++ b/scala/scala-impl/src/org/jetbrains/plugins/scala/lang/psi/types/api/designator/ScProjectionType.scala
@@ -150,7 +150,7 @@ final class ScProjectionType private(val projected: ScType,
       processor.candidates match {
         case Array(candidate) => candidate.element match {
           case candidateElement: PsiNamedElement =>
-            val thisSubstitutor = ScSubstitutor(projected, candidateElement.findContextOfType(classOf[PsiClass]).orNull)
+            val thisSubstitutor = ScSubstitutor(projected, element.findContextOfType(classOf[PsiClass]).orNull)
             val defaultSubstitutor =
               projected match {
                 case _: ScThisType => candidate.substitutor

--- a/scala/scala-impl/src/org/jetbrains/plugins/scala/lang/psi/types/api/designator/ScProjectionType.scala
+++ b/scala/scala-impl/src/org/jetbrains/plugins/scala/lang/psi/types/api/designator/ScProjectionType.scala
@@ -150,7 +150,7 @@ final class ScProjectionType private(val projected: ScType,
       processor.candidates match {
         case Array(candidate) => candidate.element match {
           case candidateElement: PsiNamedElement =>
-            val thisSubstitutor = ScSubstitutor(projected)
+            val thisSubstitutor = ScSubstitutor(projected, candidateElement.findContextOfType(classOf[PsiClass]).orNull)
             val defaultSubstitutor =
               projected match {
                 case _: ScThisType => candidate.substitutor

--- a/scala/scala-impl/src/org/jetbrains/plugins/scala/lang/psi/types/recursiveUpdate/ScSubstitutor.scala
+++ b/scala/scala-impl/src/org/jetbrains/plugins/scala/lang/psi/types/recursiveUpdate/ScSubstitutor.scala
@@ -1,6 +1,7 @@
 package org.jetbrains.plugins.scala.lang.psi.types.recursiveUpdate
 
 import com.intellij.openapi.diagnostic.Logger
+import com.intellij.psi.PsiClass
 import org.jetbrains.plugins.scala.extensions.ArrayExt
 import org.jetbrains.plugins.scala.lang.psi.api.statements.params.{ScParameter, TypeParamId}
 import org.jetbrains.plugins.scala.lang.psi.types.Compatibility.Expression
@@ -116,6 +117,10 @@ final class ScSubstitutor private(_substitutions: Array[Update],   //Array is us
     ScSubstitutor(tp).followed(this)
   }
 
+  def followUpdateThisType(tp: ScType, seenFromClass: PsiClass): ScSubstitutor = {
+    ScSubstitutor(tp, seenFromClass).followed(this)
+  }
+
   def withBindings(from: Iterable[TypeParameter], target: Iterable[TypeParameter]): ScSubstitutor = {
     assertFullSubstitutor()
 
@@ -187,7 +192,10 @@ object ScSubstitutor {
   }
 
   def apply(updateThisType: ScType): ScSubstitutor =
-    ScSubstitutor(ThisTypeSubstitution(updateThisType))
+    ScSubstitutor(ThisTypeSubstitution(updateThisType, null))
+
+  def apply(updateThisType: ScType, seenFromClass: PsiClass): ScSubstitutor =
+    ScSubstitutor(ThisTypeSubstitution(updateThisType, seenFromClass))
 
   def paramToExprType(parameters: Seq[Parameter], expressions: Seq[Expression], useExpected: Boolean = true): ScSubstitutor =
     ScSubstitutor(ParamsToExprs(parameters, expressions, useExpected))

--- a/scala/scala-impl/src/org/jetbrains/plugins/scala/lang/resolve/ScalaResolveState.scala
+++ b/scala/scala-impl/src/org/jetbrains/plugins/scala/lang/resolve/ScalaResolveState.scala
@@ -1,7 +1,7 @@
 package org.jetbrains.plugins.scala.lang.resolve
 
 import com.intellij.openapi.util.Key
-import com.intellij.psi.ResolveState
+import com.intellij.psi.{ PsiClass, ResolveState }
 import org.jetbrains.plugins.scala.extensions.ObjectExt
 import org.jetbrains.plugins.scala.lang.psi.ScExportsHolder
 import org.jetbrains.plugins.scala.lang.psi.api.statements.ScExtension
@@ -95,6 +95,9 @@ trait ResolveStateOps extends Any {
 
   def substitutorWithThisType: ScSubstitutor =
     fromType.fold(substitutor)(substitutor.followUpdateThisType)
+
+  def substitutorWithThisType(seenFromClass: PsiClass): ScSubstitutor =
+    fromType.fold(substitutor)(substitutor.followUpdateThisType(_, seenFromClass))
 
   def fromType: Option[ScType] =
     option(FROM_TYPE_KEY)

--- a/scala/scala-impl/src/org/jetbrains/plugins/scala/lang/resolve/processor/MethodResolveProcessor.scala
+++ b/scala/scala-impl/src/org/jetbrains/plugins/scala/lang/resolve/processor/MethodResolveProcessor.scala
@@ -67,7 +67,7 @@ class MethodResolveProcessor(override val ref: PsiElement,
       val accessible = isNamedParameter || isAccessible(namedElement, ref)
       if (accessibility && !accessible) return true
 
-      val s = state.substitutorWithThisType
+      val s = state.substitutorWithThisType(namedElement.findContextOfType(classOf[PsiClass]).orNull)
       val resultBuilder: PsiNamedElement => ScalaResolveResult = e =>
         new ScalaResolveResult(
           e,

--- a/scala/scala-impl/test/org/jetbrains/plugins/scala/lang/resolve2/Bug2Test.scala
+++ b/scala/scala-impl/test/org/jetbrains/plugins/scala/lang/resolve2/Bug2Test.scala
@@ -29,6 +29,7 @@ class Bug2Test extends ResolveTestBase {
   def testSCL2765(): Unit = {doTest()}
   def testDependent(): Unit = {doTest()}
   def testDependentEquality(): Unit = {doTest()}
+  def testDependentEquality2(): Unit = {doTest()}
   def testSCL2904(): Unit = {doTest()}
   def testSCL2827A(): Unit = {doTest()}
   def testSCL2827B(): Unit = {doTest()}

--- a/scala/scala-impl/test/org/jetbrains/plugins/scala/lang/resolve2/BugTest.scala
+++ b/scala/scala-impl/test/org/jetbrains/plugins/scala/lang/resolve2/BugTest.scala
@@ -65,4 +65,22 @@ class BugTest extends ResolveTestBase {
   def testThisTypeSelfType(): Unit = {doTest()}
 
   def testImplicitsOverloading(): Unit = {doTest()}
+
+  def testSCL21585B(): Unit  = doTest()
+  def testSCL21585C(): Unit  = doTest()
+  def testSCL21585C2(): Unit = doTest()
+  def testSCL21585Cm(): Unit = doTest()
+  def testSCL21585D(): Unit  = doTest()
+  def testSCL21585E(): Unit  = doTest()
+  def testSCL21585E2(): Unit = doTest()
+  def testSCL21585E3(): Unit = doTest()
+  def testSCL21585E4(): Unit = doTest()
+  def testSCL21585E5(): Unit = doTest()
+  def testSCL21585F(): Unit  = doTest()
+  def testSCL21585G(): Unit  = doTest()
+  def testSCL21585H(): Unit  = doTest()
+  def testSCL21585I(): Unit  = doTest()
+
+  def testSCL21947A(): Unit = doTest()
+  def testSCL21947B(): Unit = doTest()
 }

--- a/scala/scala-impl/testdata/resolve2/bug/SCL21585B.scala
+++ b/scala/scala-impl/testdata/resolve2/bug/SCL21585B.scala
@@ -1,0 +1,22 @@
+trait M {
+  type A
+}
+
+trait Base {
+  type T
+}
+trait B extends Base {
+  type T
+
+  def t: T
+}
+
+
+class Repro {
+
+  type M_A[M1 <: M] = M1#A
+
+  def test(value: (B{ type T = Repro }) with M_A[M { type A = B }]) = value.t./*resolved: true*/ok
+
+  def ok = ""
+}

--- a/scala/scala-impl/testdata/resolve2/bug/SCL21585C.scala
+++ b/scala/scala-impl/testdata/resolve2/bug/SCL21585C.scala
@@ -1,0 +1,49 @@
+
+object Repro {
+  trait HasBuilder {
+    type Builder
+  }
+
+  trait TList {
+    type Builder
+  }
+  trait TNil extends TList {
+    type Builder
+  }
+
+  trait TCons[H <: HasBuilder, T <: TList] extends TList {
+    type Builder = H#Builder with T#Builder
+  }
+
+  class Action1 extends HasBuilder {
+    type Builder = Action1Builder
+  }
+  trait Action1Builder {
+    type TargetType
+    def target(__DEBUG__ : Any = ""): TargetType = ???
+  }
+
+  trait HasTargetType[T] {
+    type TargetType = T
+  }
+  type ActionParam = TCons[Action1, TNil]
+//  def action1NOK1: ActionParam#Builder { type TargetType = TargetType1 } = ???
+  def action1NOK2: HasTargetType[TargetType1] with ActionParam#Builder = ???
+
+//  def action1OK1: TCons[Action1, TNil]#Builder { type TargetType = TargetType1 } = ???
+//  def action1OK2: Action1#Builder { type TargetType = TargetType1 } = ???
+//  def action1OK3: HasTargetType[TargetType1] with TCons[Action1, TNil]#Builder = ???
+//  def action1OK4: HasTargetType[TargetType1] with Action1#Builder = ???
+
+  class TargetType1 {
+    def ok = true
+  }
+
+//  action1OK1.target.ok
+//  action1OK2.target.ok
+//  action1OK3.target.ok
+//  action1OK4.target.ok
+  // good code red, "cannot resolve symbol ok"
+//  action1NOK1.target.ok
+  action1NOK2.target()./*resolved:true*/ok
+}

--- a/scala/scala-impl/testdata/resolve2/bug/SCL21585C2.scala
+++ b/scala/scala-impl/testdata/resolve2/bug/SCL21585C2.scala
@@ -1,0 +1,24 @@
+trait HasTarget  { type Target }
+trait HasBuilder { type Builder }
+trait Builder1 extends HasTarget  { def target: Target = ??? }
+trait Action1  extends HasBuilder { type Builder = Builder1 }
+trait TCons[H <: HasBuilder, T <: HasBuilder] { type Builder = H#Builder with T#Builder }
+
+trait Foo                     { def bar     = true }
+trait MkFoo extends HasTarget { type Target = Foo  }
+
+class Repro {
+  type Actions = TCons[Action1, HasBuilder]
+
+  def ko1: Actions#Builder with MkFoo = ???
+  def ok1: TCons[Action1, HasBuilder]#Builder with MkFoo = ???
+
+  ko1.target./*resolved:true*/bar // good code red, "cannot resolve symbol bar"
+  ok1.target./*resolved:true*/bar
+
+  def ko2: MkFoo with Actions#Builder = ???
+  def ok2: MkFoo with TCons[Action1, HasBuilder]#Builder = ???
+
+  ko2.target./*resolved:true*/bar // good code red, "cannot resolve symbol bar"
+  ok2.target./*resolved:true*/bar
+}

--- a/scala/scala-impl/testdata/resolve2/bug/SCL21585Cm.scala
+++ b/scala/scala-impl/testdata/resolve2/bug/SCL21585Cm.scala
@@ -1,0 +1,15 @@
+trait HasTarget  { type Target }
+trait HasBuilder { type Builder }
+trait Builder1 extends HasTarget  { def target: Target = ??? }
+trait Action1  extends HasBuilder { type Builder = Builder1 }
+trait TCons[H <: HasBuilder, T <: HasBuilder] { type Builder = H#Builder with T#Builder }
+
+trait Foo                     { def bar     = true }
+trait MkFoo extends HasTarget { type Target = Foo  }
+
+class Repro {
+  type Actions = TCons[Action1, HasBuilder]
+
+  def ko1: Actions#Builder with MkFoo = ???
+  ko1.target./*resolved:true*/bar // good code red, "cannot resolve symbol bar"
+}

--- a/scala/scala-impl/testdata/resolve2/bug/SCL21585D.scala
+++ b/scala/scala-impl/testdata/resolve2/bug/SCL21585D.scala
@@ -1,0 +1,19 @@
+object Repro {
+
+  trait O1[O1_A] {
+    type O1_A_Alias = O1_A
+    trait I1[I1_A] {
+      type I1_A_Alias = I1_A
+      def foo(__DEBUG__o1_a: O1_A_Alias): Unit = ()
+    }
+  }
+
+  trait O2 extends O1[Int] {
+    trait I2 extends I1[String] {
+      self: X =>
+      self./*resolved: true*/foo(1)
+    }
+  }
+  trait X
+
+}

--- a/scala/scala-impl/testdata/resolve2/bug/SCL21585E.scala
+++ b/scala/scala-impl/testdata/resolve2/bug/SCL21585E.scala
@@ -1,0 +1,19 @@
+object Repro {
+
+  trait O1[O1_A] {
+    type O1_A_Alias = O1_A
+    trait I1[I1_A] {
+      type I1_A_Alias = I1_A
+      def foo(__DEBUG__o1_a: O1_A_Alias): Unit = ()
+    }
+  }
+
+  trait O2 extends O1[Int] {
+    trait I2 extends I1[String] with O1[Nothing] {
+      self: X =>
+      self./*resolved: true*/foo(1)
+    }
+  }
+  trait X
+
+}

--- a/scala/scala-impl/testdata/resolve2/bug/SCL21585E2.scala
+++ b/scala/scala-impl/testdata/resolve2/bug/SCL21585E2.scala
@@ -1,0 +1,12 @@
+trait Father[A] {
+  type B = A
+  trait Son {
+    def set(x: B): Unit
+  }
+}
+
+trait Charles extends Father[Int] {
+  trait William extends Father[String] with Son {
+    def t1() = this./* resolved: true */set(1)
+  }
+}

--- a/scala/scala-impl/testdata/resolve2/bug/SCL21585E3.scala
+++ b/scala/scala-impl/testdata/resolve2/bug/SCL21585E3.scala
@@ -1,0 +1,17 @@
+trait Father[A] {
+  type B = A
+
+  trait Son {
+    def set(x: B): Unit
+  }
+}
+
+trait Charles extends Father[Int] {
+  trait William extends Father[String] with Son {
+    def t1() = this./* resolved: true */set(1)
+
+    trait George extends Son {
+      def t2() = this./* resolved: true */set("y")
+    }
+  }
+}

--- a/scala/scala-impl/testdata/resolve2/bug/SCL21585E4.scala
+++ b/scala/scala-impl/testdata/resolve2/bug/SCL21585E4.scala
@@ -1,0 +1,21 @@
+trait Father[A] {
+  type B = A
+
+  trait Son {
+    def set(x: B): Unit
+  }
+}
+
+trait Phillip extends Father[Boolean] {
+  trait Charles extends Father[Int] with Son {
+    def t0() = this./* resolved: true */set(true)
+
+    trait William extends Father[String] with Son {
+      def t1() = this./* resolved: true */set(1)
+
+      trait George extends Son {
+        def t2() = this./* resolved: true */set("y")
+      }
+    }
+  }
+}

--- a/scala/scala-impl/testdata/resolve2/bug/SCL21585E5.scala
+++ b/scala/scala-impl/testdata/resolve2/bug/SCL21585E5.scala
@@ -1,0 +1,146 @@
+class P1; object P1 extends P1
+class P2; object P2 extends P2
+class S1; object S1 extends S1
+class S2; object S2 extends S2
+
+trait GrandFather[A] {
+  type B = A
+
+  def putA(x: A): Unit
+  def putB(x: B): Unit
+
+  trait Father[M] {
+    type C = A
+    type D = B
+    type N = M
+
+    def putA2(x: A): Unit
+    def putB2(x: B): Unit
+    def putC(x: C): Unit
+    def putD(x: D): Unit
+    def setM(x: M): Unit
+    def setN(x: N): Unit
+
+    trait Son {
+      type E = A
+      type F = B
+      type G = C
+      type H = D
+      type O = M
+      type P = N
+
+      def putA3(x: A): Unit
+      def putB3(x: B): Unit
+      def putC2(x: C): Unit
+      def putD2(x: D): Unit
+      def putE(x: E): Unit
+      def putF(x: F): Unit
+      def putG(x: G): Unit
+      def putH(x: H): Unit
+      def setM2(x: M): Unit
+      def setN2(x: N): Unit
+      def setO(x: O): Unit
+      def setP(x: P): Unit
+    }
+  }
+}
+
+trait Phillip extends GrandFather[P1] {
+  def aA()   = this./* resolved: true */putA(P1)
+  def aB()   = this./* resolved: true */putB(P1)
+
+  trait Charles extends GrandFather[P2] with Father[S1] {
+    def bA()      =         this./* resolved: true */putA(P2)
+    def bB()      =         this./* resolved: true */putB(P2)
+
+    def bA_1()    = Phillip.this./* resolved: true */putA(P1)
+    def bB_1()    = Phillip.this./* resolved: true */putB(P1)
+
+    def bA2()     =         this./* resolved: true */putA2(P1)
+    def bB2()     =         this./* resolved: true */putB2(P1)
+    def bC()      =         this./* resolved: true */putC(P1)
+    def bD()      =         this./* resolved: true */putD(P1)
+    def bM()      =         this./* resolved: true */setM(S1)
+    def bN()      =         this./* resolved: true */setN(S1)
+
+    trait William extends Father[S2] with Son {
+      def cA_1()  = Charles.this./* resolved: true */putA(P2)
+      def cA_2()  = Phillip.this./* resolved: true */putA(P1)
+      def cB_1()  = Charles.this./* resolved: true */putB(P2)
+      def cB_2()  = Phillip.this./* resolved: true */putB(P1)
+
+      def cA2()   =         this./* resolved: true */putA2(P2)
+      def cB2()   =         this./* resolved: true */putB2(P2)
+      def cC()    =         this./* resolved: true */putC(P2)
+      def cD()    =         this./* resolved: true */putD(P2)
+      def cM()    =         this./* resolved: true */setM(S2)
+      def cN()    =         this./* resolved: true */setN(S2)
+
+      def cA2_1() = Charles.this./* resolved: true */putA2(P1)
+      def cB2_1() = Charles.this./* resolved: true */putB2(P1)
+      def cC_1()  = Charles.this./* resolved: true */putC(P1)
+      def cD_1()  = Charles.this./* resolved: true */putD(P1)
+      def cM_1()  = Charles.this./* resolved: true */setM(S1)
+      def cN_1()  = Charles.this./* resolved: true */setN(S1)
+
+      def cA3()   =         this./* resolved: true */putA3(P1)
+      def cB3()   =         this./* resolved: true */putB3(P1)
+      def cC2()   =         this./* resolved: true */putC2(P1)
+      def cD2()   =         this./* resolved: true */putD2(P1)
+      def cE()    =         this./* resolved: true */putE(P1)
+      def cF()    =         this./* resolved: true */putF(P1)
+      def cG()    =         this./* resolved: true */putG(P1)
+      def cH()    =         this./* resolved: true */putH(P1)
+      def cM2()   =         this./* resolved: true */setM2(S1)
+      def cN2()   =         this./* resolved: true */setN2(S1)
+      def cO()    =         this./* resolved: true */setO(S1)
+      def cP()    =         this./* resolved: true */setP(S1)
+
+      trait George extends Son {
+        def dA_2()  = Charles.this./* resolved: true */putA(P2)
+        def dA_3()  = Phillip.this./* resolved: true */putA(P1)
+        def dB_2()  = Charles.this./* resolved: true */putB(P2)
+        def dB_3()  = Phillip.this./* resolved: true */putB(P1)
+
+        def dA2_1() = William.this./* resolved: true */putA2(P2)
+        def dA2_2() = Charles.this./* resolved: true */putA2(P1)
+        def dB2_1() = William.this./* resolved: true */putB2(P2)
+        def dB2_2() = Charles.this./* resolved: true */putB2(P1)
+        def dC_1()  = William.this./* resolved: true */putC(P2)
+        def dC_2()  = Charles.this./* resolved: true */putC(P1)
+        def dD_1()  = William.this./* resolved: true */putD(P2)
+        def dD_2()  = Charles.this./* resolved: true */putD(P1)
+        def dM_1()  = William.this./* resolved: true */setM(S2)
+        def dM_2()  = Charles.this./* resolved: true */setM(S1)
+        def dN_1()  = William.this./* resolved: true */setN(S2)
+        def dN_2()  = Charles.this./* resolved: true */setN(S1)
+
+        def dA3()   =         this./* resolved: true */putA3(P2)
+        def dB3()   =         this./* resolved: true */putB3(P2)
+        def dC2()   =         this./* resolved: true */putC2(P2)
+        def dD2()   =         this./* resolved: true */putD2(P2)
+        def dE()    =         this./* resolved: true */putE(P2)
+        def dF()    =         this./* resolved: true */putF(P2)
+        def dG()    =         this./* resolved: true */putG(P2)
+        def dH()    =         this./* resolved: true */putH(P2)
+        def dM2()   =         this./* resolved: true */setM2(S2)
+        def dN2()   =         this./* resolved: true */setN2(S2)
+        def dO()    =         this./* resolved: true */setO(S2)
+        def dP()    =         this./* resolved: true */setP(S2)
+
+        def dA3_1() = William.this./* resolved: true */putA3(P1)
+        def dB3_1() = William.this./* resolved: true */putB3(P1)
+        def dC2_1() = William.this./* resolved: true */putC2(P1)
+        def dD2_1() = William.this./* resolved: true */putD2(P1)
+        def dE_1()  = William.this./* resolved: true */putE(P1)
+        def dF_1()  = William.this./* resolved: true */putF(P1)
+        def dG_1()  = William.this./* resolved: true */putG(P1)
+        def dH_1()  = William.this./* resolved: true */putH(P1)
+        def dM2_1() = William.this./* resolved: true */setM2(S1)
+        def dN2_1() = William.this./* resolved: true */setN2(S1)
+        def dO_1()  = William.this./* resolved: true */setO(S1)
+        def dP_1()  = William.this./* resolved: true */setP(S1)
+      }
+    }
+  }
+}

--- a/scala/scala-impl/testdata/resolve2/bug/SCL21585F.scala
+++ b/scala/scala-impl/testdata/resolve2/bug/SCL21585F.scala
@@ -1,0 +1,35 @@
+object Repro {
+  trait Api extends Api1
+
+  trait Api1 {
+    self: Api =>
+    type X <: XApi
+
+    class XApi
+
+    abstract class XExtractor {
+      def unapply(a: X): Option[String]
+    }
+    def apiX: X = ???
+  }
+
+  trait Impl extends Impl1 {
+
+  }
+
+  trait Impl1 extends Api {
+    self: Impl =>
+    case class X(s: String) extends XApi
+
+    object X extends XCompanion
+    val implX: X = apiX
+  }
+
+  object Test {
+    val impl: Impl = ???
+    (null: Any) match {
+      case impl.X(s) => s./*resolved: true*/charAt(0)
+    }
+  }
+}
+

--- a/scala/scala-impl/testdata/resolve2/bug/SCL21585G.scala
+++ b/scala/scala-impl/testdata/resolve2/bug/SCL21585G.scala
@@ -1,0 +1,29 @@
+object Repro {
+  trait Api extends Api1
+
+  trait Api1 {
+    self: Api =>
+
+    class XApi
+
+    type X <: XApi
+
+    abstract class XCompanion {
+      def foo(x: X) = ()
+    }
+  }
+
+  trait Impl extends Impl1
+
+  trait Impl1 extends Api {
+    self: Impl =>
+    class X extends XApi
+
+    object X extends XCompanion {
+//      override def foo(x: X) = ()
+      this./*resolved: true*/foo(new impl.X)
+    }
+  }
+
+}
+

--- a/scala/scala-impl/testdata/resolve2/bug/SCL21585H.scala
+++ b/scala/scala-impl/testdata/resolve2/bug/SCL21585H.scala
@@ -1,0 +1,29 @@
+object Repro {
+  trait Api extends Api1
+
+  trait Api1 {
+    self: Api =>
+
+    class XApi
+
+    type X <: XApi
+
+    abstract class XCompanion {
+      def foo(x: X) = ()
+    }
+  }
+
+  trait Impl extends Impl1
+
+  trait Impl1 extends Api {
+    self: Impl =>
+    class X extends XApi
+
+    object X extends XCompanion {
+      override def foo(x: X) = ()
+      this./*resolved: true*/foo(new impl.X)("")
+    }
+  }
+
+}
+

--- a/scala/scala-impl/testdata/resolve2/bug/SCL21585I.scala
+++ b/scala/scala-impl/testdata/resolve2/bug/SCL21585I.scala
@@ -1,0 +1,23 @@
+class B {
+  trait M {
+    type A
+  }
+
+  trait Base {
+    type T
+  }
+}
+
+class Repro extends B {
+  trait B extends Base {
+    type T
+
+    def t: T
+  }
+
+  type M_A[M1 <: M] = M1#A
+
+  def test(value: (B{ type T = Repro }) with M_A[M { type A = B }]) = value.t./*resolved: true*/ok
+
+  def ok = ""
+}

--- a/scala/scala-impl/testdata/resolve2/bug/SCL21947A.scala
+++ b/scala/scala-impl/testdata/resolve2/bug/SCL21947A.scala
@@ -1,0 +1,56 @@
+package example
+
+object Hello extends App {
+  val g = new nsc.Global
+  println(new C[g.type](g).exprF(new g./* resolved: true */Block(Nil, g.EmptyTree)))
+  println(g./* resolved: true */O./* resolved: true */treeMethod(g.EmptyTree))
+}
+
+class C[G <: nsc.Global](val global: G) {
+  import global._
+  def exprF(t: Tree): Int = t match {
+    case Block(_, e) => e.f
+    case _ => t.f
+  }
+}
+
+object api {
+  trait Trees {
+    type Tree
+
+    type Block <: Tree
+
+    val Block: BlockExtractor
+
+    trait T {
+      def treeMethod(t: Tree): Int
+    }
+
+    abstract class BlockExtractor {
+      def apply(stats: List[Tree], expr: Tree): Block
+      def unapply(block: Block): Option[(List[Tree], Tree)]
+    }
+  }
+}
+
+object internal {
+  abstract class SymbolTable extends Trees
+
+  trait Trees extends api.Trees { self: SymbolTable => // removing the self type fixes it
+
+    abstract class Tree { def f = 0 }
+
+    object O extends T {
+      def treeMethod(t: Tree) = t.f
+    }
+
+    case class Block(stats: List[Tree], expr: Tree) extends Tree
+    object Block extends BlockExtractor
+
+    case object EmptyTree extends Tree
+  }
+}
+
+object nsc {
+  class Global extends internal.SymbolTable
+}

--- a/scala/scala-impl/testdata/resolve2/bug/SCL21947B.scala
+++ b/scala/scala-impl/testdata/resolve2/bug/SCL21947B.scala
@@ -1,0 +1,29 @@
+object api {
+  trait Trees {
+    type Tree
+    type Block <: Tree
+    val Block: BlockExtractor
+    abstract class BlockExtractor {
+      def unapply(block: Block): Option[Tree]
+    }
+  }
+}
+
+object internal {
+  abstract class SymbolTable extends Trees
+  trait Trees extends api.Trees { self: SymbolTable => // removing the self type fixes it
+    class Tree { def f = 0 }
+    case class Block(expr: Tree) extends Tree
+    object Block extends BlockExtractor // Object creation impossible, since member unapply.. is not defined
+  }
+}
+
+class C(val g: internal.SymbolTable) {
+  import g._
+  def expr(t: Tree): Int = {
+    t match {
+      case /* name: unapply */Block(e) => e./* resolved: true */f
+      case _ => -1
+    }
+  }
+}

--- a/scala/scala-impl/testdata/resolve2/bug2/DependentEquality2.scala
+++ b/scala/scala-impl/testdata/resolve2/bug2/DependentEquality2.scala
@@ -1,0 +1,19 @@
+abstract class TreeInfo {
+  val global: Global
+  import global._
+  def foo(tree: Tree): Boolean = false
+  def foo(x: Boolean): Boolean = true
+}
+
+class Global {
+  class Tree
+  object treeInfo extends TreeInfo {
+    val global: Global.this.type = Global.this
+  }
+}
+
+trait Test {
+  val g: Global
+  import g._
+  def arg(fun: Tree) = treeInfo./* line: 4 */foo(fun)
+}


### PR DESCRIPTION
Pass in the context class of the member whose type is being substituted
(analagous to the `seenFromClass` passed to scalac's asSeenFrom). Use
this to guide the walk through enclosing classes.

Also, fix basetypes handling around ScThisType

Fixes [SCL-21585](https://youtrack.jetbrains.com/issue/SCL-21585/Failure-to-substitute-type-member-refinement-through-a-projection-type-from-a-HList-style-type)
Fixes [SCL-21947](https://youtrack.jetbrains.com/issue/SCL-21947/Mismatching-path-dependend-types-involving-self-type)
