### PR TITLE
Remove CMSClassUnloadingEnabled from default SBT flags

### DIFF
--- a/sbt/sbt-impl/src/org/jetbrains/sbt/runner/SbtRunConfiguration.scala
+++ b/sbt/sbt-impl/src/org/jetbrains/sbt/runner/SbtRunConfiguration.scala
@@ -42,7 +42,7 @@ class SbtRunConfiguration(val project: Project, val configurationFactory: Config
   /**
    * Extra java options.
    */
-  @BeanProperty var vmparams: String = "-Xms512M -Xmx1024M -Xss1M -XX:+CMSClassUnloadingEnabled"
+  @BeanProperty var vmparams: String = "-Xms512M -Xmx1024M -Xss1M"
 
   /**
    * Environment variables.


### PR DESCRIPTION
This setting was removed from Java 17 and it now throws "Unrecognized VM option 'CMSClassUnloadingEnabled'"

Should I also create YouTrack ticket for this?