### PR TITLE
Maybe it's a typo in SbtDependencyUtils.scala

### DIFF
--- a/sbt/sbt-impl/src/org/jetbrains/sbt/language/utils/SbtDependencyUtils.scala
+++ b/sbt/sbt-impl/src/org/jetbrains/sbt/language/utils/SbtDependencyUtils.scala
@@ -214,7 +214,7 @@ object SbtDependencyUtils {
         libDep => getLibraryDependenciesOrPlacesFromPsi(libDep, mode))
 
     def containsModuleName(proj: ScPatternDefinition, moduleName: String): Boolean =
-      proj.getText.toLowerCase.contains("\"" + moduleName + "\"".toLowerCase)
+      proj.getText.toLowerCase.contains(("\"" + moduleName + "\"").toLowerCase)
 
     val sbtProjectsInModule = getTopLevelSbtProjects(psiSbtFile).filter(proj => containsModuleName(proj, module.getName))
 


### PR DESCRIPTION
It seems to belong to typo.
BTW. I am using DependencyUtils to develop my plugin and have found many confusing points, such as `retrieveSettings` will not handle `platformsSettings`, `jvmSettings`, `jsSettings`, `nativeSettings`and `libraryDependencies++=List()` that seem unsupported. 
I have made some modifications to the alignment, I am not sure if it is useful for IntelliJ Scala. 

https://github.com/bitlap/intellij-sbt-dependency-analyzer/blob/779fdbb379fd6295c7278050732f0e9237325693/src/main/scala/bitlap/sbt/analyzer/util/SbtDependencyTraverser.scala#L189

https://github.com/bitlap/intellij-sbt-dependency-analyzer/blob/779fdbb379fd6295c7278050732f0e9237325693/src/main/scala/bitlap/sbt/analyzer/util/SbtDependencyTraverser.scala#L124