### PR TITLE
Update scalafmt default version to 3.8.3

### DIFF
--- a/scala/scala-impl/src/org/jetbrains/plugins/scala/lang/formatting/scalafmt/ScalafmtDynamicService.scala
+++ b/scala/scala-impl/src/org/jetbrains/plugins/scala/lang/formatting/scalafmt/ScalafmtDynamicService.scala
@@ -44,7 +44,7 @@ trait ScalafmtDynamicService {
 
 object ScalafmtDynamicService {
 
-  val DefaultVersion = ScalafmtVersion(1, 5, 1)
+  val DefaultVersion = ScalafmtVersion(3, 8, 3)
 
   def instance: ScalafmtDynamicService = ApplicationManager.getApplication.getService(classOf[ScalafmtDynamicService])
 


### PR DESCRIPTION
If one activates scalafmt formatting without a config file, currently 1.5.1 is downloaded. That is a very old version and does not support Scala 3. I don't see a reason to not update this.