### PR TITLE
Avoid flagging missing `override` keyword, missing type annotation, mismatched file names, top-level declarations in Mill build files

### DIFF
--- a/scala/scala-impl/src/org/jetbrains/plugins/scala/annotator/OverridingAnnotator.scala
+++ b/scala/scala-impl/src/org/jetbrains/plugins/scala/annotator/OverridingAnnotator.scala
@@ -190,8 +190,9 @@ trait OverridingAnnotator {
 
       if (isConcreteElement(namedElement.nameContext)) {
         val hasConcreteSuper = superSignatures.exists(isConcrete)
-
-        if (hasConcreteSuper && !member.hasModifierProperty(OVERRIDE)) {
+        // Mill build files make override optional, so don't error if the keyword is missing
+        val isMillFile = namedElement.containingScalaFile.exists(_.isMillFile)
+        if (!isMillFile && hasConcreteSuper && !member.hasModifierProperty(OVERRIDE)) {
           val maybeQuickFix: Option[Add] = namedElement match {
             case param: ScClassParameter if param.isCaseClassPrimaryParameter && !(param.isVal || param.isVar) =>
               superSignaturesWithSelfType.headOption.collect {

--- a/scala/scala-impl/src/org/jetbrains/plugins/scala/annotator/element/ScMemberAnnotator.scala
+++ b/scala/scala-impl/src/org/jetbrains/plugins/scala/annotator/element/ScMemberAnnotator.scala
@@ -26,7 +26,9 @@ object ScMemberAnnotator extends ElementAnnotator[ScMember] {
         // We know, however, that when a definition is in a package then it's not allowed.
         // This fix might not be 100% correct, but I think the false positives are much worse than the false negatives.
         // So it's better not to annotate a top-level val that is not allowed in scala 2 than annotating one that is allowed.
-        element.parents.exists(_.is[ScPackageLike])
+        element.parents.exists(_.is[ScPackageLike]) &&
+        // Mill allows top level definitions in its build.mill scripts
+        !element.containingScalaFile.exists(_.isMillFile)
     ) {
       val elementToAnnotate = element.depthFirst().find(c => keywords(c.elementType)).getOrElse(element)
       holder.createErrorAnnotation(elementToAnnotate, ScalaBundle.message("cannot.be.a.top.level.definition.in.scala.2"))

--- a/scala/scala-impl/src/org/jetbrains/plugins/scala/codeInspection/ScalaFileNameInspection.scala
+++ b/scala/scala-impl/src/org/jetbrains/plugins/scala/codeInspection/ScalaFileNameInspection.scala
@@ -40,6 +40,8 @@ final class ScalaFileNameInspection extends LocalInspectionTool {
       IntentionAvailabilityChecker.checkInspection(this, scalaFile) &&
       !InjectedLanguageManager.getInstance(scalaFile.getProject).isInjectedFragment(scalaFile) &&
       !scalaFile.isWorksheetFile &&
+      // Mill build files often have elements that differ from the file name
+      !scalaFile.isMillFile &&
       Option(scalaFile.getVirtualFile).isDefined &&
       !ScratchUtil.isScratch(scalaFile.getVirtualFile) &&
       !FileContextUtil.getFileContext(scalaFile).is[ScStringLiteral]

--- a/scala/scala-impl/src/org/jetbrains/plugins/scala/codeInspection/typeAnnotation/TypeAnnotationInspection.scala
+++ b/scala/scala-impl/src/org/jetbrains/plugins/scala/codeInspection/typeAnnotation/TypeAnnotationInspection.scala
@@ -24,7 +24,12 @@ class TypeAnnotationInspection extends LocalInspectionTool {
       inspect(value, value.bindings.head, value.expr, holder)
     case variable: ScVariableDefinition if variable.isSimple && !variable.hasExplicitType =>
       inspect(variable, variable.bindings.head, variable.expr, holder)
-    case method: ScFunctionDefinition if method.hasAssign && !method.hasExplicitType && !method.isConstructor =>
+    case method: ScFunctionDefinition
+      if method.hasAssign
+        && !method.hasExplicitType
+        && !method.isConstructor
+        // Mill build files often elide type annotations of tasks
+        && !method.containingScalaFile.exists(_.isMillFile) =>
       inspect(method, method.nameId, method.body, holder)
     case (parameter: ScParameter) & Parent(Parent(Parent(_: ScFunctionExpr))) if parameter.typeElement.isEmpty =>
       inspect(parameter, parameter.nameId, implementation = None, holder)

--- a/scala/scala-impl/src/org/jetbrains/plugins/scala/lang/psi/api/ScalaFile.scala
+++ b/scala/scala-impl/src/org/jetbrains/plugins/scala/lang/psi/api/ScalaFile.scala
@@ -27,6 +27,8 @@ trait ScalaFile extends ScalaPsiElement
 
   def isWorksheetFile: Boolean
 
+  def isMillFile: Boolean = getName.endsWith(".mill") || getName.endsWith(".mill.scala")
+
   def allowsForwardReferences: Boolean
 
   /**


### PR DESCRIPTION
Mill build files make the `override` keyword optional, so it's not an error. And they are typically written with fewer type annotations than Scala application code so we don't need to nag people to write them. And top-level declarations and statements are allowed since Mill files get wrapped by code-gen.

Tested manually

Before this PR:
<img width="976" alt="Screenshot 2024-10-28 at 2 10 36 PM" src="https://github.com/user-attachments/assets/81b38bac-e9c9-44d0-afbe-a36ea052745c">

After this PR:


<img width="976" alt="Screenshot 2024-10-28 at 2 46 15 PM" src="https://github.com/user-attachments/assets/b9b39e7e-ebf4-4132-9591-fd251f0ba700">
