### PR TITLE
Fix SCL-23198: Direct references to package objects should be allowed in `.mill` files

### DIFF
--- a/scala/scala-impl/src/org/jetbrains/plugins/scala/lang/psi/impl/expr/ScReferenceExpressionImpl.scala
+++ b/scala/scala-impl/src/org/jetbrains/plugins/scala/lang/psi/impl/expr/ScReferenceExpressionImpl.scala
@@ -195,7 +195,10 @@ class ScReferenceExpressionImpl(node: ASTNode) extends ScReferenceImpl(node) wit
       case inf: ScInfixExpr if this == inf.operation || this == inf.getBaseExpr =>
         StdKinds.refExprQualRef
       case _ =>
-        StdKinds.refExprLastRef
+        // Mill files allow direct references to package
+        // objects, even though normal .scala files do not
+        if (this.containingScalaFile.exists(_.isMillFile)) StdKinds.refExprQualRef
+        else StdKinds.refExprLastRef
     }
   }
 

--- a/scala/scala-impl/test/org/jetbrains/plugins/scala/annotator/MillHighlightingTests.scala
+++ b/scala/scala-impl/test/org/jetbrains/plugins/scala/annotator/MillHighlightingTests.scala
@@ -1,0 +1,24 @@
+package org.jetbrains.plugins.scala.annotator
+
+/**
+ * Check customized behavior for Mill build files
+ */
+class MillHighlightingTests extends ScalaHighlightingTestBase {
+  //SCL-23198
+  def testAllowDirectPackageReferences(): Unit = {
+    val code = """package foo{
+                 |  object `package`
+                 |}
+                 |
+                 |package bar{
+                 |  object qux{
+                 |    val reference = foo
+                 |  }
+                 |}
+                 |""".stripMargin
+    scala.Predef.assert(errorsFromScalaCode(code, "build.mill").isEmpty)
+    scala.Predef.assert(errorsFromScalaCode(code, "package.mill").isEmpty)
+    scala.Predef.assert(errorsFromScalaCode(code, "build.mill.scala").isEmpty)
+    scala.Predef.assert(errorsFromScalaCode(code, "build.scala").nonEmpty)
+  }
+}

--- a/scala/scala-impl/test/org/jetbrains/plugins/scala/annotator/MillHighlightingTests.scala
+++ b/scala/scala-impl/test/org/jetbrains/plugins/scala/annotator/MillHighlightingTests.scala
@@ -5,20 +5,26 @@ package org.jetbrains.plugins.scala.annotator
  */
 class MillHighlightingTests extends ScalaHighlightingTestBase {
   //SCL-23198
-  def testAllowDirectPackageReferences(): Unit = {
-    val code = """package foo{
-                 |  object `package`
-                 |}
-                 |
-                 |package bar{
-                 |  object qux{
-                 |    val reference = foo
-                 |  }
-                 |}
-                 |""".stripMargin
+  val code = """package foo{
+               |  object `package`
+               |}
+               |
+               |package bar{
+               |  object qux{
+               |    val reference = foo
+               |  }
+               |}
+               |""".stripMargin
+  def testBuildMillFileAllowsPackageReference(): Unit = {
     scala.Predef.assert(errorsFromScalaCode(code, "build.mill").isEmpty)
+  }
+  def testPackageFileAllowsPackageReference(): Unit = {
     scala.Predef.assert(errorsFromScalaCode(code, "package.mill").isEmpty)
+  }
+  def testBuildMillScalaFileAllowsPackageReference(): Unit = {
     scala.Predef.assert(errorsFromScalaCode(code, "build.mill.scala").isEmpty)
+  }
+  def testNormalScalaFileDisAllowsPackageReference(): Unit = {
     scala.Predef.assert(errorsFromScalaCode(code, "build.scala").nonEmpty)
   }
 }


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/SCL-23198/Direct-references-to-package-objects-should-be-allowed-in-.mill-files

Tested manually, seems to make the problematic highlight go away

<img width="976" alt="Screenshot 2024-11-12 at 10 45 08 AM" src="https://github.com/user-attachments/assets/e4b575c9-7638-4246-ae9a-001c285b7b80">
