### PR TITLE
Mill support: enable importing projects which contain build.mill(.scala) but not wrapper script

### DIFF
--- a/bsp/src/org/jetbrains/bsp/project/importing/MillProjectInstaller.scala
+++ b/bsp/src/org/jetbrains/bsp/project/importing/MillProjectInstaller.scala
@@ -16,7 +16,11 @@ class MillProjectInstaller extends BspProjectInstallProvider {
 
   override def canImport(workspace: File): Boolean =
     Option(workspace) match {
-      case Some(directory) if directory.isDirectory => isBspCompatible(directory) || isLegacyBspCompatible(directory) || BspUtil.findFileByName(directory, "build.mill").isDefined || BspUtil.findFileByName(directory, "build.mill.scala").isDefined || BspUtil.findFileByName(directory, "build.sc").isDefined
+      case Some(directory) if directory.isDirectory =>
+        isBspCompatible(directory) ||
+          isLegacyBspCompatible(directory) ||
+          BspUtil.findFileByName(directory, "build.mill").isDefined ||
+          BspUtil.findFileByName(directory, "build.mill.scala").isDefined
       case _ => false
     }
 
@@ -34,7 +38,7 @@ class MillProjectInstaller extends BspProjectInstallProvider {
         Success(Seq(file.getAbsolutePath, "-i", "mill.bsp.BSP/install"))
       case Some(file) if isLegacyMill =>
         Success(Seq(file.getAbsolutePath, "-i", "mill.contrib.BSP/install"))
-      case None =>
+      case _ =>
         Success(Seq("mill", "-i", "mill.bsp.BSP/install"))
     }
   }

--- a/bsp/src/org/jetbrains/bsp/project/importing/MillProjectInstaller.scala
+++ b/bsp/src/org/jetbrains/bsp/project/importing/MillProjectInstaller.scala
@@ -35,10 +35,13 @@ class MillProjectInstaller extends BspProjectInstallProvider {
     val millFileOpt = getMillFile(workspace)
     millFileOpt match {
       case Some(file) if isLegacyMill && !isMillFileBspCompatible(file, workspace) =>
+        // run this only if we're confident this is legacy Mill
         Seq(file.getAbsolutePath, "-i", "mill.contrib.BSP/install")
-      case Some(file) => // executes if isMillFileBspCompatible
+      case Some(file) =>
+        // otherwise run the normal BSP install command
         Seq(file.getAbsolutePath, "-i", "mill.bsp.BSP/install")
       case _ =>
+        // as a fallback, use Mill from PATH in case we couldn't find launcher in the project root
         Seq("mill", "-i", "mill.bsp.BSP/install")
     }
   }

--- a/bsp/src/org/jetbrains/bsp/project/importing/MillProjectInstaller.scala
+++ b/bsp/src/org/jetbrains/bsp/project/importing/MillProjectInstaller.scala
@@ -16,7 +16,7 @@ class MillProjectInstaller extends BspProjectInstallProvider {
 
   override def canImport(workspace: File): Boolean =
     Option(workspace) match {
-      case Some(directory) if directory.isDirectory => isBspCompatible(directory) || isLegacyBspCompatible(directory) || BspUtil.findFileByName(directory, "build.mill").isDefined || BspUtil.findFileByName(directory, "build.mill.scala").isDefined
+      case Some(directory) if directory.isDirectory => isBspCompatible(directory) || isLegacyBspCompatible(directory) || BspUtil.findFileByName(directory, "build.mill").isDefined || BspUtil.findFileByName(directory, "build.mill.scala").isDefined || BspUtil.findFileByName(directory, "build.sc").isDefined
       case _ => false
     }
 

--- a/bsp/src/org/jetbrains/bsp/project/importing/MillProjectInstaller.scala
+++ b/bsp/src/org/jetbrains/bsp/project/importing/MillProjectInstaller.scala
@@ -16,7 +16,7 @@ class MillProjectInstaller extends BspProjectInstallProvider {
 
   override def canImport(workspace: File): Boolean =
     Option(workspace) match {
-      case Some(directory) if directory.isDirectory => isBspCompatible(directory) || isLegacyBspCompatible(directory)
+      case Some(directory) if directory.isDirectory => isBspCompatible(directory) || isLegacyBspCompatible(directory) || BspUtil.findFileByName(directory, "build.mill").isDefined || BspUtil.findFileByName(directory, "build.mill.scala").isDefined
       case _ => false
     }
 
@@ -34,7 +34,8 @@ class MillProjectInstaller extends BspProjectInstallProvider {
         Success(Seq(file.getAbsolutePath, "-i", "mill.bsp.BSP/install"))
       case Some(file) if isLegacyMill =>
         Success(Seq(file.getAbsolutePath, "-i", "mill.contrib.BSP/install"))
-      case _ => Failure(new IllegalStateException("Unable to install BSP as this is not a Mill project"))
+      case None =>
+        Success(Seq("mill", "-i", "mill.bsp.BSP/install"))
     }
   }
 


### PR DESCRIPTION
Not all Mill projects necessarily have a wrapper script in the root. The wrapper script may be on the PATH.

But _all_ Mill projects contain `build.mill` or `build.mill.scala`, so that's _the_ robust way to recognize them.

/cc @lihaoyi 