### PR TITLE
fix #IDEA-365234

### DIFF
--- a/scala/scala-impl/src/org/jetbrains/plugins/scala/lang/refactoring/util/ScalaRefactoringUtil.scala
+++ b/scala/scala-impl/src/org/jetbrains/plugins/scala/lang/refactoring/util/ScalaRefactoringUtil.scala
@@ -521,9 +521,11 @@ object ScalaRefactoringUtil {
         .addListener(chooserModel.highlighterPopupListener)
         .setItemChosenCallback(chooserModel.elementChosen)
         .setItemSelectedCallback { item =>
-          val psiElement = toHighlight(item)
-          if (psiElement != null) {
-            chooserModel.highlightPsi.accept(psiElement)
+          if (item != null) {
+            val psiElement = toHighlight(item)
+            if (psiElement != null) {
+              chooserModel.highlightPsi.accept(psiElement)
+            }
           }
         }
         .setRenderer(new DefaultListCellRenderer {


### PR DESCRIPTION
I don't know why [this](https://youtrack.jetbrains.com/issue/IDEA-365234/Scala-Implicit-argument-pop-up-does-not-show-for-method-with-implicit-argument) is in the IDEA issue tracker. It's a Scala plugin issue.