### PR TITLE
Support `SIP-68: Reference-able Package Objects`

### DIFF
--- a/scala/scala-impl/src/org/jetbrains/plugins/scala/lang/psi/impl/expr/ScReferenceExpressionImpl.scala
+++ b/scala/scala-impl/src/org/jetbrains/plugins/scala/lang/psi/impl/expr/ScReferenceExpressionImpl.scala
@@ -182,24 +182,7 @@ class ScReferenceExpressionImpl(node: ASTNode) extends ScReferenceImpl(node) wit
     })
 
   override def getKinds(incomplete: Boolean, completion: Boolean = false): _root_.org.jetbrains.plugins.scala.lang.resolve.ResolveTargets.ValueSet = {
-    val context = getContext
-    context match {
-      case _ if completion =>
-        StdKinds.refExprQualRef // SCL-3092
-      case _: ScReferenceExpression =>
-        StdKinds.refExprQualRef
-      case postf: ScPostfixExpr if this == postf.operation || this == postf.getBaseExpr =>
-        StdKinds.refExprQualRef
-      case pref: ScPrefixExpr if this == pref.operation || this == pref.getBaseExpr =>
-        StdKinds.refExprQualRef
-      case inf: ScInfixExpr if this == inf.operation || this == inf.getBaseExpr =>
-        StdKinds.refExprQualRef
-      case _ =>
-        // Mill files allow direct references to package
-        // objects, even though normal .scala files do not
-        if (this.containingScalaFile.exists(_.isMillFile)) StdKinds.refExprQualRef
-        else StdKinds.refExprLastRef
-    }
+    StdKinds.refExprQualRef
   }
 
   override def multiType: Array[TypeResult] = {


### PR DESCRIPTION
Follow up to https://github.com/JetBrains/intellij-scala/pull/672/files. SIP-68 has been approved for experimental use, and will probably become preview/final at some point later, so opening this PR to get ready for that.

Not sure if there's a better way to do this, e.g. if we want to continue supporting the older behavior for older Scala versions. This is just a first draft to start the discussion