### PR TITLE
Start of using bloop rifle

### DIFF
--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,13 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-    <component name="Kotlin2JvmCompilerArguments">
-        <option name="jvmTarget" value="17"/>
-    </component>
-    <component name="KotlinCommonCompilerArguments">
-        <option name="apiVersion" value="1.9"/>
-        <option name="languageVersion" value="1.9"/>
-    </component>
-    <component name="KotlinJpsPluginSettings">
-        <option name="version" value="2.1.10"/>
-    </component>
+  <component name="Kotlin2JvmCompilerArguments">
+    <option name="jvmTarget" value="17" />
+  </component>
+  <component name="KotlinJpsPluginSettings">
+    <option name="version" value="2.1.10" />
+  </component>
 </project>

--- a/bsp-builtin/bsp/src/org/jetbrains/bsp/BSPCli.scala
+++ b/bsp-builtin/bsp/src/org/jetbrains/bsp/BSPCli.scala
@@ -21,6 +21,7 @@ import java.nio.file.Path
 import java.util
 import java.util.concurrent.CompletableFuture
 import java.util.{Collections, UUID}
+import scala.annotation.nowarn
 import scala.concurrent.Await
 import scala.concurrent.duration._
 import scala.io.StdIn
@@ -188,6 +189,7 @@ object BSPCli extends App {
   }
 
 
+  @nowarn("cat=deprecation")
   def testClasses(targets: BuildIds)(server: BspServer): CompletableFuture[ScalaTestClassesResult] = {
     val params = new bsp4j.ScalaTestClassesParams(targets)
     params.setOriginId(UUID.randomUUID().toString)

--- a/bsp-builtin/bsp/src/org/jetbrains/bsp/project/BspTask.scala
+++ b/bsp-builtin/bsp/src/org/jetbrains/bsp/project/BspTask.scala
@@ -191,7 +191,9 @@ class BspTask[T](project: Project,
     else {
       cleanRequest(targetsToClean)
       .exceptionally { err =>
-        new CleanCacheResult(BspBundle.message("bsp.task.server.does.not.support.cleaning.build.cache", err.getMessage), false)
+        val res = new CleanCacheResult(false)
+        res.setMessage(BspBundle.message("bsp.task.server.does.not.support.cleaning.build.cache", err.getMessage))
+        res
       }
       .thenCompose { cleaned =>
         if (cleaned.getCleaned) compileRequest(targetsWithCompileCap)
@@ -239,7 +241,7 @@ class BspTask[T](project: Project,
       case WARNING =>
         reporter.warning(textNoAnsi, None)
         buildMessages.addWarning(textNoAnsi)
-      case INFORMATION =>
+      case INFO =>
         buildMessages
       case LOG =>
         buildMessages

--- a/bsp-builtin/bsp/src/org/jetbrains/bsp/project/test/BspTestRunner.scala
+++ b/bsp-builtin/bsp/src/org/jetbrains/bsp/project/test/BspTestRunner.scala
@@ -1,6 +1,7 @@
 package org.jetbrains.bsp.project.test
 
-import ch.epfl.scala.bsp4j.TaskDataKind._
+import ch.epfl.scala.bsp4j.TaskStartDataKind._
+import ch.epfl.scala.bsp4j.TaskFinishDataKind._
 import ch.epfl.scala.bsp4j.TestStatus._
 import ch.epfl.scala.bsp4j._
 import com.google.gson.{Gson, JsonObject}

--- a/bsp-builtin/bsp/src/org/jetbrains/bsp/project/test/FetchScalaTestClassesTask.scala
+++ b/bsp-builtin/bsp/src/org/jetbrains/bsp/project/test/FetchScalaTestClassesTask.scala
@@ -16,6 +16,7 @@ import org.jetbrains.plugins.scala.build.{BuildMessages, BuildReporter, BuildToo
 import java.nio.file.Paths
 import java.util.UUID
 import java.util.concurrent.CompletableFuture
+import scala.annotation.nowarn
 import scala.concurrent.Promise
 import scala.jdk.CollectionConverters._
 import scala.util.{Failure, Success, Try}
@@ -81,6 +82,7 @@ class FetchScalaTestClassesTask(project: Project,
     }
   }
 
+  @nowarn("cat=deprecation")
   private def requestTestClasses(
     params: ScalaTestClassesParams
   )(bsp: BspServer, serverInfo: BuildServerInfo): CompletableFuture[ScalaTestClassesResult] =

--- a/bsp-builtin/bsp/src/org/jetbrains/bsp/project/test/environment/BspJvmEnvironment.scala
+++ b/bsp-builtin/bsp/src/org/jetbrains/bsp/project/test/environment/BspJvmEnvironment.scala
@@ -188,13 +188,13 @@ object BspJvmEnvironment {
       case ExecutionEnvironmentType.RUN =>
         environment[JvmRunEnvironmentResult](
           _.getJvmRunEnvironmentProvider,
-          targets => server.jvmRunEnvironment(new JvmRunEnvironmentParams(targets)),
+          targets => server.buildTargetJvmRunEnvironment(new JvmRunEnvironmentParams(targets)),
           _.getItems,
           "buildTarget/jvmRunEnvironment")
       case ExecutionEnvironmentType.TEST =>
         environment[JvmTestEnvironmentResult](
           _.getJvmTestEnvironmentProvider,
-          targets => server.jvmTestEnvironment(new JvmTestEnvironmentParams(targets)),
+          targets => server.buildTargetJvmTestEnvironment(new JvmTestEnvironmentParams(targets)),
           _.getItems,
           "buildTarget/jvmTestEnvironment")
     }

--- a/bsp-builtin/bsp/src/org/jetbrains/bsp/protocol/session/BloopLauncherConnector.scala
+++ b/bsp-builtin/bsp/src/org/jetbrains/bsp/protocol/session/BloopLauncherConnector.scala
@@ -1,8 +1,9 @@
 package org.jetbrains.bsp.protocol.session
 
-import ch.epfl.scala.bsp4j.BspConnectionDetails
-import com.intellij.execution.configurations.JavaParameters
-import com.intellij.openapi.projectRoots.Sdk
+import bloop.rifle.{BloopRifleConfig, BloopRifleLogger, BloopThreads, BloopVersion}
+import com.intellij.openapi.application.PathManager
+import com.intellij.openapi.projectRoots.{JavaSdk, Sdk}
+import org.apache.commons.io.input.ClosedInputStream
 import org.jetbrains.bsp.buildinfo.BuildInfo
 import org.jetbrains.bsp.protocol.session.BspServerConnector.BspCapabilities
 import org.jetbrains.bsp.protocol.session.BspSession.Builder
@@ -12,56 +13,63 @@ import org.jetbrains.plugins.scala.DependencyManagerBase.RichStr
 import org.jetbrains.plugins.scala.build.BuildReporter
 import org.jetbrains.plugins.scala.extensions.PathExt
 
-import java.nio.file.Path
-import scala.jdk.CollectionConverters._
+import java.io.File
+import java.nio.file.{Files, Path}
+import scala.concurrent.duration._
+import scala.util.control.NonFatal
 
 class BloopLauncherConnector(base: Path, compilerOutput: Path, capabilities: BspCapabilities, jdk: Sdk) extends BspServerConnector {
 
   val bloopVersion: String = BuildInfo.bloopVersion
-  val bspVersion = "2.0.0"
 
   override def connect(reporter: BuildReporter): Either[BspError, Builder] = {
+    def bloopClasspath(version: String): Right[Throwable, Seq[File]] = {
+      val dependencies = Seq(
+        ("ch.epfl.scala" % "bloop-frontend_2.12" % version).transitive()
+      )
 
-    val dependencies = Seq(
-      ("ch.epfl.scala" % "bloop-launcher_2.12" % bloopVersion).transitive()
-    )
-    val launcherClasspath = DependencyManager.resolve(dependencies: _*)
-      .map(_.file.toCanonicalPath.toString)
-      .asJava
+      val launcherClasspath = DependencyManager.resolve(dependencies: _*).map(_.file.toFile)
+      Right(launcherClasspath)
+    }
 
-    val javaParameters: JavaParameters = new JavaParameters
-    javaParameters.setJdk(jdk)
-    javaParameters.setWorkingDirectory(base.toFile)
-    javaParameters.getClassPath.addAll(launcherClasspath)
-    javaParameters.setMainClass("bloop.launcher.Launcher")
+    val bloopDataStore = PathManager.getCommonDataPath.resolve("bloop")
 
-    val cmdLine = javaParameters.toCommandLine
-    cmdLine.addParameter(bloopVersion)
-
-    val argv = cmdLine.getCommandLineList(null)
-
+    val details = BloopRifleConfig.default(
+      BloopRifleConfig.Address.DomainSocket(bloopDataStore),
+      bloopClasspath,
+      workingDir = base.toFile
+    ).copy(javaPath = JavaSdk.getInstance().getVMExecutablePath(jdk), retainedBloopVersion = BloopRifleConfig.AtLeast(BloopVersion(bloopVersion)))
     reporter.log(BspBundle.message("bsp.protocol.starting.bloop"))
-    //noinspection ReferencePassedToNls
-    reporter.log(cmdLine.getCommandLineString)
+    reporter.log(s"Configuring default bloop using ${details}")
 
-    val details = new BspConnectionDetails("Bloop", argv, bloopVersion, bspVersion, List("java","scala").asJava)
-    Right(prepareBspSession(details))
+    Right(prepareBspSession(details, bloopDataStore))
+
   }
 
-  private def prepareBspSession(details: BspConnectionDetails): Builder = {
+  private def prepareBspSession(details: BloopRifleConfig, bloopDataDir: Path): Builder = {
 
-    val processBuilder = new java.lang.ProcessBuilder(details.getArgv).directory(base.toFile)
-    val process = processBuilder.start()
+    val threads = BloopThreads.create()
+    val (connection, socket, _) = bloop.rifle.BloopServer.bsp(details, base, threads, BloopRifleLogger.nop, 10.seconds, 30.seconds)
+
+    def safeClose(close: => Unit) =
+      try {
+        close
+      } catch {
+        case NonFatal(_) => ()
+      }
 
     val cleanup = () => {
-      process.destroy()
+      safeClose(connection.stop())
+      safeClose(socket.close())
+      safeClose(threads.shutdown())
     }
+    val pid = scala.util.Try(Files.readString(bloopDataDir.resolve("pid"))).toOption.flatMap(_.toIntOption).getOrElse(-1)
 
     val rootUri = base.toCanonicalPath.toUri
     val compilerOutputUri = compilerOutput.toCanonicalPath.toUri
     val initializeBuildParams = BspServerConnector.createInitializeBuildParams(rootUri, compilerOutputUri, capabilities)
 
-    BspSession.builder(process.pid(), process.getInputStream, process.getErrorStream, process.getOutputStream, initializeBuildParams, cleanup)
+    BspSession.builder(pid, socket.getInputStream, ClosedInputStream.INSTANCE, socket.getOutputStream, initializeBuildParams, cleanup)
   }
 
 }

--- a/bsp-builtin/bsp/src/org/jetbrains/bsp/protocol/session/BspSession.scala
+++ b/bsp-builtin/bsp/src/org/jetbrains/bsp/protocol/session/BspSession.scala
@@ -165,7 +165,6 @@ class BspSession private(bspPID: Long,
       .create()
     val listening = launcher.startListening()
     val bspServer = cancellationSafeBspServer(launcher.getRemoteProxy)
-    localClient.onConnectWithServer(bspServer)
 
     val messageHandler = new BspProcessMessageHandler(bspErr)
     val messageHandlerRunning = AppExecutorUtil.getAppExecutorService.submit(messageHandler)
@@ -359,8 +358,6 @@ class BspSession private(bspPID: Long,
     }
 
     // build-level notifications
-    override def onConnectWithServer(server: bsp4j.BuildServer): Unit = super.onConnectWithServer(server)
-
     override def onBuildTargetDidChange(didChange: bsp4j.DidChangeBuildTarget): Unit = {
       updateLastActivity()
       val event = DidChangeBuildTarget(didChange)

--- a/bsp-builtin/bsp/test/org/jetbrains/bsp/project/importing/BspResolverLogicTest.scala
+++ b/bsp-builtin/bsp/test/org/jetbrains/bsp/project/importing/BspResolverLogicTest.scala
@@ -16,7 +16,13 @@ class BspResolverLogicTest {
     val target = new BuildTarget(
       new BuildTargetIdentifier("ePzqj://jqke:540/n/ius7/jDa/t/z78"),
       List("bla").asJava, null, List.empty.asJava,
-      new BuildTargetCapabilities(true,true,true)
+      {
+        val cap = new BuildTargetCapabilities()
+        cap.setCanCompile(true)
+        cap.setCanTest(true)
+        cap.setCanRun(true)
+        cap
+      }
     )
 
     val descriptions = BspResolverLogic.calculateModuleDescriptions(List(target), Nil, Nil, Nil, Nil, Nil, Nil)
@@ -34,7 +40,13 @@ class BspResolverLogicTest {
     val target = new BuildTarget(
       new BuildTargetIdentifier(id),
       emptyList, null, emptyList,
-      new BuildTargetCapabilities(true, true, true)
+      {
+        val cap = new BuildTargetCapabilities()
+        cap.setCanCompile(true)
+        cap.setCanTest(true)
+        cap.setCanRun(true)
+        cap
+      }
     )
     target.setDisplayName(displayName)
     target

--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -13,7 +13,7 @@ object Versions {
   // NOTE: sbt-launch / bloop-launcher won't be fetched on refresh.
   // run runtimeDependencies/update manually
   val sbtVersion: String = "1.10.7"
-  val bloopVersion = "1.5.6"
+  val bloopVersion = "2.0.9"
   val zincVersion = "1.10.7"
 
   // ATTENTION: check the comment in `Common.newProjectWithKotlin` when updating this version
@@ -29,7 +29,7 @@ object Versions {
   val (
     intellijVersion_ForManagedIntellijDependencies,
     intellijRepository_ForManagedIntellijDependencies,
-  ) = detectIntellijArtifactVersionAndRepository(intellijVersion)
+    ) = detectIntellijArtifactVersionAndRepository(intellijVersion)
 
   private def detectIntellijArtifactVersionAndRepository(intellijVersion: String): (String, MavenRepository) = {
     val locationDescriptor = IntellijVersionUtils.detectArtifactLocation(BuildInfo(intellijVersion, IdeaCommunity), ".zip")
@@ -42,7 +42,7 @@ object Versions {
   val junitVersion: String = "4.13.2"
   val junitInterfaceVersion: String = "0.13.3"
 
-  val bspVersion = "2.1.0-M3"
+  val bspVersion = "2.1.1"
   val sbtStructureVersion: String = "2025.1.5"
   val sbtIdeaShellVersion: String = "2025.1.4"
   val compilerIndicesVersion = "1.0.16"
@@ -117,7 +117,7 @@ object Dependencies {
    */
   val jupiterInterface: ModuleID = "com.github.sbt.junit" % "jupiter-interface" % "0.13.3"
 
-  val jupiterParams: String => ModuleID = (version: String) =>"org.junit.jupiter" % "junit-jupiter-params" % version
+  val jupiterParams: String => ModuleID = (version: String) => "org.junit.jupiter" % "junit-jupiter-params" % version
 
   val ivy2: ModuleID = "org.apache.ivy" % "ivy" % "2.5.2"
 
@@ -210,6 +210,7 @@ object Dependencies {
 }
 
 object DependencyGroups {
+
   import Dependencies.*
   import Versions.*
 
@@ -238,6 +239,7 @@ object DependencyGroups {
   )
 
   val bsp: Seq[ModuleID] = Seq(
+    ("ch.epfl.scala" %% "bloop-rifle" % bloopVersion).excludeAll(bspExclusions *),
     ("ch.epfl.scala" % "bsp4j" % bspVersion).excludeAll(bspExclusions *),
     ("ch.epfl.scala" %% "bsp-testkit" % bspVersion).excludeAll(bspExclusions *) % Test,
     scalaCheck


### PR DESCRIPTION
Should fix https://youtrack.jetbrains.com/issue/SCL-21024/Use-a-locally-installed-bloop-with-provided-connection-file#focus=Comments-27-11406726.0-0

* Remove old bloop launcher
* Fix some warnings which became errors in the build, by adding @scala.annotation.nowarn("cat=deprecation") where needed.

TODO:
* Make the bloop version configurable.