### PR TITLE
[SCL-23269] Find usages for context bound name

### DIFF
--- a/scala/scala-impl/src/org/jetbrains/plugins/scala/annotator/gutter/ScalaGoToDeclarationHandler.scala
+++ b/scala/scala-impl/src/org/jetbrains/plugins/scala/annotator/gutter/ScalaGoToDeclarationHandler.scala
@@ -254,7 +254,7 @@ object ScalaGoToDeclarationHandler {
       case parameter: ScParameter                                 =>
         val contextBound = findSyntheticContextBoundInfo(parameter).flatMap {
           case ContextBoundInfo(typeParam, _, idx, _) =>
-            typeParam.contextBounds(idx).nameId
+            typeParam.contextBounds(idx).nameIdOpt
         }
 
         parameterForSyntheticParameter(parameter).toSeq ++ contextBound

--- a/scala/scala-impl/src/org/jetbrains/plugins/scala/codeInsight/intention/types/ConvertImplicitBoundsToImplicitParameter.scala
+++ b/scala/scala-impl/src/org/jetbrains/plugins/scala/codeInsight/intention/types/ConvertImplicitBoundsToImplicitParameter.scala
@@ -77,7 +77,7 @@ object ConvertImplicitBoundsToImplicitParameter {
       cb       <- tp.contextBounds
       cbTe     = cb.typeElement
       teText   = cbTe.getText
-      cbName   = cb.name.getOrElse(teText.lowercased)
+      cbName   = cb.nameOpt.getOrElse(teText.lowercased)
       typeText = teText.parenthesize(!ScalaNamesValidator.isIdentifier(teText))
     } yield (
       cbName.escapeNonIdentifiers,

--- a/scala/scala-impl/src/org/jetbrains/plugins/scala/findUsages/SearchTargetExtractors.scala
+++ b/scala/scala-impl/src/org/jetbrains/plugins/scala/findUsages/SearchTargetExtractors.scala
@@ -4,6 +4,7 @@ import com.intellij.psi.{PsiClass, PsiElement, PsiNamedElement}
 import org.jetbrains.plugins.scala.extensions._
 import org.jetbrains.plugins.scala.lang.psi.ScalaPsiUtil.inNameContext
 import org.jetbrains.plugins.scala.lang.psi.api.base.ScReference
+import org.jetbrains.plugins.scala.lang.psi.api.base.types.ScContextBound
 import org.jetbrains.plugins.scala.lang.psi.api.statements.ScFunction
 import org.jetbrains.plugins.scala.lang.psi.api.statements.params.ScParameter
 import org.jetbrains.plugins.scala.lang.psi.api.toplevel.typedef.{ScMember, ScObject}
@@ -28,6 +29,7 @@ object SearchTargetExtractors {
             val isLocal = idef match {
               case member: ScMember => member.isLocal
               case _: ScParameter => true // ScClassParameters are already processed with ScMember
+              case _: ScContextBound => true
               case inNameContext(member: ScMember) => member.isLocal
               case _              => false
             }

--- a/scala/scala-impl/src/org/jetbrains/plugins/scala/findUsages/factory/ScalaFindUsagesConfiguration.scala
+++ b/scala/scala-impl/src/org/jetbrains/plugins/scala/findUsages/factory/ScalaFindUsagesConfiguration.scala
@@ -9,6 +9,7 @@ import org.jetbrains.plugins.scala.findUsages.factory.ScalaFindUsagesConfigurati
 import org.jetbrains.plugins.scala.findUsages.factory.dialog.{ScalaOverridableMemberFindUsagesDialog, ScalaTypeDefinitionUsagesDialog}
 import org.jetbrains.plugins.scala.lang.psi.ScalaPsiUtil.inNameContext
 import org.jetbrains.plugins.scala.lang.psi.api.base.patterns.ScCaseClause
+import org.jetbrains.plugins.scala.lang.psi.api.base.types.ScContextBound
 import org.jetbrains.plugins.scala.lang.psi.api.expr.{ScForBinding, ScGenerator}
 import org.jetbrains.plugins.scala.lang.psi.api.statements.params.{ScParameter, ScTypeParam}
 import org.jetbrains.plugins.scala.lang.psi.api.toplevel.typedef.{ScMember, ScTypeDefinition}
@@ -42,7 +43,7 @@ final class ScalaFindUsagesConfiguration(project: Project) {
         FindUsagesOptionsResolver.ForTypeDefinitions(typeDef, typeDefinitionOptions)
       case inNameContext(m: ScMember) if !m.isLocal =>
         FindUsagesOptionsResolver.ForMembers(m, memberOptions)
-      case _: ScParameter | _: ScTypeParam =>
+      case _: ScParameter | _: ScTypeParam | _: ScContextBound =>
         FindUsagesOptionsResolver.ForLocals(localOptions)
       case inNameContext(_: ScMember | _: ScCaseClause | _: ScGenerator | _: ScForBinding) =>
         FindUsagesOptionsResolver.ForLocals(localOptions)

--- a/scala/scala-impl/src/org/jetbrains/plugins/scala/findUsages/factory/ScalaFindUsagesHandlerFactory.scala
+++ b/scala/scala-impl/src/org/jetbrains/plugins/scala/findUsages/factory/ScalaFindUsagesHandlerFactory.scala
@@ -7,6 +7,7 @@ import com.intellij.psi.{PsiElement, PsiNamedElement}
 import org.jetbrains.plugins.scala.extensions._
 import org.jetbrains.plugins.scala.findUsages.SearchTargetExtractors.ShouldBeSearchedInBytecode
 import org.jetbrains.plugins.scala.findUsages.{ExternalSearchScopeChecker, UsageType}
+import org.jetbrains.plugins.scala.lang.psi.api.base.types.ScContextBound
 import org.jetbrains.plugins.scala.lang.psi.api.base.{ScEnd, ScPrimaryConstructor}
 import org.jetbrains.plugins.scala.lang.psi.api.statements.params.ScTypeParam
 import org.jetbrains.plugins.scala.lang.psi.api.statements.{ScFunction, ScTypeAlias}
@@ -30,6 +31,7 @@ class ScalaFindUsagesHandlerFactory(project: Project) extends FindUsagesHandlerF
       case _: ScTypeAlias            => true
       case _: ScPrimaryConstructor   => true
       case _: ScTypeParam            => true
+      case _: ScContextBound         => true
       case _: PsiClassWrapper        => true
       case _: PsiMethodWrapper[_]    => true
       case contextBoundElement(_, _) => true

--- a/scala/scala-impl/src/org/jetbrains/plugins/scala/lang/psi/ScalaPsiUtil.scala
+++ b/scala/scala-impl/src/org/jetbrains/plugins/scala/lang/psi/ScalaPsiUtil.scala
@@ -1396,7 +1396,7 @@ object ScalaPsiUtil {
       owner <- maybeOwner.toSeq
       typeParameter <- owner.typeParameters
       (bound, idx) <- typeParameter.contextBounds.zipWithIndex
-    } yield ContextBoundInfo(typeParameter, bound.typeElement, idx, bound.name)
+    } yield ContextBoundInfo(typeParameter, bound.typeElement, idx, bound.nameOpt)
 
     contextBounds.find { case ContextBoundInfo(typeParameter, typeElement, index, name) =>
       val currentParameterName = name.getOrElse(contextBoundParameterName(typeParameter, typeElement, index))
@@ -1452,7 +1452,7 @@ object ScalaPsiUtil {
     val bounds = for {
       typeParameter <- tparams
       (cb, index) <- typeParameter.contextBounds.zipWithIndex
-    } yield ParameterDescriptor(typeParameter, cb.typeElement, index, cb.name)
+    } yield ParameterDescriptor(typeParameter, cb.typeElement, index, cb.nameOpt)
 
     val boundsTexts = bounds.map {
       case ParameterDescriptor(typeParameter, typeElement, index, name) =>
@@ -1630,6 +1630,7 @@ object ScalaPsiUtil {
 
   def isImplicit(@Nullable namedElement: PsiNamedElement): Boolean =
     namedElement match {
+      case _: ScContextBound  => true
       case _: ScGiven         => true
       case _: ScGivenPattern  => true
       case Implicit0Binding() => true

--- a/scala/scala-impl/src/org/jetbrains/plugins/scala/lang/psi/api/base/types/ScContextBound.scala
+++ b/scala/scala-impl/src/org/jetbrains/plugins/scala/lang/psi/api/base/types/ScContextBound.scala
@@ -2,8 +2,9 @@ package org.jetbrains.plugins.scala.lang.psi.api.base.types
 
 import com.intellij.psi.PsiElement
 import org.jetbrains.plugins.scala.lang.psi.api.ScalaPsiElement
+import org.jetbrains.plugins.scala.lang.psi.api.toplevel.ScNamedElement
 
-trait ScContextBound extends ScalaPsiElement {
+trait ScContextBound extends ScalaPsiElement with ScNamedElement {
   /**
    * @return Actual bound type element
    */
@@ -12,14 +13,16 @@ trait ScContextBound extends ScalaPsiElement {
   /**
    * @return Optional `as` name for 3.6+ style context bounds
    */
-  def nameId: Option[PsiElement]
+  def nameIdOpt: Option[PsiElement]
 
-  def name: Option[String] = nameId.map(_.getText)
+  def nameOpt: Option[String] = nameIdOpt.map(_.getText)
+
+  override def nameId: PsiElement = nameIdOpt.orNull
 }
 
 object ScContextBound {
   object Named {
     def unapply(bound: ScContextBound): Option[(ScTypeElement, String)] =
-      bound.name.map(bound.typeElement -> _)
+      bound.nameOpt.map(bound.typeElement -> _)
   }
 }

--- a/scala/scala-impl/src/org/jetbrains/plugins/scala/lang/psi/api/base/types/ScContextBound.scala
+++ b/scala/scala-impl/src/org/jetbrains/plugins/scala/lang/psi/api/base/types/ScContextBound.scala
@@ -16,8 +16,6 @@ trait ScContextBound extends ScalaPsiElement with ScNamedElement {
   def nameIdOpt: Option[PsiElement]
 
   def nameOpt: Option[String] = nameIdOpt.map(_.getText)
-
-  override def nameId: PsiElement = nameIdOpt.orNull
 }
 
 object ScContextBound {

--- a/scala/scala-impl/src/org/jetbrains/plugins/scala/lang/psi/impl/base/types/ScContextBoundImpl.scala
+++ b/scala/scala-impl/src/org/jetbrains/plugins/scala/lang/psi/impl/base/types/ScContextBoundImpl.scala
@@ -17,4 +17,6 @@ class ScContextBoundImpl(node: ASTNode) extends ScalaPsiElementImpl(node) with S
 
   override def nameIdOpt: Option[PsiElement] =
     findLastChildByTypeScala(ScalaTokenTypes.tIDENTIFIER)
+
+  override def nameId: PsiElement = nameIdOpt.getOrElse(findChild[ScTypeElement].orNull)
 }

--- a/scala/scala-impl/src/org/jetbrains/plugins/scala/lang/psi/impl/base/types/ScContextBoundImpl.scala
+++ b/scala/scala-impl/src/org/jetbrains/plugins/scala/lang/psi/impl/base/types/ScContextBoundImpl.scala
@@ -15,6 +15,6 @@ class ScContextBoundImpl(node: ASTNode) extends ScalaPsiElementImpl(node) with S
   override def typeElement: ScTypeElement =
     findChild[ScTypeElement].get
 
-  override def nameId: Option[PsiElement] =
+  override def nameIdOpt: Option[PsiElement] =
     findLastChildByTypeScala(ScalaTokenTypes.tIDENTIFIER)
 }

--- a/scala/scala-impl/src/org/jetbrains/plugins/scala/lang/psi/impl/toplevel/typedef/AbstractTypeContextBoundsInjector.scala
+++ b/scala/scala-impl/src/org/jetbrains/plugins/scala/lang/psi/impl/toplevel/typedef/AbstractTypeContextBoundsInjector.scala
@@ -29,7 +29,7 @@ class AbstractTypeContextBoundsInjector extends SyntheticMembersInjector {
     typesWithContextBounds.flatMap { typeDecl =>
       val bounds = typeDecl.contextBounds
       bounds.map { cb =>
-        val optionalName = cb.name.fold("")(_ + ": ")
+        val optionalName = cb.nameOpt.fold("")(_ + ": ")
         val tpe          = s"(${cb.typeElement.getText})[${typeDecl.name}]"
         s"given $optionalName$tpe = scala.compiletime.deferred"
       }

--- a/scala/scala-impl/src/org/jetbrains/plugins/scala/util/ImplicitUtil.scala
+++ b/scala/scala-impl/src/org/jetbrains/plugins/scala/util/ImplicitUtil.scala
@@ -18,7 +18,7 @@ import org.jetbrains.plugins.scala.lang.psi.api.base.{ScConstructorInvocation, S
 import org.jetbrains.plugins.scala.lang.psi.api.expr._
 import org.jetbrains.plugins.scala.lang.psi.api.statements.ScFunction
 import org.jetbrains.plugins.scala.lang.psi.api.statements.ScFunction.CommonNames
-import org.jetbrains.plugins.scala.lang.psi.api.statements.params.ScTypeParam
+import org.jetbrains.plugins.scala.lang.psi.api.statements.params.{ScParameter, ScTypeParam}
 import org.jetbrains.plugins.scala.lang.psi.api.toplevel.ScNamedElement
 import org.jetbrains.plugins.scala.lang.psi.api.toplevel.typedef.ScMember
 import org.jetbrains.plugins.scala.lang.resolve.ScalaResolveResult
@@ -27,10 +27,15 @@ import scala.annotation.tailrec
 
 object ImplicitUtil {
   implicit class ImplicitTargetExt(private val targetImplicit: PsiElement) extends AnyVal {
+    private def isContextBound(target: PsiElement, element: PsiElement) = {
+      target.is[ScContextBound] && target == element.getNavigationElement.getContext
+    }
+
     private def isTarget(srr: ScalaResolveResult): Boolean = srr.element match {
       case `targetImplicit`                                              => true
       case f: ScMember if targetImplicit == f.syntheticNavigationElement => true
       case f: ScFunction if f.name == CommonNames.Apply                  => srr.innerResolveResult.exists(isTarget)
+      case p: ScParameter if isContextBound(targetImplicit, p)           => true
       case _                                                             => false
     }
 
@@ -51,6 +56,7 @@ object ImplicitUtil {
       case ref: ScReference if ref.bind().exists(isTarget)        => Option(ref)
       case e: ScExpression if isImplicitConversionOrParameter(e)  => Option(ImplicitReference(e, targetImplicit))
       case c: ScConstructorInvocation if isImplicitParameterOf(c) => Option(ImplicitReference(c, targetImplicit))
+      case c: ScContextBound if isContextBound(c, targetImplicit) => Option(ImplicitReference(c, targetImplicit))
       case _                                                      => None
     }
   }

--- a/scala/scala-impl/test/org/jetbrains/plugins/scala/highlighter/usages/ScalaHighlightImplicitUsagesHandlerTest.scala
+++ b/scala/scala-impl/test/org/jetbrains/plugins/scala/highlighter/usages/ScalaHighlightImplicitUsagesHandlerTest.scala
@@ -121,7 +121,7 @@ abstract class ScalaHighlightImplicitUsagesHandlerTestBase extends ScalaHighligh
          |
          |def double[T $CARET: Semigroup](t: T) = implicitly[Semigroup[T]].op(t, t)
       """.stripMargin
-    doTest(code, Seq("implicitly[Semigroup[T]]"))
+    doTest(code, Seq("Semigroup", "implicitly[Semigroup[T]]"))
   }
 
   def testContextBoundsColon2(): Unit = {
@@ -135,7 +135,7 @@ abstract class ScalaHighlightImplicitUsagesHandlerTestBase extends ScalaHighligh
          |
          |def double[T:$CARET Semigroup](t: T) = implicitly[Semigroup[T]].op(t, t)
       """.stripMargin
-    doTest(code, Seq("implicitly[Semigroup[T]]"))
+    doTest(code, Seq("Semigroup", "implicitly[Semigroup[T]]"))
   }
 
   def testImplicitClass(): Unit = {

--- a/scala/scala-impl/test/org/jetbrains/plugins/scala/highlighter/usages/ScalaHighlightImplicitUsagesHandlerTest.scala
+++ b/scala/scala-impl/test/org/jetbrains/plugins/scala/highlighter/usages/ScalaHighlightImplicitUsagesHandlerTest.scala
@@ -357,4 +357,28 @@ class ScalaHighlightImplicitUsagesHandlerTest extends ScalaHighlightImplicitUsag
 
 class ScalaHighlightImplicitUsagesHandlerTest_Scala3 extends ScalaHighlightImplicitUsagesHandlerTestBase {
   override protected def supportedIn(version: ScalaVersion): Boolean = version >= ScalaVersion.Latest.Scala_3_6
+
+  def testNamedContextBounds(): Unit = {
+    val code =
+      s"""
+         |trait Semigroup[T] {
+         |  def op(a: T, b: T): T
+         |}
+         |
+         |def double[T: Semigroup as x$CARET](t: T) = implicitly[Semigroup[T]].op(t, t)
+      """.stripMargin
+    doTest(code, Seq("x", "implicitly[Semigroup[T]]"))
+  }
+
+  def testNamedContextBoundsUsage(): Unit = {
+    val code =
+      s"""
+         |trait Semigroup[T] {
+         |  def op(a: T, b: T): T
+         |}
+         |
+         |def summonSemigroup[T: Semigroup as x](t: T) = x$CARET
+      """.stripMargin
+    doTest(code, Seq("Semigroup as x", "x"))
+  }
 }


### PR DESCRIPTION
I was also wondering if it would be possible to make a unused context bound highlighting, even if it is not named, as in the case of given. Is there a separate SCL for this?