### PR TITLE
SCL-6315: case-to-case inheritance prohibited

### DIFF
--- a/scala/scala-impl/resources/messages/ScalaBundle.properties
+++ b/scala/scala-impl/resources/messages/ScalaBundle.properties
@@ -420,6 +420,7 @@ mixin.required={0} ''{1}'' needs to be mixin, since member ''{2}'' in ''{3}'' is
 illegal.undefined.member=Only classes can have declared but undefined members
 illegal.inheritance.from.final.kind=Illegal inheritance from final {0} ''{1}''
 illegal.inheritance.from.value.class=Illegal inheritance from value class ''{0}''
+illegal.inheritance.from.case.class=Case class ''{0}'' has case ancestor ''{1}'', but case-to-case inheritance is prohibited
 illegal.inheritance.extends.enum=Extending enums is prohibited
 trait.may.not.call.constructor=Trait {0} may not call constructor of {1}
 trait.is.already.implemented.by.superclass=Trait {0} is already implemented by superclass {1}, \

--- a/scala/scala-impl/src/org/jetbrains/plugins/scala/annotator/element/ScTemplateDefinitionAnnotator.scala
+++ b/scala/scala-impl/src/org/jetbrains/plugins/scala/annotator/element/ScTemplateDefinitionAnnotator.scala
@@ -23,6 +23,7 @@ import org.jetbrains.plugins.scala.lang.resolve.ScalaResolveResult
 import org.jetbrains.plugins.scala.overrideImplement.{ScMethodMember, ScalaOIUtil, ScalaTypedMember}
 import org.jetbrains.plugins.scala.{NlsString, ScalaBundle, overrideImplement}
 
+import scala.annotation.tailrec
 import scala.util.chaining._
 
 object ScTemplateDefinitionAnnotator extends ElementAnnotator[ScTemplateDefinition] {
@@ -37,6 +38,7 @@ object ScTemplateDefinitionAnnotator extends ElementAnnotator[ScTemplateDefiniti
     annotateEnumClassInheritance(element)
     annotateTraitPassingConstructorParameters(element)
     annotateParentTraitConstructorParameters(element)
+    annotateCaseToCaseInheritance(element)
 
     if (typeAware) {
       annotateNeedsToBeMixin(element)
@@ -235,14 +237,47 @@ object ScTemplateDefinitionAnnotator extends ElementAnnotator[ScTemplateDefiniti
     superRefs(element).collect {
       case (range, clazz) if clazz.hasFinalModifier =>
         (range, NlsString(ScalaBundle.message("illegal.inheritance.from.final.kind", kindOf(clazz, toLowerCase = true), clazz.name)))
-      case (range, clazz: ScClass) if clazz.isCase && element.asOptionOf[ScClass].exists(_.isCase) =>
-        (range, NlsString(ScalaBundle.message("illegal.inheritance.from.case.class", element.name, clazz.name)))
       case (range, clazz) if ValueClassType.extendsAnyVal(clazz) =>
         (range, NlsString(ScalaBundle.message("illegal.inheritance.from.value.class", clazz.name)))
     }.foreach {
       case (range, message) =>
         holder.createErrorAnnotation(range, message.nls)
     }
+  }
+
+  def annotateCaseToCaseInheritance(element: ScTemplateDefinition)
+                                   (implicit holder: ScalaAnnotationHolder): Unit = {
+    @tailrec
+    def findCaseAncestor(queue: List[ScClass]): Option[ScClass] = queue match {
+      case Nil => None
+      case head :: tail =>
+        if (head.isCase) Some(head)
+        else {
+          val nextLevel = superRefs(head)
+            .map(_._2)
+            .collect { case c: ScClass => c }
+          findCaseAncestor(tail ++ nextLevel)
+        }
+    }
+
+    element.asOptionOf[ScClass]
+      .filter(_.isCase)
+      .flatMap { clazz =>
+        for {
+          (range, firstAncestor) <- superRefs(clazz).collectFirst {
+            case (rng, sc: ScClass) => (rng, sc)
+          }
+          ancestorCaseClass <- findCaseAncestor(List(firstAncestor))
+        } yield (range, ancestorCaseClass)
+      }
+      .foreach { case (range, ancestor) =>
+        val msg = ScalaBundle.message(
+          "illegal.inheritance.from.case.class",
+          element.name,
+          ancestor.name
+        )
+        holder.createErrorAnnotation(range, msg)
+      }
   }
 
   def annotateIllegalInheritance(element: ScTemplateDefinition)

--- a/scala/scala-impl/src/org/jetbrains/plugins/scala/annotator/element/ScTemplateDefinitionAnnotator.scala
+++ b/scala/scala-impl/src/org/jetbrains/plugins/scala/annotator/element/ScTemplateDefinitionAnnotator.scala
@@ -235,6 +235,8 @@ object ScTemplateDefinitionAnnotator extends ElementAnnotator[ScTemplateDefiniti
     superRefs(element).collect {
       case (range, clazz) if clazz.hasFinalModifier =>
         (range, NlsString(ScalaBundle.message("illegal.inheritance.from.final.kind", kindOf(clazz, toLowerCase = true), clazz.name)))
+      case (range, clazz: ScClass) if clazz.isCase && element.asOptionOf[ScClass].exists(_.isCase) =>
+        (range, NlsString(ScalaBundle.message("illegal.inheritance.from.case.class", element.name, clazz.name)))
       case (range, clazz) if ValueClassType.extendsAnyVal(clazz) =>
         (range, NlsString(ScalaBundle.message("illegal.inheritance.from.value.class", clazz.name)))
     }.foreach {

--- a/scala/scala-impl/test/org/jetbrains/plugins/scala/annotator/template/CaseToCaseInheritanceTest.scala
+++ b/scala/scala-impl/test/org/jetbrains/plugins/scala/annotator/template/CaseToCaseInheritanceTest.scala
@@ -1,0 +1,40 @@
+package org.jetbrains.plugins.scala.annotator.template
+
+import org.jetbrains.plugins.scala.ScalaBundle
+import org.jetbrains.plugins.scala.annotator.{AnnotatorTestBase, Message, ScalaAnnotationHolder}
+import org.jetbrains.plugins.scala.annotator.element.ScTemplateDefinitionAnnotator
+import org.jetbrains.plugins.scala.lang.psi.api.toplevel.typedef.ScTemplateDefinition
+
+class CaseToCaseInheritanceTest extends AnnotatorTestBase[ScTemplateDefinition] {
+  import Message._
+
+  def testCaseToCase(): Unit = {
+    val message = ScalaBundle.message("illegal.inheritance.from.case.class", "B", "A")
+
+    val expectation: PartialFunction[List[Message], Unit] = {
+      case Error("A", `message`) :: Nil =>
+    }
+
+    assertMatches(messages("case class A(); case class B() extends A(); B()"))(expectation)
+  }
+
+  def testIndirectCaseToCase(): Unit = {
+    val message = ScalaBundle.message("illegal.inheritance.from.case.class", "C", "A")
+
+    val expectation: PartialFunction[List[Message], Unit] = {
+      case Error("B", `message`) :: Nil =>
+    }
+
+    assertMatches(messages(
+      """
+        |case class A(a : Int)
+        |class B extends A(2)
+        |case class C(z: Int) extends B
+      """.stripMargin
+    ))(expectation)
+  }
+
+  override protected def annotate(element: ScTemplateDefinition)
+                                 (implicit holder: ScalaAnnotationHolder): Unit =
+    ScTemplateDefinitionAnnotator.annotateCaseToCaseInheritance(element)
+}

--- a/scala/scala-impl/test/org/jetbrains/plugins/scala/annotator/template/FinalClassInheritanceTest.scala
+++ b/scala/scala-impl/test/org/jetbrains/plugins/scala/annotator/template/FinalClassInheritanceTest.scala
@@ -55,6 +55,16 @@ class FinalClassInheritanceTest extends AnnotatorTestBase[ScTemplateDefinition] 
     assertMatches(messages("class C(val x: Int) extends AnyVal; class X extends C(2)"))(expectation)
   }
 
+  def testCaseToCase(): Unit = {
+    val message = ScalaBundle.message("illegal.inheritance.from.case.class", "B", "A")
+
+    val expectation: PartialFunction[List[Message], Unit] = {
+      case Error("A", `message`) :: Nil =>
+    }
+
+    assertMatches(messages("case class A(); case class B() extends A(); B()"))(expectation)
+  }
+
   override protected def annotate(element: ScTemplateDefinition)
                                  (implicit holder: ScalaAnnotationHolder): Unit =
     ScTemplateDefinitionAnnotator.annotateFinalClassInheritance(element)

--- a/scala/scala-impl/test/org/jetbrains/plugins/scala/annotator/template/FinalClassInheritanceTest.scala
+++ b/scala/scala-impl/test/org/jetbrains/plugins/scala/annotator/template/FinalClassInheritanceTest.scala
@@ -55,16 +55,6 @@ class FinalClassInheritanceTest extends AnnotatorTestBase[ScTemplateDefinition] 
     assertMatches(messages("class C(val x: Int) extends AnyVal; class X extends C(2)"))(expectation)
   }
 
-  def testCaseToCase(): Unit = {
-    val message = ScalaBundle.message("illegal.inheritance.from.case.class", "B", "A")
-
-    val expectation: PartialFunction[List[Message], Unit] = {
-      case Error("A", `message`) :: Nil =>
-    }
-
-    assertMatches(messages("case class A(); case class B() extends A(); B()"))(expectation)
-  }
-
   override protected def annotate(element: ScTemplateDefinition)
                                  (implicit holder: ScalaAnnotationHolder): Unit =
     ScTemplateDefinitionAnnotator.annotateFinalClassInheritance(element)


### PR DESCRIPTION
Also [SCL-3424](https://youtrack.jetbrains.com/issue/SCL-3424/Bad-code-is-green-Scala-case-classes-inheritance)