### PR TITLE
SCL-23855: show type parameters in XRay mode

### DIFF
--- a/scala/codeInsight/src/org/jetbrains/plugins/scala/codeInsight/hints/ScalaTypeHintsPass.scala
+++ b/scala/codeInsight/src/org/jetbrains/plugins/scala/codeInsight/hints/ScalaTypeHintsPass.scala
@@ -16,18 +16,24 @@ import org.jetbrains.plugins.scala.codeInsight.ScalaCodeInsightBundle
 import org.jetbrains.plugins.scala.codeInsight.hints.ScalaTypeHintsPass._
 import org.jetbrains.plugins.scala.extensions._
 import org.jetbrains.plugins.scala.lang.lexer.ScalaTokenTypes
-import org.jetbrains.plugins.scala.lang.psi.api.base.ScPatternList
+import org.jetbrains.plugins.scala.lang.psi.api.InferUtil
+import org.jetbrains.plugins.scala.lang.psi.api.base.{ScConstructorInvocation, ScMethodLike, ScPatternList, ScPrimaryConstructor}
 import org.jetbrains.plugins.scala.lang.psi.api.base.patterns.{ScReferencePattern, ScTypedPatternLike, ScWildcardPattern}
-import org.jetbrains.plugins.scala.lang.psi.api.expr.{ScExpression, ScInfixExpr, ScReferenceExpression, ScTypedExpression, ScUnderscoreSection}
-import org.jetbrains.plugins.scala.lang.psi.api.statements.params.{ScParameter, ScParameterClause}
+import org.jetbrains.plugins.scala.lang.psi.api.expr.{ScExpression, ScInfixExpr, ScMethodCall, ScReferenceExpression, ScTypedExpression, ScUnderscoreSection}
+import org.jetbrains.plugins.scala.lang.psi.api.statements.params.{ScParameter, ScParameterClause, ScTypeParam}
 import org.jetbrains.plugins.scala.lang.psi.api.statements.{ScFunction, ScFunctionDefinition, ScPatternDefinition, ScValueOrVariable, ScVariableDefinition}
-import org.jetbrains.plugins.scala.lang.psi.types.nonvalue.ScMethodType
+import org.jetbrains.plugins.scala.lang.psi.api.toplevel.typedef.ScTypeDefinition
+import org.jetbrains.plugins.scala.lang.psi.types.api.TypeParameter
+import org.jetbrains.plugins.scala.lang.psi.types.nonvalue.{ScMethodType, ScTypePolymorphicType}
 import org.jetbrains.plugins.scala.lang.psi.types.result.Typeable
-import org.jetbrains.plugins.scala.lang.psi.types.{ScType, TypePresentationContext}
+import org.jetbrains.plugins.scala.lang.psi.types.{ConstraintSystem, ScAbstractType, ScType, TypePresentationContext}
+import org.jetbrains.plugins.scala.lang.resolve.ScalaResolveResult
 import org.jetbrains.plugins.scala.settings.ScalaApplicationSettings.{getInstance => ScalaApplicationSettings}
 import org.jetbrains.plugins.scala.settings.ScalaHighlightingMode
 import org.jetbrains.plugins.scala.settings.annotations.Definition
 import org.jetbrains.plugins.scala.settings.annotations.Definition.{FunctionDefinition, ValueDefinition, VariableDefinition}
+
+import scala.annotation.tailrec
 
 private[codeInsight] trait ScalaTypeHintsPass {
   protected implicit def settings: ScalaHintsSettings
@@ -54,8 +60,49 @@ private[codeInsight] trait ScalaTypeHintsPass {
   }
 
   private def collectXRayHints(editor: Editor, root: PsiElement) = root.elements(_.isVisible).flatMap {
+    case ci@ScConstructorInvocation.reference(Resolved(r@ScalaResolveResult(fun: ScMethodLike, _)))
+      if getTypeParameters(fun).nonEmpty && ScalaApplicationSettings.XRAY_SHOW_TYPE_PARAMETERS_HINTS =>
+      r.resultUndef.flatMap { cs =>
+        xRayTypeParametersHints(ci.typeElement, cs, fun, editor)
+      }.getOrElse(Seq.empty)
+    case outermostMethodCall@ScMethodCall.withDeepestInvoked((invoked: ScReferenceExpression) & Resolved(ScalaResolveResult(methodLike: ScMethodLike, _)))
+      if ScalaApplicationSettings.XRAY_SHOW_TYPE_PARAMETERS_HINTS && !outermostMethodCall.getParent.is[ScMethodCall] && getTypeParameters(methodLike).nonEmpty =>
+      val cs = collectMethodCalls(outermostMethodCall)
+        .map { mc =>
+          for {
+            typePoly <- mc.getNonValueType(fromUnderscore = true).toOption.flatMap(_.asOptionOf[ScTypePolymorphicType])
+            inferRes = InferUtil.localTypeInferenceWithApplicabilityExt(
+              typePoly.internalType,
+              mc.matchedParameters.map(_._2),
+              mc.matchedParameters.map(_._1),
+              typePoly.typeParameters
+            )
+          } yield inferRes._2.constraints
+        }
+        .collect { case Some(x) => x }
+        .foldLeft(ConstraintSystem.empty)(_ + _)
+      val hints = xRayTypeParametersHints(invoked, cs, methodLike, editor)
+      hints.getOrElse(Seq.empty)
     case e @ Typeable(t) => xRayHintsFor(e, t)(editor.getColorsScheme, TypePresentationContext(e), settings)
     case _ => Seq.empty
+  }
+
+  private def xRayTypeParametersHints(invoked: PsiElement, cs: ConstraintSystem, fun: ScMethodLike, editor: Editor) = {
+    cs.substitutionBounds(canThrowSCE = false)(editor.getProject).map { bounds =>
+      def typeParamSubst(tp: ScTypeParam) = {
+        bounds.substitutor(ScAbstractType(TypeParameter(tp), tp.lowerBound.getOrNothing, tp.upperBound.getOrAny))
+      }
+
+      getTypeParameters(fun).map { tp =>
+        val ty = typeParamSubst(tp)
+        textPartsOf(ty, settings.presentationLength, invoked)(editor.getColorsScheme, TypePresentationContext(invoked))
+      }
+    }.map(texts =>
+      Seq(
+        Hint(Seq(Text("[")), invoked, suffix = true, corners = Corners.Left),
+        Hint(texts.intersperse(Seq(Text(", "))).flatten :+ Text("]"), invoked, suffix = true, relatesToPrecedingElement = true, corners = Corners.Right)
+      )
+    )
   }
 
   private def xRayHintsFor(e: PsiElement, t: ScType)(implicit scheme: EditorColorsScheme, context: TypePresentationContext, settings: ScalaHintsSettings): Seq[Hint] = e match {
@@ -73,6 +120,27 @@ private[codeInsight] trait ScalaTypeHintsPass {
       Seq(Hint(Seq(Text("(")), e, suffix = false, corners = Corners.Left), Hint(Text(": ") +: textPartsOf(t, settings.presentationLength, e) :+ Text(")"), e, suffix = true, relatesToPrecedingElement = true, corners = Corners.Right))
     else
       Seq(Hint(Text(": ") +: textPartsOf(t, settings.presentationLength, e), e, suffix = true, relatesToPrecedingElement = true))
+  }
+
+  private def getTypeParameters(function: ScMethodLike) = function match {
+    case fun: ScFunction if !fun.isConstructor => fun.typeParameters
+    case _: ScFunction | _: ScPrimaryConstructor =>
+      function.containingClass match {
+        case td: ScTypeDefinition => td.typeParameters
+        case _ => Seq.empty
+      }
+    case _ => Seq.empty
+  }
+
+  private def collectMethodCalls(expr: ScExpression): List[ScMethodCall] = {
+    @tailrec
+    def loop(current: ScExpression, acc: List[ScMethodCall]): List[ScMethodCall] = current match {
+      case call: ScMethodCall =>
+        loop(call.getEffectiveInvokedExpr, call :: acc)
+      case _ => acc
+    }
+
+    loop(expr, Nil)
   }
 }
 

--- a/scala/scala-impl/resources/messages/ScalaBundle.properties
+++ b/scala/scala-impl/resources/messages/ScalaBundle.properties
@@ -2339,6 +2339,7 @@ scala.project.settings.form.xray.show=Show:
 scala.project.settings.form.xray.parameter.name.hints=Parameter name hints
 scala.project.settings.form.xray.by-name.argument.hints=By-name argument hints
 scala.project.settings.form.xray.type.hints=Type hints for:
+scala.project.settings.form.xray.type.parameter.hints=Type parameters
 scala.project.settings.form.xray.member.variables=Member variables
 scala.project.settings.form.xray.local.variables=Local variables
 scala.project.settings.form.xray.method.results=Method results

--- a/scala/scala-impl/src/org/jetbrains/plugins/scala/settings/ScalaApplicationSettings.java
+++ b/scala/scala-impl/src/org/jetbrains/plugins/scala/settings/ScalaApplicationSettings.java
@@ -106,6 +106,7 @@ public class ScalaApplicationSettings implements PersistentStateComponent<ScalaA
   public boolean XRAY_SHOW_LAMBDA_PARAMETER_HINTS = true;
   public boolean XRAY_SHOW_LAMBDA_PLACEHOLDER_HINTS = true;
   public boolean XRAY_SHOW_VARIABLE_PATTERN_HINTS = true;
+  public boolean XRAY_SHOW_TYPE_PARAMETERS_HINTS = false;
   public boolean XRAY_SHOW_METHOD_CHAIN_HINTS = true;
   public boolean XRAY_SHOW_IMPLICIT_HINTS = true;
   public boolean XRAY_FOR_ALL_PARAMETERS = false;

--- a/scala/scala-impl/src/org/jetbrains/plugins/scala/settings/sections/XRayModeSettingsSectionPanel.form
+++ b/scala/scala-impl/src/org/jetbrains/plugins/scala/settings/sections/XRayModeSettingsSectionPanel.form
@@ -90,7 +90,7 @@
           <text resource-bundle="messages/ScalaBundle" key="scala.project.settings.form.xray.widget"/>
         </properties>
       </component>
-      <grid id="e4db3" layout-manager="GridLayoutManager" row-count="16" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+      <grid id="e4db3" layout-manager="GridLayoutManager" row-count="17" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
           <grid row="4" column="0" row-span="14" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="2" indent="0" use-parent-layout="false"/>
@@ -108,7 +108,7 @@
           </component>
           <component id="c2735" class="javax.swing.JCheckBox" binding="myShowMethodChainHintsCheckbox">
             <constraints>
-              <grid row="12" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="1" use-parent-layout="false"/>
+              <grid row="13" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="1" use-parent-layout="false"/>
             </constraints>
             <properties>
               <text resource-bundle="messages/ScalaBundle" key="scala.project.settings.form.xray.method.chain.hints"/>
@@ -116,7 +116,7 @@
           </component>
           <component id="11b9" class="javax.swing.JCheckBox" binding="myShowIndentGuidesCheckbox">
             <constraints>
-              <grid row="14" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="1" use-parent-layout="false"/>
+              <grid row="15" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="1" use-parent-layout="false"/>
             </constraints>
             <properties>
               <text resource-bundle="messages/ScalaBundle" key="scala.project.settings.form.xray.indent.guides"/>
@@ -124,7 +124,7 @@
           </component>
           <component id="2e3dd" class="javax.swing.JCheckBox" binding="myShowMethodSeparatorsCheckbox">
             <constraints>
-              <grid row="15" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="1" use-parent-layout="false"/>
+              <grid row="16" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="1" use-parent-layout="false"/>
             </constraints>
             <properties>
               <text resource-bundle="messages/ScalaBundle" key="scala.project.settings.form.xray.method.separators"/>
@@ -132,7 +132,7 @@
           </component>
           <component id="cb34d" class="javax.swing.JCheckBox" binding="myShowImplicitHintsCheckbox">
             <constraints>
-              <grid row="13" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="1" use-parent-layout="false"/>
+              <grid row="14" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="1" use-parent-layout="false"/>
             </constraints>
             <properties>
               <text resource-bundle="messages/ScalaBundle" key="scala.project.settings.form.xray.implicit.hints"/>
@@ -225,6 +225,14 @@
             </constraints>
             <properties>
               <text resource-bundle="messages/ScalaBundle" key="scala.project.settings.form.xray.apply.method.hints"/>
+            </properties>
+          </component>
+          <component id="3a00f" class="javax.swing.JCheckBox" binding="myShowTypeParametersCheckbox">
+            <constraints>
+              <grid row="12" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="2" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text resource-bundle="messages/ScalaBundle" key="scala.project.settings.form.xray.type.parameter.hints"/>
             </properties>
           </component>
         </children>

--- a/scala/scala-impl/src/org/jetbrains/plugins/scala/settings/sections/XRayModeSettingsSectionPanel.java
+++ b/scala/scala-impl/src/org/jetbrains/plugins/scala/settings/sections/XRayModeSettingsSectionPanel.java
@@ -36,6 +36,7 @@ public class XRayModeSettingsSectionPanel extends SettingsSectionPanel {
     private JCheckBox myForAllParametersCheckbox;
     private JCheckBox myDoublePressAndHoldCheckbox;
     private JCheckBox myPressAndHoldCheckbox;
+    private JCheckBox myShowTypeParametersCheckbox;
     private JComboBox<XRayWidgetMode> myWidgetModeCombobox;
     private JPanel rootPanel;
 
@@ -81,6 +82,7 @@ public class XRayModeSettingsSectionPanel extends SettingsSectionPanel {
                 scalaApplicationSettings.XRAY_SHOW_LAMBDA_PARAMETER_HINTS != myShowLambdaParametersCheckbox.isSelected() ||
                 scalaApplicationSettings.XRAY_SHOW_LAMBDA_PLACEHOLDER_HINTS != myShowLambdaPlaceholdersCheckbox.isSelected() ||
                 scalaApplicationSettings.XRAY_SHOW_VARIABLE_PATTERN_HINTS != myShowVariablePatternsCheckbox.isSelected() ||
+                scalaApplicationSettings.XRAY_SHOW_TYPE_PARAMETERS_HINTS != myShowTypeParametersCheckbox.isSelected() ||
                 scalaApplicationSettings.XRAY_SHOW_METHOD_CHAIN_HINTS != myShowMethodChainHintsCheckbox.isSelected() ||
                 scalaApplicationSettings.XRAY_SHOW_IMPLICIT_HINTS != myShowImplicitHintsCheckbox.isSelected() ||
                 scalaApplicationSettings.XRAY_FOR_ALL_PARAMETERS != myForAllParametersCheckbox.isSelected() ||
@@ -105,6 +107,7 @@ public class XRayModeSettingsSectionPanel extends SettingsSectionPanel {
         scalaApplicationSettings.XRAY_SHOW_LAMBDA_PARAMETER_HINTS = myShowLambdaParametersCheckbox.isSelected();
         scalaApplicationSettings.XRAY_SHOW_LAMBDA_PLACEHOLDER_HINTS = myShowLambdaPlaceholdersCheckbox.isSelected();
         scalaApplicationSettings.XRAY_SHOW_VARIABLE_PATTERN_HINTS = myShowVariablePatternsCheckbox.isSelected();
+        scalaApplicationSettings.XRAY_SHOW_TYPE_PARAMETERS_HINTS = myShowTypeParametersCheckbox.isSelected();
         scalaApplicationSettings.XRAY_SHOW_METHOD_CHAIN_HINTS = myShowMethodChainHintsCheckbox.isSelected();
         scalaApplicationSettings.XRAY_SHOW_IMPLICIT_HINTS = myShowImplicitHintsCheckbox.isSelected();
         scalaApplicationSettings.XRAY_FOR_ALL_PARAMETERS = myForAllParametersCheckbox.isSelected();
@@ -128,6 +131,7 @@ public class XRayModeSettingsSectionPanel extends SettingsSectionPanel {
         myShowLambdaParametersCheckbox.setSelected(scalaApplicationSettings.XRAY_SHOW_LAMBDA_PARAMETER_HINTS);
         myShowLambdaPlaceholdersCheckbox.setSelected(scalaApplicationSettings.XRAY_SHOW_LAMBDA_PLACEHOLDER_HINTS);
         myShowVariablePatternsCheckbox.setSelected(scalaApplicationSettings.XRAY_SHOW_VARIABLE_PATTERN_HINTS);
+        myShowTypeParametersCheckbox.setSelected(scalaApplicationSettings.XRAY_SHOW_TYPE_PARAMETERS_HINTS);
         myShowMethodChainHintsCheckbox.setSelected(scalaApplicationSettings.XRAY_SHOW_METHOD_CHAIN_HINTS);
         myShowImplicitHintsCheckbox.setSelected(scalaApplicationSettings.XRAY_SHOW_IMPLICIT_HINTS);
         myForAllParametersCheckbox.setSelected(scalaApplicationSettings.XRAY_FOR_ALL_PARAMETERS);
@@ -200,23 +204,23 @@ public class XRayModeSettingsSectionPanel extends SettingsSectionPanel {
         this.$$$loadLabelText$$$(label5, this.$$$getMessageFromBundle$$$("messages/ScalaBundle", "scala.project.settings.form.xray.widget"));
         rootPanel.add(label5, new GridConstraints(19, 0, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_FIXED, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
         final JPanel panel2 = new JPanel();
-        panel2.setLayout(new GridLayoutManager(16, 1, new Insets(0, 0, 0, 0), -1, -1));
+        panel2.setLayout(new GridLayoutManager(17, 1, new Insets(0, 0, 0, 0), -1, -1));
         rootPanel.add(panel2, new GridConstraints(4, 0, 14, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_VERTICAL, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, null, null, null, 0, false));
         final JLabel label6 = new JLabel();
         this.$$$loadLabelText$$$(label6, this.$$$getMessageFromBundle$$$("messages/ScalaBundle", "scala.project.settings.form.xray.show"));
         panel2.add(label6, new GridConstraints(0, 0, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_FIXED, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
         myShowMethodChainHintsCheckbox = new JCheckBox();
         this.$$$loadButtonText$$$(myShowMethodChainHintsCheckbox, this.$$$getMessageFromBundle$$$("messages/ScalaBundle", "scala.project.settings.form.xray.method.chain.hints"));
-        panel2.add(myShowMethodChainHintsCheckbox, new GridConstraints(12, 0, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 1, false));
+        panel2.add(myShowMethodChainHintsCheckbox, new GridConstraints(13, 0, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 1, false));
         myShowIndentGuidesCheckbox = new JCheckBox();
         this.$$$loadButtonText$$$(myShowIndentGuidesCheckbox, this.$$$getMessageFromBundle$$$("messages/ScalaBundle", "scala.project.settings.form.xray.indent.guides"));
-        panel2.add(myShowIndentGuidesCheckbox, new GridConstraints(14, 0, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 1, false));
+        panel2.add(myShowIndentGuidesCheckbox, new GridConstraints(15, 0, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 1, false));
         myShowMethodSeparatorsCheckbox = new JCheckBox();
         this.$$$loadButtonText$$$(myShowMethodSeparatorsCheckbox, this.$$$getMessageFromBundle$$$("messages/ScalaBundle", "scala.project.settings.form.xray.method.separators"));
-        panel2.add(myShowMethodSeparatorsCheckbox, new GridConstraints(15, 0, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 1, false));
+        panel2.add(myShowMethodSeparatorsCheckbox, new GridConstraints(16, 0, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 1, false));
         myShowImplicitHintsCheckbox = new JCheckBox();
         this.$$$loadButtonText$$$(myShowImplicitHintsCheckbox, this.$$$getMessageFromBundle$$$("messages/ScalaBundle", "scala.project.settings.form.xray.implicit.hints"));
-        panel2.add(myShowImplicitHintsCheckbox, new GridConstraints(13, 0, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 1, false));
+        panel2.add(myShowImplicitHintsCheckbox, new GridConstraints(14, 0, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 1, false));
         myShowTypeHintsCheckbox = new JCheckBox();
         this.$$$loadButtonText$$$(myShowTypeHintsCheckbox, this.$$$getMessageFromBundle$$$("messages/ScalaBundle", "scala.project.settings.form.xray.type.hints"));
         panel2.add(myShowTypeHintsCheckbox, new GridConstraints(5, 0, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 1, false));
@@ -251,6 +255,9 @@ public class XRayModeSettingsSectionPanel extends SettingsSectionPanel {
         myShowApplyMethodHintsCheckbox = new JCheckBox();
         this.$$$loadButtonText$$$(myShowApplyMethodHintsCheckbox, this.$$$getMessageFromBundle$$$("messages/ScalaBundle", "scala.project.settings.form.xray.apply.method.hints"));
         panel2.add(myShowApplyMethodHintsCheckbox, new GridConstraints(4, 0, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 1, false));
+        myShowTypeParametersCheckbox = new JCheckBox();
+        this.$$$loadButtonText$$$(myShowTypeParametersCheckbox, this.$$$getMessageFromBundle$$$("messages/ScalaBundle", "scala.project.settings.form.xray.type.parameter.hints"));
+        panel2.add(myShowTypeParametersCheckbox, new GridConstraints(12, 0, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 2, false));
         label4.setLabelFor(myWidgetModeCombobox);
     }
 


### PR DESCRIPTION
There are some cases when the type parameter is not inferred, and hint simply displays a type variable, for example `A_`. I'll try to figure out these cases, but what to do if the type variable is not inferred: show as is or don't display the hint at all?