### PR TITLE
SCL-24180 Allow 'final' modifier for top-level package declarations

### DIFF
--- a/scala/scala-impl/src/org/jetbrains/plugins/scala/annotator/modifiers/ModifierChecker.scala
+++ b/scala/scala-impl/src/org/jetbrains/plugins/scala/annotator/modifiers/ModifierChecker.scala
@@ -138,7 +138,7 @@ private[annotator] object ModifierChecker {
                     } else {
                       checkIllegalCombinations(modifierPsi, Final)
                     }
-                  case e: ScMember if e.getParent.is[ScalaFile] =>
+                  case e: ScMember if e.isTopLevel =>
                     checkIllegalCombinations(modifierPsi, Final)
                   case e: ScClassParameter =>
                     if (PsiTreeUtil.getParentOfType(e, classOf[ScTypeDefinition]).hasFinalModifier) {

--- a/scala/scala-impl/test/org/jetbrains/plugins/scala/annotator/modifiers/ModifierCheckerTest.scala
+++ b/scala/scala-impl/test/org/jetbrains/plugins/scala/annotator/modifiers/ModifierCheckerTest.scala
@@ -264,6 +264,17 @@ class ModifierCheckerTest_Scala_3 extends ModifierCheckerTest_Scala_2 {
         |""".stripMargin))
   }
 
+  def testFinalInTopLevelPackageDefinitionsWithAssignment(): Unit = {
+    assertNothing(messages(
+      """package outer {
+        |  final val outerValue = ???
+        |  package inner {
+        |    final val innerValue = ???
+        |  }
+        |}
+        |""".stripMargin))
+  }
+
   protected val RedundantOpen = "'open' modifier is redundant for this definition"
   protected val OnlyClassesCanBeOpen = "Only classes can be open"
   protected val IllegalOpaqueModifier = "'opaque' modifier allowed only for type aliases"


### PR DESCRIPTION
Closes SCL-24180

See task for details.

TLDR: `final` modifier is currently prohibited in top-level package declarations, like
```scala
package foo
final val x = ???
```
This PR tries to fix this