### PR TITLE
SCL-24291 Implement `BuildToolModuleHandler` for Bazel Projects

### DIFF
--- a/scala/integration/intellij-bazel/resources/scalaCommunity.intellij-bazel.xml
+++ b/scala/integration/intellij-bazel/resources/scalaCommunity.intellij-bazel.xml
@@ -8,6 +8,9 @@
         <projectPostSyncHook implementation="org.jetbrains.plugins.scala.bazel.ScalaProjectSettingsConfigurePostSyncHook"/>
         <projectPostSyncHook implementation="org.jetbrains.plugins.scala.bazel.BazelScalaModuleConfiguratorPostSyncHook"/>
     </extensions>
+    <extensions defaultExtensionNs="org.jetbrains.sbt">
+        <buildToolModuleHandler implementation="org.jetbrains.plugins.scala.bazel.BazelModuleHandler"/>
+    </extensions>
     <extensions defaultExtensionNs="org.intellij.scala">
         <newScalaFileActionExtension implementation="org.jetbrains.plugins.scala.bazel.BazelNewScalaFileActionExtension"/>
     </extensions>

--- a/scala/integration/intellij-bazel/src/org/jetbrains/plugins/scala/bazel/BazelModuleHandler.scala
+++ b/scala/integration/intellij-bazel/src/org/jetbrains/plugins/scala/bazel/BazelModuleHandler.scala
@@ -1,0 +1,11 @@
+package org.jetbrains.plugins.scala.bazel
+
+import com.intellij.openapi.module.Module
+import org.jetbrains.bazel.config.BazelProjectPropertiesKt
+import org.jetbrains.sbt.project.BuildToolModuleHandler
+
+//noinspection ApiStatus
+private final class BazelModuleHandler extends BuildToolModuleHandler {
+  override def handles(module: Module): Boolean =
+    BazelProjectPropertiesKt.isBazelProject(module.getProject)
+}


### PR DESCRIPTION
This PR is a direct port of https://github.com/bazelbuild/intellij/pull/7704, which registers Bazel projects using `BuildToolModuleHandler` to enable code insight for mixed sbt Bazel projects.

Tested locally that code insight is disabled without the fix and enabled with the fix.

Before:

<img width="1379" height="746" alt="Screenshot 2025-09-01 at 6 48 07 PM" src="https://github.com/user-attachments/assets/eaf7ede2-ab58-48be-ad3d-f49ecb49e8aa" />

After:

<img width="2806" height="962" alt="image" src="https://github.com/user-attachments/assets/069e4eb0-c0ba-454d-b256-3364984f6a06" />
