### PR TITLE
Fix false "Unnecessary parentheses" for function types in type patterns #SCL-21577

### DIFF
--- a/scala/scala-impl/src/org/jetbrains/plugins/scala/extensions/ParenthesizedElement.scala
+++ b/scala/scala-impl/src/org/jetbrains/plugins/scala/extensions/ParenthesizedElement.scala
@@ -199,10 +199,13 @@ object ParenthesizedElement {
     /*
      * Parenthesis here are not redundant
      * test { blub: (Int => Int) => ??? }
+     * case _: (String => String) =>  // SCL-21577
      */
     def unapply(p: ScParenthesisedTypeElement): Boolean =
-      p.innerElement.exists(_.is[ScFunctionalTypeElement]) &&
-        p.getParent.is[ScParameterType] &&
-        p.nextVisibleLeaf.exists(_.elementType == ScalaTokenTypes.tFUNTYPE)
+      p.innerElement.exists(_.is[ScFunctionalTypeElement]) && (
+        (p.getParent.is[ScParameterType] &&
+         p.nextVisibleLeaf.exists(_.elementType == ScalaTokenTypes.tFUNTYPE)) ||
+        p.getParent.is[ScTypePattern]
+      )
   }
 }

--- a/scala/scala-impl/test/org/jetbrains/plugins/scala/codeInspection/parentheses/ScalaUnnecessaryParenthesesInspectionTest.scala
+++ b/scala/scala-impl/test/org/jetbrains/plugins/scala/codeInspection/parentheses/ScalaUnnecessaryParenthesesInspectionTest.scala
@@ -680,4 +680,15 @@ class ScalaUnnecessaryParenthesesInspectionTest_Scala3 extends ScalaUnnecessaryP
     checkTextHasErrors(s"val $START((x = _, y = _))$END = ???")
     checkTextHasErrors(s"val (x = _, y = $START(_)$END) = ???")
   }
+
+  def testSCL21577_FunctionTypeInPattern(): Unit = {
+    checkTextHasNoErrors(
+      """
+        |null match {
+        |  case _: (String => String) =>
+        |  case _ =>
+        |}
+      """.stripMargin
+    )
+  }
 }


### PR DESCRIPTION

## What
Fixes [SCL-21577](https://youtrack.jetbrains.com/issue/SCL-21577): Wrong "Unnecessary parentheses" warning shown in type pattern with function literal

## Problem
IntelliJ was incorrectly flagging parentheses around function types in type patterns as unnecessary:

```scala
null match {
  case _: (String => String) =>  // Parentheses ARE needed but were flagged as unnecessary
  case _ =>
}
```

Without the parentheses, the code would be parsed differently and wouldn't compile.

## Solution
Extended the `NeededParenthesisAroundFunctionalType` check in `ParenthesizedElement.scala` to recognize that parentheses are necessary when:
- The parent is `ScParameterType` (already handled)
- **OR** the parent is `ScTypePattern` (newly added)

## Testing
- Added test case `testSCL21577_FunctionTypeInPattern` in `ScalaUnnecessaryParenthesesInspectionTest_Scala3`
- Test verifies that parentheses around function types in type patterns are NOT flagged as unnecessary
- Test fails before the fix, passes after

## Files Changed
- `scala/scala-impl/src/org/jetbrains/plugins/scala/extensions/ParenthesizedElement.scala`
- `scala/scala-impl/test/org/jetbrains/plugins/scala/codeInspection/parentheses/ScalaUnnecessaryParenthesesInspectionTest.scala`