### PR TITLE
SCL-22406 Single character variable name expanded with "{}" in interpolated string

### DIFF
--- a/scala/scala-impl/src/org/jetbrains/plugins/scala/lang/completion/handlers/ScalaInsertHandler.scala
+++ b/scala/scala-impl/src/org/jetbrains/plugins/scala/lang/completion/handlers/ScalaInsertHandler.scala
@@ -90,6 +90,7 @@ object ScalaInsertHandler {
         .getStartOffset
 
       document.insertString(tailOffset, "}")
+      // This looks like a bug, when insertString(offset) param is equal to context.currentOffset it does not increment
       document.insertString(startOffset, "{")
       document.insertString(literalOffset, "s")
       context.commitDocument()
@@ -103,7 +104,7 @@ object ScalaInsertHandler {
 
       val element = context
         .getFile
-        .findElementAt(context.getStartOffset + 2)
+        .findElementAt(context.getStartOffset + 1) // There is a bug in Platform SDK in which context offset is not updated when the insertOffset is the same as current offset.
 
       val maybeBlock = element.getNode.getElementType match {
         case `tIDENTIFIER` =>

--- a/scala/scala-impl/test/org/jetbrains/plugins/scala/lang/completion3/ScalaStringInterpolatorCompletionTest.scala
+++ b/scala/scala-impl/test/org/jetbrains/plugins/scala/lang/completion3/ScalaStringInterpolatorCompletionTest.scala
@@ -1,0 +1,96 @@
+package org.jetbrains.plugins.scala.lang.completion3
+
+import org.jetbrains.plugins.scala.lang.completion3.base.ScalaCompletionTestBase
+
+class ScalaStringInterpolatorCompletionTest extends ScalaCompletionTestBase {
+
+  def testBracesBasic(): Unit = doCompletionTest(
+    fileText =
+      s"""
+         |object A {
+         |  val zzz = ""
+         |  val y = "$$z$CARET"
+         |}
+      """.stripMargin,
+    resultText =
+      s"""
+         |object A {
+         |  val zzz = ""
+         |  val y = s"$$zzz$CARET"
+         |}
+      """.stripMargin,
+    item = "zzz",
+  )
+
+  def testBracesBasicEmpty(): Unit = doCompletionTest(
+    fileText =
+      s"""
+         |object A {
+         |  val zzz = ""
+         |  val y = "$$$CARET"
+         |}
+      """.stripMargin,
+    resultText =
+      s"""
+         |object A {
+         |  val zzz = ""
+         |  val y = s"$$zzz$CARET"
+         |}
+      """.stripMargin,
+    item = "zzz",
+  )
+
+  def testBracesSingleLetter(): Unit = doCompletionTest(
+    fileText =
+      s"""
+         |object A {
+         |  val z = ""
+         |  val y = "$$z$CARET"
+         |}
+      """.stripMargin,
+    resultText =
+      s"""
+         |object A {
+         |  val z = ""
+         |  val y = s"$$z$CARET"
+         |}
+      """.stripMargin,
+    item = "z",
+  )
+
+  def testBracesSingleLetterEmpty(): Unit = doCompletionTest(
+    fileText =
+      s"""
+         |object A {
+         |  val z = ""
+         |  val y = "$$$CARET"
+         |}
+      """.stripMargin,
+    resultText =
+      s"""
+         |object A {
+         |  val z = ""
+         |  val y = s"$$z$CARET"
+         |}
+      """.stripMargin,
+    item = "z",
+  )
+
+  def testAddBracesWhenRequiredForMethods(): Unit = doCompletionTest(
+    fileText =
+      s"""
+         |object A {
+         |  def zzz(a: String): String = ""
+         |  val y = "$$$CARET"
+         |}
+      """.stripMargin,
+    resultText =
+      s"""
+         |object A {
+         |  def zzz(a: String): String = ""
+         |  val y = s"$${zzz($CARET)}"
+         |}
+      """.stripMargin,
+    item = "zzz",
+  )
+}


### PR DESCRIPTION
I believe this was caused by a bug in platform which does not increment current start offset if the document.insert().offset is the same as the current start offset.