### PR TITLE
SCL-21400 Highlight missing enum constructor arguments without "extends"

### DIFF
--- a/scala/scala-impl/resources/messages/ScalaBundle.properties
+++ b/scala/scala-impl/resources/messages/ScalaBundle.properties
@@ -233,6 +233,7 @@ annotator.error.cannot.apply.constructor=Cannot apply constructor {0}
 annotator.error.enum.nonvariant.type.param,in.enum=Cannot determine type argument for enum class parent {0}, type parameter {1} is invariant
 annotator.error.enum.case.must.extend.parent=Enum case must extend its enum class {0}
 annotator.error.enum.two.type.parameter.clauses=Explicit extends clause required because both enum case and enum class have type parameters
+annotator.error.enum.parent.has.required.parameters=Explicit extends clause required because its enum class {0} has required parameters
 
 ### org/jetbrains/plugins/scala/annotator/element/ScEnumeratorsAnnotator.scala
 semicolon.not.allowed.here=Semicolon not allowed here

--- a/scala/scala-impl/src/org/jetbrains/plugins/scala/annotator/element/ScEnumCaseAnnotator.scala
+++ b/scala/scala-impl/src/org/jetbrains/plugins/scala/annotator/element/ScEnumCaseAnnotator.scala
@@ -63,5 +63,12 @@ object ScEnumCaseAnnotator extends ElementAnnotator[ScEnumCase] {
         ScalaBundle.message("annotator.error.enum.two.type.parameter.clauses")
       )
     }
+
+    if (enumDef.parameters.exists(!_.isDefaultParam) && parents.isEmpty) {
+      holder.createErrorAnnotation(
+        cse.nameId,
+        ScalaBundle.message("annotator.error.enum.parent.has.required.parameters", enumDef.name)
+      )
+    }
   }
 }

--- a/scala/scala-impl/test/org/jetbrains/plugins/scala/annotator/ScEnumCaseAnnotatorTest.scala
+++ b/scala/scala-impl/test/org/jetbrains/plugins/scala/annotator/ScEnumCaseAnnotatorTest.scala
@@ -216,4 +216,22 @@ class ScEnumCaseAnnotatorTest extends ScalaHighlightingTestBase {
       |}
       |""".stripMargin
   )()
+
+  def testParentHasRequiredParameter(): Unit =
+    doTest(
+      """
+        |enum Color(y: Int) {
+        |  case Green
+        |}
+        |""".stripMargin
+    )(Error("Green", "Explicit extends clause required because its enum class Color has required parameters"))
+
+  def testParentHasParameterWithDefault(): Unit =
+    doTest(
+      """
+        |enum Color(y: Int = 1) {
+        |  case Green
+        |}
+        |""".stripMargin
+    )()
 }


### PR DESCRIPTION
Fixes [SCL-21400](https://youtrack.jetbrains.com/issue/SCL-21400/Highlight-missing-enum-constructor-arguments-without-extends)