### PR TITLE
An action to add a parameter to a method #SCL-24374

### DIFF
--- a/scala/codeInsight/resources/META-INF/codeInsight.xml
+++ b/scala/codeInsight/resources/META-INF/codeInsight.xml
@@ -106,6 +106,13 @@
             <language>Scala</language>
             <categoryKey>intention.category.scala.argument.conversion</categoryKey>
             <bundleName>messages.ScalaCodeInsightBundle</bundleName>
+            <className>org.jetbrains.plugins.scala.codeInsight.intention.argument.AddParametersIntention</className>
+        </intentionAction>
+
+        <intentionAction>
+            <language>Scala</language>
+            <categoryKey>intention.category.scala.argument.conversion</categoryKey>
+            <bundleName>messages.ScalaCodeInsightBundle</bundleName>
             <className>org.jetbrains.plugins.scala.codeInsight.intention.argument.ArgumentToBlockExpressionIntention</className>
         </intentionAction>
 

--- a/scala/codeInsight/resources/intentionDescriptions/AddParametersIntention/after.scala.template
+++ b/scala/codeInsight/resources/intentionDescriptions/AddParametersIntention/after.scala.template
@@ -1,0 +1,3 @@
+def method(a: Int, arg1: String)
+
+method(0, "foo")

--- a/scala/codeInsight/resources/intentionDescriptions/AddParametersIntention/before.scala.template
+++ b/scala/codeInsight/resources/intentionDescriptions/AddParametersIntention/before.scala.template
@@ -1,0 +1,3 @@
+def method(a: Int)
+
+method(0, <spot>"foo"</spot>)

--- a/scala/codeInsight/resources/intentionDescriptions/AddParametersIntention/description.html
+++ b/scala/codeInsight/resources/intentionDescriptions/AddParametersIntention/description.html
@@ -1,0 +1,2 @@
+<html><body>
+<p>Adds a new parameter to the method's declaration.</p></body></html>

--- a/scala/codeInsight/resources/messages/ScalaCodeInsightBundle.properties
+++ b/scala/codeInsight/resources/messages/ScalaCodeInsightBundle.properties
@@ -158,6 +158,10 @@ remove.explicit.arguments.action.description=Remove explicit arguments
 family.name.use.named.arguments=Use named arguments
 use.named.arguments.for.current.and.subsequent.arguments=Use named arguments for current and subsequent arguments
 
+### org/jetbrains/plugins/scala/codeInsight/intention/argument/AddParametersIntention.scala
+family.name.add.parameter=Add parameter(s) to a method
+add.parameter.to.a.method=Add parameter(s) to a method
+
 ### org/jetbrains/plugins/scala/codeInsight/intention/argument/ArgumentToBlockExpressionIntention.scala
 family.name.convert.to.block.expression=Convert to block expression
 

--- a/scala/codeInsight/src/org/jetbrains/plugins/scala/codeInsight/intention/argument/AddParametersIntention.scala
+++ b/scala/codeInsight/src/org/jetbrains/plugins/scala/codeInsight/intention/argument/AddParametersIntention.scala
@@ -1,0 +1,118 @@
+package org.jetbrains.plugins.scala.codeInsight.intention.argument
+
+import com.intellij.codeInsight.CodeInsightUtilCore
+import com.intellij.codeInsight.intention.PsiElementBaseIntentionAction
+import com.intellij.codeInsight.intention.preview.IntentionPreviewUtils
+import com.intellij.codeInsight.template.TemplateBuilderImpl
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import com.intellij.psi.util.PsiTreeUtil
+import org.jetbrains.plugins.scala.annotator.TemplateUtils
+import org.jetbrains.plugins.scala.annotator.createFromUsage.CreateFromUsageUtil.addParametersToTemplate
+import org.jetbrains.plugins.scala.codeInsight.ScalaCodeInsightBundle
+import org.jetbrains.plugins.scala.lang.psi.api.base.literals.{ScBooleanLiteral, ScDoubleLiteral, ScFloatLiteral, ScIntegerLiteral, ScStringLiteral}
+import org.jetbrains.plugins.scala.lang.psi.api.expr.{ScArgumentExprList, ScExpression, ScMethodCall}
+import org.jetbrains.plugins.scala.lang.psi.api.statements.ScFunctionDefinition
+import org.jetbrains.plugins.scala.lang.psi.api.statements.params.ScParameter
+import org.jetbrains.plugins.scala.lang.psi.impl.ScalaPsiElementFactory.createClauseFromText
+
+import scala.collection.mutable.ArrayBuffer
+
+final class AddParametersIntention extends PsiElementBaseIntentionAction {
+
+  override def invoke(project: Project, editor: Editor, element: PsiElement): Unit =
+    if (element.isValid) addParameterFix(element, editor).foreach(_.apply())
+
+  override def isAvailable(project: Project, editor: Editor, element: PsiElement): Boolean =
+    addParameterFix(element, editor).isDefined
+
+  override def getFamilyName: String = ScalaCodeInsightBundle.message("family.name.add.parameter")
+
+  override def getText: String = ScalaCodeInsightBundle.message("add.parameter.to.a.method")
+
+  private def addParameterFix(element: PsiElement, editor: Editor): Option[() => Unit] = {
+    val argList: ScArgumentExprList = PsiTreeUtil.getParentOfType(element, classOf[ScArgumentExprList])
+    if (argList == null || argList.isBlockArgs) return None
+
+    val methodCall = PsiTreeUtil.getParentOfType(element, classOf[ScMethodCall])
+    val arguments = methodCall.args.exprs
+    val funDefOpt = methodCall.target.map(result => result.element)
+    if (funDefOpt.isEmpty) return None
+
+    val funDef = funDefOpt.get.asInstanceOf[ScFunctionDefinition]
+    val parameters = funDef.parameters
+    if (parameters.size >= arguments.size) return None
+
+    val clause = funDef.paramClauses.clauses.head
+    if (!clause.isValid || !clause.isPhysical) return None
+
+    Some(() => IntentionPreviewUtils.write { () =>
+      if (!IntentionPreviewUtils.isIntentionPreviewActive) {
+        val indices       = findNewParameterIndices(parameters, arguments)
+        val newParamTexts = generateNewParameterTexts(arguments, indices, parameters.map(_.name))
+        val newClauseText = createNewClauseText(clause.getText, newParamTexts)
+        val newClause     = clause.replace(createClauseFromText(newClauseText, clause.getParent)(element.getManager))
+
+        val builder = new TemplateBuilderImpl(newClause)
+        addParametersToTemplate(newClause, builder)
+        CodeInsightUtilCore.forcePsiPostprocessAndRestoreElement(newClause)
+        TemplateUtils.positionCursorAndStartTemplate(newClause, builder.buildTemplate(), editor)
+      }
+    })
+  }
+
+  private def createNewClauseText(oldClauseText: String, newParamTexts: Seq[(Int, String)]): String = {
+    val paramTexts = oldClauseText
+      .substring(1, oldClauseText.length - 1)
+      .split(',')
+      .map(_.trim)
+      .filter(_.nonEmpty)
+      .toList
+
+    val newTxtList = newParamTexts.foldLeft(paramTexts) { case (pts, (i, newParamText)) =>
+      val (prev, next) = pts.splitAt(i)
+      prev ::: newParamText :: next
+    }
+    "(" + newTxtList.mkString(", ") + ")"
+  }
+
+  private def findNewParameterIndices(parameters: Seq[ScParameter], arguments: Seq[ScExpression]): Seq[Int] = {
+    val buf = ArrayBuffer.empty[Int]
+    var ai = 0
+    var pi = 0
+    while (ai < arguments.size) {
+      if (pi == parameters.size) buf.addOne(ai)
+      else {
+        val ptr = parameters(pi).`type`().getOrNothing.toString
+        val atr = argumentTypeText(arguments(ai))
+        if (ptr != atr) buf.addOne(ai) else pi += 1
+      }
+      ai += 1
+    }
+    buf.toSeq
+  }
+
+  private def argumentTypeText(expr: ScExpression): String = expr match {
+    case _: ScIntegerLiteral => "Int"
+    case _: ScDoubleLiteral  => "Double"
+    case _: ScFloatLiteral   => "Float"
+    case _: ScBooleanLiteral => "Boolean"
+    case _: ScStringLiteral  => "String"
+    case _ => expr.getTypeAfterImplicitConversion().tr.getOrAny.toString
+  }
+
+  private def generateNewParameterTexts(arguments: Seq[ScExpression], indices: Seq[Int], paramNames: Seq[String]): Seq[(Int, String)] = {
+    var index = 0
+    indices.map { i =>
+      index += 1
+      var name = s"arg$index"
+      while (paramNames.contains(name)) {
+        index += 1
+        name = s"arg$index"
+      }
+      val typeText = argumentTypeText(arguments(i))
+      i -> s"$name: $typeText"
+    }
+  }
+}

--- a/scala/codeInsight/test/org/jetbrains/plugins/scala/codeInsight/intention/argument/AddParametersIntentionTest.scala
+++ b/scala/codeInsight/test/org/jetbrains/plugins/scala/codeInsight/intention/argument/AddParametersIntentionTest.scala
@@ -1,0 +1,169 @@
+package org.jetbrains.plugins.scala.codeInsight.intention.argument
+
+import org.jetbrains.plugins.scala.codeInsight.{ScalaCodeInsightBundle, intentions}
+
+class AddParametersIntentionTest extends intentions.ScalaIntentionTestBase {
+
+  override def familyName: String = ScalaCodeInsightBundle.message("family.name.add.parameter")
+
+  def test1(): Unit = {
+    val text =
+      s"""
+         |object Foo {
+         |  def doSomething(flag: Boolean) {}
+         |
+         |  doSomething(true, false${CARET})
+         |}
+      """.stripMargin
+    val resultText =
+      s"""
+         |object Foo {
+         |  def doSomething(flag: Boolean, arg1: Boolean)${CARET} {}
+         |
+         |  doSomething(true, false)
+         |}
+      """.stripMargin
+
+    doTest(text, resultText)
+  }
+
+  def test2(): Unit = {
+    val text =
+      s"""
+         |object Foo {
+         |  def doSomething(flag: Boolean) {}
+         |
+         |  doSomething(true, 2, false${CARET})
+         |}
+      """.stripMargin
+    val resultText =
+      s"""
+         |object Foo {
+         |  def doSomething(flag: Boolean, arg1: Int, arg2: Boolean)${CARET} {}
+         |
+         |  doSomething(true, 2, false)
+         |}
+      """.stripMargin
+
+    doTest(text, resultText)
+  }
+
+  def test3(): Unit = {
+    val text =
+      s"""
+         |object Foo {
+         |  def doSomething(flag: Boolean) {}
+         |
+         |  doSomething(1${CARET}, true)
+         |}
+      """.stripMargin
+    val resultText =
+      s"""
+         |object Foo {
+         |  def doSomething(arg1: Int, flag: Boolean)${CARET} {}
+         |
+         |  doSomething(1, true)
+         |}
+      """.stripMargin
+
+    doTest(text, resultText)
+  }
+
+  def test4(): Unit = {
+    val text =
+      s"""
+         |object Foo {
+         |  val list: List[String] = ???
+         |
+         |  def doSomething(flag: Boolean) {}
+         |
+         |  doSomething(true, list${CARET})
+         |}
+      """.stripMargin
+    val resultText =
+      s"""
+         |object Foo {
+         |  val list: List[String] = ???
+         |
+         |  def doSomething(flag: Boolean, arg1: List[String])${CARET} {}
+         |
+         |  doSomething(true, list)
+         |}
+      """.stripMargin
+
+    doTest(text, resultText)
+  }
+
+  def test5(): Unit = {
+    val text =
+      s"""
+         |case class Foo(n: Int)
+         |
+         |object Foo {
+         |  def doSomething(flag: Boolean) {}
+         |
+         |  doSomething(true, Foo(1)${CARET})
+         |}
+      """.stripMargin
+    val resultText =
+      s"""
+         |case class Foo(n: Int)
+         |
+         |object Foo {
+         |  def doSomething(flag: Boolean, arg1: Foo)${CARET} {}
+         |
+         |  doSomething(true, Foo(1))
+         |}
+      """.stripMargin
+
+    doTest(text, resultText)
+  }
+
+  def test6(): Unit = {
+    val text =
+      s"""
+         |object Foo {
+         |  def doSomething() {}
+         |
+         |  doSomething(true${CARET})
+         |}
+      """.stripMargin
+    val resultText =
+      s"""
+         |object Foo {
+         |  def doSomething(arg1: Boolean)${CARET} {}
+         |
+         |  doSomething(true)
+         |}
+      """.stripMargin
+
+    doTest(text, resultText)
+  }
+
+  def test7(): Unit = {
+    val text =
+      s"""
+         |case class Foo(n: Int)
+         |
+         |object Foo {
+         |  def doSomething(flag: Boolean, n: Int) {}
+         |
+         |  val r = (x: Int) => Foo(x)
+         |  doSomething(true, r, Foo(1)${CARET}, 1)
+         |}
+      """.stripMargin
+    val resultText =
+      s"""
+         |case class Foo(n: Int)
+         |
+         |object Foo {
+         |  def doSomething(flag: Boolean, arg1: Int => Foo, arg2: Foo, n: Int)${CARET} {}
+         |
+         |  val r = (x: Int) => Foo(x)
+         |  doSomething(true, r, Foo(1), 1)
+         |}
+      """.stripMargin
+
+    doTest(text, resultText)
+  }
+}


### PR DESCRIPTION
If the user adds an argument to the method call and opens the action menu when the new argument is highlighted, they should see now a new intention: "Add parameter(s) to a method". After choosing, a new parameter of the inferred type will be added the method's declaration, and the caret will be moved to the parameters clause, in the style of "Create Method".

Limitations:
1. The action works only for arguments added to the first parameters clause. If the method has more clauses, the intention does not appear in the popup.
2. The caret is moved to the first parameter in the clause even if new parameters start at subsequent places. 