### PR TITLE
make scalaCommunity.bsp and scalaCommunity.testing-support content modules public #SCL-24490

### DIFF
--- a/bsp-builtin/bsp/resources/scalaCommunity.bsp.xml
+++ b/bsp-builtin/bsp/resources/scalaCommunity.bsp.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="iso-8859-1"?>
-<idea-plugin>
+<idea-plugin visibility="public">
     <extensionPoints>
         <extensionPoint qualifiedName="com.intellij.bspEnvironmentRunnerExtension"
                         interface="org.jetbrains.bsp.project.test.environment.BspEnvironmentRunnerExtension"

--- a/pluginXml/resources/META-INF/plugin.xml
+++ b/pluginXml/resources/META-INF/plugin.xml
@@ -46,7 +46,7 @@
         <plugin id="org.intellij.intelliLang"/>
     </dependencies>
 
-    <content>
+    <content namespace="jetbrains">
         <module name="scalaCommunity.bsp" />
         <module name="scalaCommunity.bsp-junit" />
         <module name="scalaCommunity.bsp-terminal" />

--- a/scala/test-integration/testing-support/resources/scalaCommunity.testing-support.xml
+++ b/scala/test-integration/testing-support/resources/scalaCommunity.testing-support.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="iso-8859-1"?>
-<idea-plugin>
+<idea-plugin visibility="public">
     <dependencies>
         <plugin id="JUnit"/>
         <module name="scalaCommunity.bsp"/>


### PR DESCRIPTION
This is a quick fix for the main problem described in SCL-24490, it'll unblock enabling visibility checks in the platform.