### PR TITLE
Fix deadlock in Extract Method when multiple scopes exist

### DIFF
--- a/scala/scala-impl/src/org/jetbrains/plugins/scala/lang/refactoring/util/ScalaRefactoringUtil.scala
+++ b/scala/scala-impl/src/org/jetbrains/plugins/scala/lang/refactoring/util/ScalaRefactoringUtil.scala
@@ -2,7 +2,6 @@ package org.jetbrains.plugins.scala.lang.refactoring.util
 
 import com.intellij.codeInsight.PsiEquivalenceUtil
 import com.intellij.codeInsight.highlighting.HighlightManager
-import com.intellij.codeInsight.navigation.PsiTargetNavigator
 import com.intellij.codeInsight.unwrap.ScopeHighlighter
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.editor.colors.{EditorColors, EditorColorsScheme}
@@ -12,7 +11,6 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.popup.{JBPopup, JBPopupFactory, JBPopupListener, LightweightWindowEvent}
 import com.intellij.openapi.util.{Key, TextRange}
 import com.intellij.openapi.vfs.ReadonlyStatusHandler
-import com.intellij.platform.backend.presentation.TargetPresentation
 import com.intellij.psi._
 import com.intellij.psi.search.searches.ReferencesSearch
 import com.intellij.psi.search.{GlobalSearchScope, LocalSearchScope}
@@ -547,32 +545,10 @@ object ScalaRefactoringUtil {
                                       presentation: T => String,
                                       toHighlight: PsiElement => PsiElement = identity)
                                      (implicit project: Project, editor: Editor): Unit =
-    showChooserImpl(onChosen) { chooserModel =>
-      new PsiTargetNavigator(elements.asJava)
-        .presentationProvider((element: T) => TargetPresentation.builder(presentation(element)).presentation())
-        .builderConsumer { builder =>
-          builder
-            .setMovable(false)
-            .setResizable(false)
-            .setRequestFocus(true)
-            .addListener(chooserModel.highlighterPopupListener)
-            .setItemSelectedCallback { item =>
-              if (item != null) {
-                val element = item.dereference()
-                if (element != null) {
-                  val psiElement = toHighlight(element)
-                  if (psiElement != null) {
-                    chooserModel.highlightPsi.accept(psiElement)
-                  }
-                }
-              }
-            }
-        }
-        .createPopup(project, title, (element: T) => {
-          chooserModel.elementChosen.accept(element)
-          true
-        })
-    }
+    // Use JBPopupFactory instead of PsiTargetNavigator to avoid deadlock.
+    // PsiTargetNavigator.createPopup() calls computeItems() which uses runBlocking on the EDT,
+    // causing a deadlock when worker threads contend for the indexing lock. #SCL-25001
+    showChooserGeneric[T](elements, onChosen, title, presentation, toHighlight(_))
 
   /** See [[showChooserImpl]] */
   private final case class HighlightingChooserModel[T](


### PR DESCRIPTION
> **Note:** This PR was authored by Claude Code (Anthropic's CLI tool).

**YouTrack:** [SCL-25001](https://youtrack.jetbrains.com/issue/SCL-25001)

## Summary

- Replace `PsiTargetNavigator` with `JBPopupFactory` in `showPsiChooser` to fix a deadlock that can freeze IntelliJ when "Extract Method" is invoked on code with multiple extraction scopes while another operation holds the indexing lock

## Problem

`PsiTargetNavigator.createPopup()` internally calls `runBlocking` on the EDT via `computeItems()` → `Utils.computeWithProgressIcon()`. The dispatched coroutine workers then contend for the indexing lock (`ChangeTrackingValueContainer`), which can't be released because the EDT is blocked. This creates a permanent deadlock with 34 threads blocked.

**This is a race condition** — it requires both multiple extraction scopes (triggering `PsiTargetNavigator`) AND concurrent index lock contention (e.g., Find Occurrences running at the same time). It does not freeze every time, but `runBlocking` on the EDT is still architecturally wrong.

See [SCL-25001](https://youtrack.jetbrains.com/issue/SCL-25001) for full thread dump analysis.

## Fix

`showPsiChooser` now delegates to `showChooserGeneric`, which uses `JBPopupFactory` — a safe popup mechanism that doesn't use `runBlocking`. This method already exists in the same file and provides the same functionality (title, presentation, highlighting, selection callback).

The items passed to `showPsiChooser` are already fully computed `PsiElement`s with pre-computed presentation strings, so there is no need for the async computation that `PsiTargetNavigator` provides.

## Test plan

- [ ] Existing Extract Method tests pass (`ScalaExtractMethodTestBase`, `ScalaExtractMethodScopeTest`, etc.)
- [ ] Manual test: invoke Extract Method on Scala code with multiple valid extraction scopes while Find Occurrences or indexing is active — the scope chooser popup should appear without freezing