### PR TITLE
Fix language injection not matching methods with type arguments, #SCL-24947

### DIFF
--- a/scala/integration/intellilang/test/org/jetbrains/plugins/scala/intelliLang/injection/ScalaLanguageInjectorTest.scala
+++ b/scala/integration/intellilang/test/org/jetbrains/plugins/scala/intelliLang/injection/ScalaLanguageInjectorTest.scala
@@ -1,9 +1,11 @@
 package org.jetbrains.plugins.scala.intelliLang.injection
 
+import com.intellij.patterns.PsiJavaPatterns
 import com.intellij.patterns.compiler.PatternCompilerImpl.LazyPresentablePattern
 import org.intellij.plugins.intelliLang.inject.config.{BaseInjection, InjectionPlace}
 import org.jetbrains.plugins.scala.ScalaVersion
 import org.jetbrains.plugins.scala.intelliLang.injection.InjectionTestUtils.*
+import org.jetbrains.plugins.scala.patterns.ScalaPatterns
 import org.junit.Assert.*
 
 import scala.jdk.CollectionConverters.*
@@ -280,6 +282,66 @@ class ScalaLanguageInjectorTest_Scala3 extends ScalaLanguageInjectorTest_Scala2 
       ScalaLangId,
       s"""MyJavaClass("val x = 0")""",
       "val x = 0"
+    )
+  }
+}
+
+class ScalaLanguageInjectorTest_CallArgumentPattern extends InjectionInBodyTestBase {
+
+  override protected def supportedIn(version: ScalaVersion): Boolean =
+    version == ScalaVersion.Latest.Scala_2_13
+
+  private var testInjection: BaseInjection = scala.compiletime.uninitialized
+
+  override def setUp(): Unit = {
+    super.setUp()
+    val methodPattern = PsiJavaPatterns.psiMethod().withName("myMethod").definedInClass("A")
+    val place = new InjectionPlace(ScalaPatterns.scalaLiteral().callArgument(0, methodPattern), true)
+    testInjection = new BaseInjection("scala")
+    testInjection.setInjectedLanguageId(RegexpLangId)
+    testInjection.setInjectionPlaces(place)
+    scalaInjectionTestFixture.intelliLangConfig.replaceInjections(
+      List(testInjection).asJava,
+      List.empty[BaseInjection].asJava,
+      false
+    )
+  }
+
+  override def tearDown(): Unit = {
+    try {
+      if (testInjection != null)
+        scalaInjectionTestFixture.intelliLangConfig.replaceInjections(
+          List.empty[BaseInjection].asJava,
+          List(testInjection).asJava,
+          false
+        )
+    } finally {
+      super.tearDown()
+    }
+  }
+
+  def testPatternInjection_CallArgument_RegularMethodCall(): Unit = {
+    scalaInjectionTestFixture.doTest(
+      RegexpLangId,
+      s"""class A {
+         |  def myMethod(pattern: String): Unit = ???
+         |}
+         |new A().myMethod("[0-9]+")
+         |""".stripMargin,
+      "[0-9]+"
+    )
+  }
+
+  // SCL-24947: language injection should also work when the method is called with type arguments
+  def testPatternInjection_CallArgument_GenericMethodCall(): Unit = {
+    scalaInjectionTestFixture.doTest(
+      RegexpLangId,
+      s"""class A {
+         |  def myMethod[T](pattern: String): T = ???
+         |}
+         |new A().myMethod[String]("[0-9]+")
+         |""".stripMargin,
+      "[0-9]+"
     )
   }
 }

--- a/scala/scala-impl/src/org/jetbrains/plugins/scala/patterns/ScalaElementPatternImpl.scala
+++ b/scala/scala-impl/src/org/jetbrains/plugins/scala/patterns/ScalaElementPatternImpl.scala
@@ -5,7 +5,7 @@ import com.intellij.psi.{PsiElement, PsiMethod}
 import com.intellij.util.ProcessingContext
 import org.jetbrains.plugins.scala.lang.psi.api.ScalaPsiElement
 import org.jetbrains.plugins.scala.lang.psi.api.base.{ScConstructorInvocation, ScReference}
-import org.jetbrains.plugins.scala.lang.psi.api.expr.{ScArgumentExprList, ScMethodCall, ScPostfixExpr, ScReferenceExpression}
+import org.jetbrains.plugins.scala.lang.psi.api.expr.{ScArgumentExprList, ScGenericCall, ScMethodCall, ScPostfixExpr, ScReferenceExpression}
 
 private[scala]
 object ScalaElementPatternImpl {
@@ -35,6 +35,12 @@ object ScalaElementPatternImpl {
             call.getEffectiveInvokedExpr match {
               case ref: ScReference =>
                 return resolvesAndMatchesPattern(ref, methodPattern, context)
+              case generic: ScGenericCall =>
+                generic.referencedExpr match {
+                  case ref: ScReference =>
+                    return resolvesAndMatchesPattern(ref, methodPattern, context)
+                  case _ =>
+                }
               case _ =>
             }
           case _ =>


### PR DESCRIPTION
Fix for https://youtrack.jetbrains.com/projects/SCL/issues/SCL-24947/Method-call-with-type-arguments-is-not-recognised-by-a-callArgument-pattern