### PR TITLE
SCL-25169 Scala plugin creates incorrect run configuration for ScalaTest using Bazel

### DIFF
--- a/scala/integration/intellij-bazel/src/org/jetbrains/plugins/scala/bazel/BazelScalaTestRunLineMarkerLogic.scala
+++ b/scala/integration/intellij-bazel/src/org/jetbrains/plugins/scala/bazel/BazelScalaTestRunLineMarkerLogic.scala
@@ -52,9 +52,10 @@ private object BazelScalaTestRunLineMarkerLogic {
    */
   def getExtraProgramArguments(psiElement: PsiElement): Seq[String] = {
     val testElement = psiElement.getParent
-    val testName = getTestName(testElement)
-    // Use the test name as a single extra parameter
-    testName.toSeq
+    getTestName(testElement) match {
+      case Some(testName) => Seq(TestArg, testName)
+      case None => Seq.empty
+    }
   }
 
   private def getTestName(testElement: PsiElement): Option[String] = testElement match {
@@ -75,8 +76,7 @@ private object BazelScalaTestRunLineMarkerLogic {
 
   private def getTestNameImpl(psiElement: PsiElement): Option[String] = {
     val scalaTestName = getScalaTestTestName(psiElement)
-    val testName = scalaTestName.orElse(getZioTestTestName(psiElement))
-    testName.map(escape)
+    scalaTestName.orElse(getZioTestTestName(psiElement))
   }
 
   private def getScalaTestTestName(psiElement: PsiElement): Option[String] =
@@ -101,12 +101,4 @@ private object BazelScalaTestRunLineMarkerLogic {
         }
       case _ => None
     }
-
-  private def escape(testName: String): String =
-    testName.split("\n")
-      // Scalatest names can contain spaces, so the name needs to be quoted
-      // This means we need to escape " in the test name
-      .map(name => name.replace("\"", "\\\""))
-      .map(name => s"$TestArg \"$name\"")
-      .mkString(" ")
 }


### PR DESCRIPTION
**Before:** IntelliJ executes `bazel test //src/test/scala:tests --test_arg='-t "example"'`, which fails with `Argument unrecognized by ScalaTest's Runner` error.

![](https://github.com/user-attachments/assets/1261edbd-ec34-4309-b8d6-ccb3cde2ad7d)

**After:** IntelliJ executes `bazel test //src/test/scala:tests --test_arg='-t' --test_arg='example'`, which works.

![](https://github.com/user-attachments/assets/bb78fc99-b3d4-4d99-93c5-3552038a0d0c)

---

Nested test cases with spaces and special characters also work as expected:

![](https://github.com/user-attachments/assets/98420856-2979-46e8-85fe-bf520320f826)


