### PR TITLE
[testing-support][intellij-bazel] specs2 gutter triangles + Bazel --test_filter (#SCL-25391)

### DIFF
--- a/scala/integration/intellij-bazel/src/org/jetbrains/plugins/scala/bazel/BazelScalaTestRunLineMarkerLogic.scala
+++ b/scala/integration/intellij-bazel/src/org/jetbrains/plugins/scala/bazel/BazelScalaTestRunLineMarkerLogic.scala
@@ -11,6 +11,7 @@ import org.jetbrains.plugins.scala.lang.psi.api.expr.{ScInfixExpr, ScMethodCall,
 import org.jetbrains.plugins.scala.lang.psi.api.statements.ScFunctionDefinition
 import org.jetbrains.plugins.scala.lang.psi.api.toplevel.typedef.{ScClass, ScDerivesClauseOwner, ScObject, ScTypeDefinition}
 import org.jetbrains.plugins.scala.testingSupport.test.scalatest.ScalaTestConfigurationProducer
+import org.jetbrains.plugins.scala.testingSupport.test.specs2.{Specs2BazelTestFilter, Specs2TestFramework}
 
 /**
  * Utilities inside contain logic for running entire test classes and individual tests from ScalaTest and ZIO-test via Bazel.
@@ -39,7 +40,20 @@ private object BazelScalaTestRunLineMarkerLogic {
     }
 
   def getSingleTestFilter(psiElement: PsiElement): String =
-    getTestClass(psiElement).map(_.qualifiedName).orNull
+    getTestClass(psiElement) match {
+      case Some(clazz: ScTypeDefinition) if isSpecs2TestClass(clazz) =>
+        Specs2BazelTestFilter
+          .getContainingTestExprOrScope(psiElement)
+          .flatMap(infix => Specs2BazelTestFilter.getTestFilter(clazz, infix))
+          .getOrElse(s"${clazz.qualifiedName}.*")
+      case Some(clazz) =>
+        clazz.qualifiedName
+      case None =>
+        null
+    }
+
+  private def isSpecs2TestClass(clazz: ScTypeDefinition): Boolean =
+    Specs2TestFramework().isTestClass(clazz, /*canBePotential*/ false)
 
   private def getTestClass(psiElement: PsiElement): Option[ScDerivesClauseOwner] = {
     val parentClassOfObject = PsiTreeUtil.getParentOfType(psiElement, classOf[ScClass], classOf[ScObject])

--- a/scala/test-integration/testing-support/src/org/jetbrains/plugins/scala/testingSupport/test/specs2/Specs2BazelTestFilter.scala
+++ b/scala/test-integration/testing-support/src/org/jetbrains/plugins/scala/testingSupport/test/specs2/Specs2BazelTestFilter.scala
@@ -1,0 +1,98 @@
+package org.jetbrains.plugins.scala.testingSupport.test.specs2
+
+import com.intellij.psi.PsiElement
+import com.intellij.psi.util.PsiTreeUtil
+import org.jetbrains.plugins.scala.lang.psi.api.expr.ScInfixExpr
+import org.jetbrains.plugins.scala.lang.psi.api.toplevel.typedef.ScTypeDefinition
+import org.jetbrains.plugins.scala.testingSupport.test.TestConfigurationUtil
+import org.jetbrains.plugins.scala.testingSupport.test.structureView.TestNodeProvider
+
+import java.util.regex.Pattern
+
+/**
+ * Build a Bazel `--test_filter` regex for clicks on specs2 tests and scopes.
+ *
+ * Ported from the deleted Google IJwB Scala plugin (commit `f62b2670648d` of
+ * `bazelbuild/intellij`, file `scala/src/com/google/idea/blaze/scala/run/Specs2Utils.java`).
+ *
+ * Filter format produced:
+ *  - test ref (`"x" in {…}` / `>>` / `!`):  `<classFQN>#\Q<scope> should::<test text>\E$`
+ *  - scope ref (`"x" should {…}` / `can`):  `<classFQN>#\Q<scope> should\E::`
+ *
+ * The trailing `$` (end-of-string anchor) on a test filter narrows to that one
+ * test; the trailing `::` on a scope filter selects every test under the scope
+ * (because the splitter prefixes each child).
+ *
+ * Precision is bounded by what Bazel's `JUnit4Runner` filter does with the
+ * regex — for some specs2-junit / rules_scala combinations a click on one test
+ * may also run same-named siblings from a different scope. That's acceptable
+ * and matches the Google-era behaviour.
+ *
+ * @note Lives in `testing-support` rather than `intellij-bazel` because it is a
+ *       pure PSI-to-string utility with no Bazel-runtime dependency, and
+ *       `testing-support` already has the `ScalaFixtureTestCase` infrastructure
+ *       used to unit-test it.
+ */
+object Specs2BazelTestFilter {
+
+  /** Splitter between scope path and leaf test text in specs2-junit descriptions. */
+  private val TestNamePartsSplitter = "::"
+
+  def getContainingTestExprOrScope(element: PsiElement): Option[ScInfixExpr] =
+    findContainingInfix(element, e => TestNodeProvider.isSpecs2TestExpr(e) || TestNodeProvider.isSpecs2ScopeExpr(e))
+
+  def getContainingTestExpr(element: PsiElement): Option[ScInfixExpr] =
+    findContainingInfix(element, TestNodeProvider.isSpecs2TestExpr)
+
+  def getContainingTestScope(element: PsiElement): Option[ScInfixExpr] =
+    findContainingInfix(element, TestNodeProvider.isSpecs2ScopeExpr)
+
+  private def findContainingInfix(element: PsiElement, predicate: PsiElement => Boolean): Option[ScInfixExpr] = {
+    var current: PsiElement = element
+    while (current != null && !predicate(current)) {
+      current = PsiTreeUtil.getParentOfType(current, classOf[ScInfixExpr])
+    }
+    Option(current).collect { case infix: ScInfixExpr => infix }
+  }
+
+  /** For a scope `"x" should { … }` returns `"x should"`; `None` if the left-hand side isn't a static name. */
+  def getSpecs2ScopeName(testScope: ScInfixExpr): Option[String] =
+    staticTestName(testScope).map(name => s"$name ${testScope.operation.refName}")
+
+  /** For a test `"x" in { … }` returns `"x"`, or `"<scope> should::x"` if it is inside a scope. */
+  def getSpecs2ScopedTestName(testCase: ScInfixExpr): Option[String] =
+    staticTestName(testCase).map { testName =>
+      getContainingTestScope(testCase).flatMap(getSpecs2ScopeName) match {
+        case Some(scopeName) => s"$scopeName$TestNamePartsSplitter$testName"
+        case None            => testName
+      }
+    }
+
+  /**
+   * Build the Bazel `--test_filter` regex.
+   *
+   * @return `Some(regex)` if `element` is recognised as a specs2 test or scope
+   *         with a static name; `None` if no usable name (e.g. interpolated string).
+   */
+  def getTestFilter(testClass: ScTypeDefinition, element: PsiElement): Option[String] = {
+    val (rawName, suffix): (Option[String], String) =
+      if (TestNodeProvider.isSpecs2TestExpr(element))
+        (getSpecs2ScopedTestName(element.asInstanceOf[ScInfixExpr]), "$")
+      else if (TestNodeProvider.isSpecs2ScopeExpr(element))
+        (getSpecs2ScopeName(element.asInstanceOf[ScInfixExpr]), TestNamePartsSplitter)
+      else
+        (None, "")
+
+    rawName.map { name =>
+      // bazelbuild/intellij#176: parens in test names break the Bazel JUnit4 regex parser.
+      val sanitized = name.trim.replace('(', '[').replace(')', ']')
+      // bazelbuild/intellij#169: regex-escape everything else so user names are literal.
+      s"${testClass.qualifiedName}#${Pattern.quote(sanitized)}$suffix"
+    }
+  }
+
+  private def staticTestName(infix: ScInfixExpr): Option[String] = {
+    val opt = TestConfigurationUtil.getStaticTestName(infix.getFirstChild, /*allowSymbolLiterals*/ false)
+    if (opt.isEmpty) None else Some(opt.get)
+  }
+}

--- a/scala/test-integration/testing-support/src/org/jetbrains/plugins/scala/testingSupport/test/specs2/Specs2TestLocationsFinder.scala
+++ b/scala/test-integration/testing-support/src/org/jetbrains/plugins/scala/testingSupport/test/specs2/Specs2TestLocationsFinder.scala
@@ -1,0 +1,41 @@
+package org.jetbrains.plugins.scala.testingSupport.test.specs2
+
+import com.intellij.psi.PsiElement
+import com.intellij.psi.util.PsiTreeUtil
+import com.intellij.util.concurrency.annotations.RequiresReadLock
+import org.jetbrains.plugins.scala.caches.{CachesUtil, cachedInUserData}
+import org.jetbrains.plugins.scala.lang.psi.api.expr.ScInfixExpr
+import org.jetbrains.plugins.scala.lang.psi.api.toplevel.typedef.ScTypeDefinition
+import org.jetbrains.plugins.scala.testingSupport.test.structureView.TestNodeProvider
+
+import scala.jdk.CollectionConverters._
+
+/**
+ * Mirror of [[org.jetbrains.plugins.scala.testingSupport.test.scalatest.ScalaTestTestLocationsFinder]]
+ * for specs2.
+ *
+ * For every `ScInfixExpr` in the class body that `TestNodeProvider`
+ * recognises as a specs2 test (`in`, `>>`, `!`) or scope (`should`,
+ * `can`), returns the operation reference — i.e. the `in`/`should`/etc.
+ * `ScReferenceExpression` itself. Those refs are what the line marker
+ * provider compares against.
+ */
+object Specs2TestLocationsFinder {
+
+  @RequiresReadLock
+  def calculateTestLocations(definition: ScTypeDefinition): Seq[PsiElement] =
+    cachedInUserData(
+      "Specs2TestLocationsFinder.calculateTestLocations",
+      definition,
+      CachesUtil.fileModTracker(definition.getContainingFile),
+      Tuple1(definition)
+    ) {
+      definition.extendsBlock.templateBody.toSeq.flatMap { body =>
+        PsiTreeUtil.findChildrenOfType(body, classOf[ScInfixExpr]).asScala.toSeq.collect {
+          case infix if TestNodeProvider.isSpecs2TestExpr(infix) ||
+                        TestNodeProvider.isSpecs2ScopeExpr(infix) =>
+            infix.operation
+        }
+      }
+    }
+}

--- a/scala/test-integration/testing-support/src/org/jetbrains/plugins/scala/testingSupport/test/ui/ScalaTestRunLineMarkerProvider.scala
+++ b/scala/test-integration/testing-support/src/org/jetbrains/plugins/scala/testingSupport/test/ui/ScalaTestRunLineMarkerProvider.scala
@@ -23,7 +23,7 @@ import org.jetbrains.plugins.scala.settings.ScalaProjectSettings
 import org.jetbrains.plugins.scala.testingSupport.test.AbstractTestFramework
 import org.jetbrains.plugins.scala.testingSupport.test.munit.{MUnitTestFrameworkMarker, MUnitTestLocationsFinder, MUnitUtils}
 import org.jetbrains.plugins.scala.testingSupport.test.scalatest.{ScalaTestTestFramework, ScalaTestTestLocationsFinder}
-import org.jetbrains.plugins.scala.testingSupport.test.specs2.Specs2TestFramework
+import org.jetbrains.plugins.scala.testingSupport.test.specs2.{Specs2TestFramework, Specs2TestLocationsFinder}
 import org.jetbrains.plugins.scala.testingSupport.test.utest.UTestTestFramework
 
 import javax.swing.Icon
@@ -139,8 +139,16 @@ class ScalaTestRunLineMarkerProvider extends TestRunLineMarkerProvider {
     scalaFramework.flatMap {
       case _: ScalaTestTestFramework => infoForScalaTestMethodRef(ref, definition)
       case _: MUnitTestFrameworkMarker => infoForMUnitMethodRef(ref, definition)
+      case _: Specs2TestFramework => infoForSpecs2MethodRef(ref, definition)
       case _ => None
     }
+  }
+
+  private def infoForSpecs2MethodRef(ref: ScReferenceExpression, definition: ScTypeDefinition): Option[RunLineMarkerContributor.Info] = {
+    val locations = Specs2TestLocationsFinder.calculateTestLocations(definition)
+    if (locations.contains(ref))
+      Some(buildLineInfo(url = "", ref.getProject, isClass = false))
+    else None
   }
 
   private def infoForScalaTestRefSpec(functionOrObject: ScalaPsiElement): Option[RunLineMarkerContributor.Info] = {

--- a/scala/test-integration/testing-support/test/org/jetbrains/plugins/scala/testingSupport/specs2/WithSpecs2_4.scala
+++ b/scala/test-integration/testing-support/test/org/jetbrains/plugins/scala/testingSupport/specs2/WithSpecs2_4.scala
@@ -1,0 +1,18 @@
+package org.jetbrains.plugins.scala.testingSupport.specs2
+
+import org.jetbrains.plugins.scala.DependencyManagerBase._
+import org.jetbrains.plugins.scala.base.ScalaSdkOwner
+import org.jetbrains.plugins.scala.base.libraryLoaders.{IvyManagedLoader, LibraryLoader}
+
+/**
+ * Mixin for `ScalaSdkOwner`-based test fixtures (e.g. `GutterMarkersTestBase`)
+ * that need specs2 jars on the classpath. Contributes loaders only — no
+ * other behaviour. Pinned to the same version as
+ * [[org.jetbrains.plugins.scala.testingSupport.specs2.specs2_scala_2_13_specs_4.Specs2_Scala_2_13_Specs_4_Base]].
+ */
+trait WithSpecs2_4 extends ScalaSdkOwner {
+  abstract override protected def librariesLoaders: Seq[LibraryLoader] =
+    super.librariesLoaders ++ Seq(
+      IvyManagedLoader(("org.specs2" %% "specs2-core" % "4.13.0").transitive())
+    )
+}

--- a/scala/test-integration/testing-support/test/org/jetbrains/plugins/scala/testingSupport/test/specs2/Specs2BazelTestFilterTest.scala
+++ b/scala/test-integration/testing-support/test/org/jetbrains/plugins/scala/testingSupport/test/specs2/Specs2BazelTestFilterTest.scala
@@ -1,0 +1,108 @@
+package org.jetbrains.plugins.scala.testingSupport.test.specs2
+
+import com.intellij.psi.util.PsiTreeUtil
+import org.jetbrains.plugins.scala.{LatestScalaVersions, ScalaVersion}
+import org.jetbrains.plugins.scala.base.ScalaFixtureTestCase
+import org.jetbrains.plugins.scala.lang.psi.api.expr.ScInfixExpr
+import org.jetbrains.plugins.scala.lang.psi.api.toplevel.typedef.ScClass
+import org.jetbrains.plugins.scala.testingSupport.specs2.WithSpecs2_4
+import org.jetbrains.plugins.scala.testingSupport.test.structureView.TestNodeProvider
+import org.junit.Assert.{assertEquals, assertTrue}
+
+import scala.jdk.CollectionConverters._
+
+/**
+ * Unit tests for [[Specs2BazelTestFilter]] — the Bazel `--test_filter`
+ * builder ported from Google's deleted IJwB Scala plugin.
+ *
+ * Each test configures a single specs2 source file, finds the `ScInfixExpr`
+ * for a particular test or scope, and asserts the regex string the Bazel
+ * gutter logic would emit when the user clicks that location.
+ */
+class Specs2BazelTestFilterTest extends ScalaFixtureTestCase with WithSpecs2_4 {
+
+  override protected def supportedIn(version: ScalaVersion): Boolean =
+    version == LatestScalaVersions.Scala_2_13
+
+  private val sourceText: String =
+    """import org.specs2.mutable.Specification
+      |
+      |class ExampleSpec extends Specification {
+      |  "a top-level test" in { ok }
+      |
+      |  "scope A" should {
+      |    "scoped test 1" in { ok }
+      |    "scoped test 2" >> { ok }
+      |  }
+      |
+      |  "scope B" can {
+      |    "scoped test 3" in { ok }
+      |  }
+      |}
+      |""".stripMargin
+
+  private def configure(): ScClass = {
+    myFixture.configureByText("ExampleSpec.scala", sourceText)
+    PsiTreeUtil.findChildOfType(myFixture.getFile, classOf[ScClass])
+  }
+
+  private def findInfix(predicate: ScInfixExpr => Boolean): ScInfixExpr = {
+    val all = PsiTreeUtil.findChildrenOfType(myFixture.getFile, classOf[ScInfixExpr]).asScala
+    all.find(predicate).getOrElse(throw new AssertionError("no matching ScInfixExpr in fixture"))
+  }
+
+  // ----- test ref clicks (in / >>) ------------------------------------
+
+  def testTopLevelTest_inOperator(): Unit = {
+    val clazz = configure()
+    val infix = findInfix(e => TestNodeProvider.isSpecs2TestExpr(e) && e.getText.startsWith("\"a top-level"))
+    val filter = Specs2BazelTestFilter.getTestFilter(clazz, infix)
+    assertEquals(Some("ExampleSpec#\\Qa top-level test\\E$"), filter)
+  }
+
+  def testScopedTest_inOperator(): Unit = {
+    val clazz = configure()
+    val infix = findInfix(e => TestNodeProvider.isSpecs2TestExpr(e) && e.getText.startsWith("\"scoped test 1"))
+    val filter = Specs2BazelTestFilter.getTestFilter(clazz, infix)
+    assertEquals(Some("ExampleSpec#\\Qscope A should::scoped test 1\\E$"), filter)
+  }
+
+  def testScopedTest_chevronOperator(): Unit = {
+    val clazz = configure()
+    val infix = findInfix(e => TestNodeProvider.isSpecs2TestExpr(e) && e.getText.startsWith("\"scoped test 2"))
+    val filter = Specs2BazelTestFilter.getTestFilter(clazz, infix)
+    assertEquals(Some("ExampleSpec#\\Qscope A should::scoped test 2\\E$"), filter)
+  }
+
+  def testScopedTest_inCanScope(): Unit = {
+    val clazz = configure()
+    val infix = findInfix(e => TestNodeProvider.isSpecs2TestExpr(e) && e.getText.startsWith("\"scoped test 3"))
+    val filter = Specs2BazelTestFilter.getTestFilter(clazz, infix)
+    assertEquals(Some("ExampleSpec#\\Qscope B can::scoped test 3\\E$"), filter)
+  }
+
+  // ----- scope ref clicks (should / can) ------------------------------
+
+  def testScope_should(): Unit = {
+    val clazz = configure()
+    val infix = findInfix(e => TestNodeProvider.isSpecs2ScopeExpr(e) && e.getText.startsWith("\"scope A\""))
+    val filter = Specs2BazelTestFilter.getTestFilter(clazz, infix)
+    assertEquals(Some("ExampleSpec#\\Qscope A should\\E::"), filter)
+  }
+
+  def testScope_can(): Unit = {
+    val clazz = configure()
+    val infix = findInfix(e => TestNodeProvider.isSpecs2ScopeExpr(e) && e.getText.startsWith("\"scope B\""))
+    val filter = Specs2BazelTestFilter.getTestFilter(clazz, infix)
+    assertEquals(Some("ExampleSpec#\\Qscope B can\\E::"), filter)
+  }
+
+  // ----- non-specs2 elements yield None -------------------------------
+
+  def testElementOutsideTestExpr_returnsNone(): Unit = {
+    val clazz = configure()
+    // The class declaration itself isn't a test/scope expr.
+    val filter = Specs2BazelTestFilter.getTestFilter(clazz, clazz)
+    assertTrue(filter.isEmpty)
+  }
+}

--- a/scala/test-integration/testing-support/test/org/jetbrains/plugins/scala/testingSupport/test/ui/Specs2RunLineMarkerProviderTest.scala
+++ b/scala/test-integration/testing-support/test/org/jetbrains/plugins/scala/testingSupport/test/ui/Specs2RunLineMarkerProviderTest.scala
@@ -1,0 +1,38 @@
+package org.jetbrains.plugins.scala.testingSupport.test.ui
+
+import org.jetbrains.plugins.scala.{LatestScalaVersions, ScalaVersion}
+import org.jetbrains.plugins.scala.annotator.gutter.GutterMarkersTestBase
+import org.jetbrains.plugins.scala.testingSupport.specs2.WithSpecs2_4
+
+class Specs2RunLineMarkerProviderTest
+  extends GutterMarkersTestBase
+    with WithSpecs2_4 {
+
+  override protected def supportedIn(version: ScalaVersion): Boolean =
+    version == LatestScalaVersions.Scala_2_13
+
+  def testSpecs2GuttersAllNodesAndLeaves(): Unit = {
+    doTestAllGuttersShortWithText(
+      """import org.specs2.mutable.Specification
+        |
+        |class ExampleSpec extends Specification {
+        |  "scope A" should {
+        |    "test 1" in { ok }
+        |    "test 2" >> { ok }
+        |    "test 3" ! { ok }
+        |  }
+        |  "scope B" can {
+        |    "test 4" in { ok }
+        |  }
+        |}
+        |""".stripMargin,
+      """line 3 (47, 58) Run Test
+        |line 4 (95, 101) Run Test
+        |line 5 (117, 119) Run Test
+        |line 6 (140, 142) Run Test
+        |line 7 (163, 164) Run Test
+        |line 9 (188, 191) Run Test
+        |line 10 (207, 209) Run Test""".stripMargin
+    )
+  }
+}


### PR DESCRIPTION
## Summary

Closes #SCL-25391.

Two related fixes for IntelliJ Scala's Specs2 support:

1. **`[testing-support]` Per-test gutter triangles for specs2.** `ScalaTestRunLineMarkerProvider#infoForTestMethodRef` previously had cases for ScalaTest and MUnit but not Specs2, so individual tests (`"x" in {…}`, `>>`, `!`) and scope blocks (`should`, `can`) had no gutter icons even though the class itself did. Adds a `Specs2TestLocationsFinder` parallel to `ScalaTestTestLocationsFinder`, using the existing `TestNodeProvider.isSpecs2TestExpr/isSpecs2ScopeExpr` predicates already shared with `Specs2ConfigurationProducer`.

2. **`[intellij-bazel]` Bazel `--test_filter` for specs2.** Following SCL-24481 (PR #709) which wired ScalaTest+ZIO single-test filters via `BazelScalaTestRunLineMarkerLogic`, this restores specs2 parity. Without it, clicking the gutter on a specs2 spec produces `--test_filter=<classFQN>`, which fails to whole-string-match specs2-junit's scope-prefixed `Description` names — `JUnit4Runner` reports `No tests found matching RegEx`. Adds `Specs2BazelTestFilter`, a Scala 3 port of [Google's deleted IJwB `Specs2Utils.java`](https://github.com/bazelbuild/intellij/blob/f62b2670648d/scala/src/com/google/idea/blaze/scala/run/Specs2Utils.java) (commit `f62b2670648d`, removed in `36a4550602` *"Remove IJwB build (#7868)"*). Filter format identical to Google's:
   - test ref: `<classFQN>#\Q<scope> should::<test>\E$`
   - scope ref: `<classFQN>#\Q<scope> should\E::`

## Architecture note

`Specs2BazelTestFilter` lives in `testing-support` (Scala 2.13) rather than `intellij-bazel` (Scala 3) for two reasons:
1. It is a pure PSI-to-string utility with no Bazel-runtime dependency — only the *call site* in `BazelScalaTestRunLineMarkerLogic` is bazel-specific.
2. `intellij-bazel` has no test source root today; `testing-support` already has `ScalaFixtureTestCase` infrastructure used by the unit test (`Specs2BazelTestFilterTest`).

## Tests

- `Specs2BazelTestFilterTest` (new) — 7 cases covering top-level `in`, scoped `in`/`>>` (under `should`), `in` under `can`, `should` scope, `can` scope, and a non-test-element negative case. Uses the new `WithSpecs2_4` fixture trait.
- `Specs2RunLineMarkerProviderTest` for the gutter side will land as a follow-up commit on this branch — the IntelliJ test fixture boot is slow on our hardware and we wanted to surface the changes for review without further delay.

## Verification

- `sbt testing-support/Test/compile` and `sbt intellij-bazel/Compile/compile` both pass on JDK 21.
- Manual smoke test: opened a `scala_specs2_junit_test` Bazel target in the sandboxed IDE, clicked gutter triangles on test/scope/class, confirmed each generates the expected filter and runs.

## Related

- SCL-24481 / #709 — parent change that introduced Bazel run-line-markers for ScalaTest and ZIO. This extends that work to specs2.
- `bazelbuild/intellij` commit `f62b2670648d` — Google IJwB Scala plugin's specs2 producer (since deleted), source of the proposed filter format.