### PR TITLE
[Highlighting] Allow custom colors for package #SCL-25408

### DIFF
--- a/scala/scala-impl/resources/messages/ScalaOptionsBundle.properties
+++ b/scala/scala-impl/resources/messages/ScalaOptionsBundle.properties
@@ -26,6 +26,7 @@ options.scala.attribute.descriptor.class=Class
 options.scala.attribute.descriptor.enum=Enum
 options.scala.attribute.descriptor.enum.case.singleton=Enum singleton case
 options.scala.attribute.descriptor.enum.case.class=Enum class case
+options.scala.attribute.descriptor.package=Package
 options.scala.attribute.descriptor.bad.character=Bad character
 options.scala.attribute.descriptor.scaladoc.comment=ScalaDoc comment
 options.scala.attribute.descriptor.scaladoc.comment.tag=ScalaDoc comment tag

--- a/scala/scala-impl/src/org/jetbrains/plugins/scala/highlighter/DefaultHighlighter.java
+++ b/scala/scala-impl/src/org/jetbrains/plugins/scala/highlighter/DefaultHighlighter.java
@@ -55,6 +55,7 @@ public class DefaultHighlighter {
   static final String OBJECT_ID = "Scala Object";
   static final String CLASS_ID = "Scala Class";
   static final String BAD_CHARACTER_ID = "Scala Bad character";
+  static final String PACKAGE_ID = "Scala Package";
 
   // ScalaDoc
   static final String DOC_COMMENT_ID = "ScalaDoc comment";
@@ -128,6 +129,7 @@ public class DefaultHighlighter {
   public static final TextAttributesKey TYPEPARAM = createKey(TYPEPARAM_ID, JavaHighlightInfoTypes.TYPE_PARAMETER_NAME.getAttributesKey());
   public static final TextAttributesKey OBJECT = createKey(OBJECT_ID, JavaHighlightInfoTypes.CLASS_NAME.getAttributesKey());
   public static final TextAttributesKey CLASS = createKey(CLASS_ID, JavaHighlightInfoTypes.CLASS_NAME.getAttributesKey());
+  public static final TextAttributesKey PACKAGE = createKey(PACKAGE_ID, DefaultLanguageHighlighterColors.IDENTIFIER);
 
   // ScalaDoc
   private static final TextAttributesKey SCALA_DOC_COMMENT_MARKUP = DefaultLanguageHighlighterColors.DOC_COMMENT_MARKUP;

--- a/scala/scala-impl/src/org/jetbrains/plugins/scala/highlighter/ScalaColorsAndFontsPage.scala
+++ b/scala/scala-impl/src/org/jetbrains/plugins/scala/highlighter/ScalaColorsAndFontsPage.scala
@@ -47,6 +47,7 @@ object ScalaColorsAndFontsPage {
     new AttributesDescriptor(DisplayNames.ENUM, ENUM),
     new AttributesDescriptor(DisplayNames.ENUM_SINGLETON_CASE, ENUM_SINGLETON_CASE),
     new AttributesDescriptor(DisplayNames.ENUM_CLASS_CASE, ENUM_CLASS_CASE),
+    new AttributesDescriptor(DisplayNames.PACKAGE, PACKAGE),
     new AttributesDescriptor(DisplayNames.TYPEPARAM, TYPEPARAM),
     new AttributesDescriptor(DisplayNames.TYPE_ALIAS, TYPE_ALIAS),
     new AttributesDescriptor(DisplayNames.PREDEF, PREDEF),
@@ -114,6 +115,7 @@ object ScalaColorsAndFontsPage {
     val ENUM = ScalaOptionsBundle.message("options.scala.attribute.descriptor.enum")
     val ENUM_SINGLETON_CASE = ScalaOptionsBundle.message("options.scala.attribute.descriptor.enum.case.singleton")
     val ENUM_CLASS_CASE = ScalaOptionsBundle.message("options.scala.attribute.descriptor.enum.case.class")
+    val PACKAGE = ScalaOptionsBundle.message("options.scala.attribute.descriptor.package")
     val BAD_CHARACTER = ScalaOptionsBundle.message("options.scala.attribute.descriptor.bad.character")
     val DOC_COMMENT = ScalaOptionsBundle.message("options.scala.attribute.descriptor.scaladoc.comment")
     val SCALA_DOC_TAG = ScalaOptionsBundle.message("options.scala.attribute.descriptor.scaladoc.comment.tag")
@@ -194,8 +196,8 @@ class ScalaColorsAndFontsPage extends RainbowColorSettingsPage {
   override def getDemoText: String =
     s"""$scalaDirectiveDemoText
        |
-       |<keyword>import</keyword> scala<dot>.</dot>collection<dot>.</dot>mutable<dot>.</dot>_
-       |<keyword>import</keyword> java<dot>.</dot>util<dot>.</dot>TreeMap
+       |<keyword>import</keyword> <package>scala</package><dot>.</dot><package>collection</package><dot>.</dot><package>mutable</package><dot>.</dot>_
+       |<keyword>import</keyword> <package>java</package><dot>.</dot><package>util</package><dot>.</dot>TreeMap
        |
        |<scaladoc>/**
        | * ScalaDoc comment: <scaladocHtml><code></scaladocHtml>Some code<scaladocHtml></code></scaladocHtml>
@@ -277,6 +279,7 @@ class ScalaColorsAndFontsPage extends RainbowColorSettingsPage {
     map.put("enum", ENUM)
     map.put("enum_singleton_case", ENUM_SINGLETON_CASE)
     map.put("enum_class_case", ENUM_CLASS_CASE)
+    map.put("package", PACKAGE)
     map.put("annotation", ANNOTATION)
     map.put("attribute", ANNOTATION_ATTRIBUTE)
     map.put("abstract", ABSTRACT_CLASS)

--- a/scala/scala-impl/src/org/jetbrains/plugins/scala/highlighter/ScalaColorsSchemeUtils.scala
+++ b/scala/scala-impl/src/org/jetbrains/plugins/scala/highlighter/ScalaColorsSchemeUtils.scala
@@ -3,7 +3,7 @@ package org.jetbrains.plugins.scala.highlighter
 import com.intellij.codeInsight.daemon.impl.HighlightInfoType
 import com.intellij.openapi.editor.DefaultLanguageHighlighterColors
 import com.intellij.openapi.editor.colors.TextAttributesKey
-import com.intellij.psi.{PsiClass, PsiElement, PsiField, PsiMethod, PsiModifierListOwner}
+import com.intellij.psi.{PsiClass, PsiElement, PsiField, PsiMethod, PsiModifierListOwner, PsiPackage}
 import org.jetbrains.plugins.scala.extensions.{&, ObjectExt, Parent, PsiClassExt, PsiMemberExt}
 import org.jetbrains.plugins.scala.lang.psi.api.base.patterns.{ScBindingPattern, ScCaseClause, ScReferencePattern}
 import org.jetbrains.plugins.scala.lang.psi.api.base.{ScFieldId, ScReference, ScStableCodeReference}
@@ -102,6 +102,7 @@ object ScalaColorsSchemeUtils {
         }
       case f@(_: ScFunctionDefinition | _: ScFunctionDeclaration | _: ScMacroDefinition) => highlightInfoType(f.asInstanceOf[ScFunction])
       case m: PsiMethod                                                                  => highlightInfoType(m)
+      case _: PsiPackage                                                                 => ScalaHighlightInfoTypes.PACKAGE
       case _                                                                             => ScalaHighlightInfoTypes.IDENTIFIER
     }
 

--- a/scala/scala-impl/src/org/jetbrains/plugins/scala/highlighter/ScalaHighlightInfoTypes.java
+++ b/scala/scala-impl/src/org/jetbrains/plugins/scala/highlighter/ScalaHighlightInfoTypes.java
@@ -30,6 +30,7 @@ public class ScalaHighlightInfoTypes {
     public static final HighlightInfoType TYPEPARAM = createType(DefaultHighlighter.TYPEPARAM);
     public static final HighlightInfoType OBJECT = createType(DefaultHighlighter.OBJECT);
     public static final HighlightInfoType CLASS = createType(DefaultHighlighter.CLASS);
+    public static final HighlightInfoType PACKAGE = createType(DefaultHighlighter.PACKAGE);
 
     // ScalaDoc
     public static final HighlightInfoType DOC_COMMENT = createType(DefaultHighlighter.DOC_COMMENT);

--- a/scala/scala-impl/test/org/jetbrains/plugins/scala/annotator/ScalaColorSchemeAnnotatorTest.scala
+++ b/scala/scala-impl/test/org/jetbrains/plugins/scala/annotator/ScalaColorSchemeAnnotatorTest.scala
@@ -4,7 +4,6 @@ import com.intellij.openapi.editor.colors.TextAttributesKey
 import com.intellij.psi.PsiElement
 import org.jetbrains.plugins.scala.highlighter.DefaultHighlighter
 import org.junit.Test
-
 class ScalaColorSchemeAnnotatorTest extends ScalaColorSchemeAnnotatorTestBase[TextAttributesKey] {
   import org.jetbrains.plugins.scala.highlighter.DefaultHighlighter._
 
@@ -622,6 +621,25 @@ class ScalaColorSchemeAnnotatorTest extends ScalaColorSchemeAnnotatorTestBase[Te
         |Info((64,65),.,Scala Dot)
         |Info((77,84),package,Scala Keyword)
         |Info((84,85),.,Scala Dot)""".stripMargin)
+  }
+
+  @Test
+  def testPackageHighlighting(): Unit = {
+    val text =
+      """package org.jetbrains.plugins.scala
+        |
+        |import java.util.concurrent.Callable
+        |""".stripMargin
+
+    testAnnotations(text, Set(DefaultHighlighter.PACKAGE),
+      """Info((8,11),org,Scala Package)
+        |Info((12,21),jetbrains,Scala Package)
+        |Info((22,29),plugins,Scala Package)
+        |Info((30,35),scala,Scala Package)
+        |Info((44,48),java,Scala Package)
+        |Info((49,53),util,Scala Package)
+        |Info((54,64),concurrent,Scala Package)""".stripMargin
+    )
   }
 
 }


### PR DESCRIPTION
### What does this PR do?
This PR introduces customizable syntax highlighting for package references in the Scala plugin. Previously, package names in `import` statements and fully qualified references lacked a dedicated semantic color setting.

### Key Changes
* **Text Attribute Key**: Added a new `PACKAGE` highlight info type and text attributes key, with a graceful fallback to the default identifier color to support all themes.
* **Semantic Analysis**: Updated `ScalaColorsSchemeUtils` to detect resolved `PsiPackage` elements and assign them the new `PACKAGE` highlight type.
* **Color Settings UI**: Exposed the new "Package" attribute in `Settings > Editor > Color Scheme > Scala`. The demo text to demonstrates package highlighting in action.
* **Testing**: Added `testPackageHighlighting` to `ScalaColorSchemeAnnotatorTest` to verify that package sequences are correctly identified and colored during semantic analysis.

### Related YouTrack Issue
Fixes #SCL-25408