### PR TITLE
[bsp] fallback to javaVersion before moduleJdkVersion when setting language level during import #SCL-25592 fixed

### DIFF
--- a/bsp-builtin/bsp/src/org/jetbrains/bsp/data/BspMetadataService.scala
+++ b/bsp-builtin/bsp/src/org/jetbrains/bsp/data/BspMetadataService.scala
@@ -44,7 +44,8 @@ class BspMetadataService extends ScalaAbstractProjectDataService[BspMetadata, Mo
       val moduleJdkVersion = moduleJdk.map(_.getVersionString)
 
       Option(data.languageLevel)
-        .orElse(moduleJdkVersion.map(LanguageLevel.parse))
+        .orElse(Option(data.javaVersion).map(LanguageLevel.parse)) // Fallback to javaVersion
+        .orElse(moduleJdkVersion.map(LanguageLevel.parse)) // Fallback to the version of javaHome
         .flatMap(versionString => Option(versionString))
         .foreach(setLanguageLevel(model, _))
     }


### PR DESCRIPTION
When importing a Java module using BSP and the `JvmBuildTarget` response is received, the `javaVersion` field may be lower than the version of the JDK located at `javaHome`.

Before these changes, if `BspMetadata.languageLevel` was null, the language level would fallback to that of the JDK at `javaHome`.
These changes fallback the language level of the module to `javaVersion`, and if that is missing for some reason, then it further falls back to the version of the JDK at `javaHome`.

Related: https://youtrack.jetbrains.com/issue/SCL-25592